### PR TITLE
docs: symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-See [AGENTS.md](./AGENTS.md). Same content applies to Claude.
+AGENTS.md


### PR DESCRIPTION
This change replaces the empty `CLAUDE.md` with a symbolic link to `AGENTS.md`, so agent tooling that looks for `CLAUDE.md` and documentation that maintains `AGENTS.md` stay in sync without duplication.

**Change:** `CLAUDE.md` → symlink to `AGENTS.md` (relative path).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLAUDE.md with a reference to AGENTS.md.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonkneen/tiny-world-builder/pull/15)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->