### PR TITLE
fix: correct horizontal orbit drag direction

### DIFF
--- a/tiny-world-builder.html
+++ b/tiny-world-builder.html
@@ -6510,7 +6510,7 @@
         if (dragMode === 'pan') {
           panCameraByPixels(ddx, ddy);
         } else {
-          azimuth -= ddx * 0.008;
+          azimuth += ddx * 0.008;
           polar = Math.max(0.18, Math.min(1.25, polar - ddy * 0.006));
           updateCamera();
         }


### PR DESCRIPTION
Left-drag / one-finger orbit felt horizontally inverted: the azimuth delta used the opposite sign from the usual screen-space expectation.

**Change:** `azimuth -= ddx * 0.008` → `azimuth += ddx * 0.008` in the pointer orbit branch (pan unchanged).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected camera orbit direction to align pointer movement with intuitive camera rotation during drag interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonkneen/tiny-world-builder/pull/16)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->