### PR TITLE
Shade under-island engines so they read as in shadow

### DIFF
--- a/engine/world/03-geometry-materials.js
+++ b/engine/world/03-geometry-materials.js
@@ -269,8 +269,11 @@
     boardSide:  new THREE.MeshLambertMaterial({ color: 0x8b8d88, side: THREE.FrontSide }),
     islandUnder:  new THREE.MeshLambertMaterial({ color: 0x34373b, side: THREE.DoubleSide }),
     islandUnderD: new THREE.MeshLambertMaterial({ color: 0x202327, side: THREE.DoubleSide }),
-    rocketSteel:  new THREE.MeshLambertMaterial({ color: 0x767d86, side: THREE.FrontSide }),
-    rocketSteelD: new THREE.MeshLambertMaterial({ color: 0x2f353c, side: THREE.FrontSide }),
+    // Darkened (~0.6x) so the heavy/rocket engine reads as shaded under the
+    // island instead of brightly lit — parity with the lift engine's under-island
+    // shade (engine/world/09b UNDER_ISLAND_ENGINE_SHADE). Rocket-only materials.
+    rocketSteel:  new THREE.MeshLambertMaterial({ color: 0x474b50, side: THREE.FrontSide }),
+    rocketSteelD: new THREE.MeshLambertMaterial({ color: 0x1c2024, side: THREE.FrontSide }),
     utilityPipe:  new THREE.MeshLambertMaterial({ color: 0x6f7881, side: THREE.FrontSide }),
     utilityPipeD: new THREE.MeshLambertMaterial({ color: 0x343a40, side: THREE.FrontSide }),
     utilityCable: new THREE.MeshLambertMaterial({ color: 0x171b20, side: THREE.FrontSide }),

--- a/engine/world/03-geometry-materials.js
+++ b/engine/world/03-geometry-materials.js
@@ -269,11 +269,11 @@
     boardSide:  new THREE.MeshLambertMaterial({ color: 0x8b8d88, side: THREE.FrontSide }),
     islandUnder:  new THREE.MeshLambertMaterial({ color: 0x34373b, side: THREE.DoubleSide }),
     islandUnderD: new THREE.MeshLambertMaterial({ color: 0x202327, side: THREE.DoubleSide }),
-    // Darkened (~0.6x) so the heavy/rocket engine reads as shaded under the
+    // Darkened (~0.45x) so the heavy/rocket engine reads as shaded under the
     // island instead of brightly lit — parity with the lift engine's under-island
     // shade (engine/world/09b UNDER_ISLAND_ENGINE_SHADE). Rocket-only materials.
-    rocketSteel:  new THREE.MeshLambertMaterial({ color: 0x474b50, side: THREE.FrontSide }),
-    rocketSteelD: new THREE.MeshLambertMaterial({ color: 0x1c2024, side: THREE.FrontSide }),
+    rocketSteel:  new THREE.MeshLambertMaterial({ color: 0x35383c, side: THREE.FrontSide }),
+    rocketSteelD: new THREE.MeshLambertMaterial({ color: 0x15181b, side: THREE.FrontSide }),
     utilityPipe:  new THREE.MeshLambertMaterial({ color: 0x6f7881, side: THREE.FrontSide }),
     utilityPipeD: new THREE.MeshLambertMaterial({ color: 0x343a40, side: THREE.FrontSide }),
     utilityCable: new THREE.MeshLambertMaterial({ color: 0x171b20, side: THREE.FrontSide }),
@@ -482,6 +482,26 @@
     hover:     new THREE.MeshBasicMaterial({ color: 0x2a2722, transparent: true, opacity: 0.18, depthWrite: false }),
     hoverErase:new THREE.MeshBasicMaterial({ color: 0xb84838, transparent: true, opacity: 0.28, depthWrite: false }),
   };
+
+  // Return a cached, darkened clone of a Lambert/standard material. Used to make
+  // hardware that hangs in the island's shadow (engines, utility pipes, hanging
+  // dressing cubes) read as occluded instead of brightly lit, without touching
+  // the shared material used on the sunlit top surfaces. Keyed by source material
+  // uuid + factor so darkened meshes still batch/merge by material. 1 = unchanged.
+  const shadedMaterialCache = new Map();
+  function shadeLambertMaterial(mat, factor) {
+    if (!mat || !mat.color || !(factor >= 0) || factor === 1) return mat;
+    const key = mat.uuid + ':' + factor;
+    let out = shadedMaterialCache.get(key);
+    if (!out) {
+      out = mat.clone();
+      out.color.multiplyScalar(factor);
+      if (out.emissive) out.emissive.multiplyScalar(factor);
+      out.userData = Object.assign({}, mat.userData, { underIslandShaded: true });
+      shadedMaterialCache.set(key, out);
+    }
+    return out;
+  }
 
   const islandShellMaterialCache = new Map();
   function syncIslandShellMaterial(baseMat, shellMat) {

--- a/engine/world/09b-voxel-build-factories.js
+++ b/engine/world/09b-voxel-build-factories.js
@@ -14,6 +14,28 @@
     return voxelBuildMaterialCache.get(key);
   }
 
+  // Lift/rocket engines hang in the island's shadow, but their Lambert materials
+  // still catch full ambient + sky light, so they read far too bright against the
+  // dark underside (they look freshly minted instead of "in shadow"). Multiply
+  // every engine palette colour toward black to fake the ambient occlusion the
+  // geometry above would cast — a "used-universe" shaded look. 1 = untouched,
+  // lower = darker. Tune here to taste.
+  const UNDER_ISLAND_ENGINE_SHADE = 0.6;
+  function shadeEngineHex(hex, factor = UNDER_ISLAND_ENGINE_SHADE) {
+    const clean = normalizeHexColor(hex) || '#ffffff';
+    const n = parseInt(clean.slice(1), 16);
+    const r = Math.round(Math.max(0, Math.min(255, ((n >> 16) & 255) * factor)));
+    const g = Math.round(Math.max(0, Math.min(255, ((n >> 8) & 255) * factor)));
+    const b = Math.round(Math.max(0, Math.min(255, (n & 255) * factor)));
+    return '#' + ((r << 16) | (g << 8) | b).toString(16).padStart(6, '0');
+  }
+  // Same cached MeshLambertMaterial pipeline as voxelBuildMaterial, but with the
+  // under-island shade pre-applied to the colour. Darkened colours cache under
+  // their own key, so engines still merge by material.
+  function engineBuildMaterial(hex, textureKind = null) {
+    return voxelBuildMaterial(shadeEngineHex(hex), textureKind);
+  }
+
   function voxelFallbackColorForMaterialName(name) {
     const key = String(name || '').trim().toLowerCase();
     const direct = normalizeHexColor(key);
@@ -1130,14 +1152,14 @@
     root.add(engine);
     const body = new THREE.Group();
     engine.add(body);
-    const liftStone = voxelBuildMaterial('#6f6a60', 'stone');
-    const liftStoneHi = voxelBuildMaterial('#8b8478', 'stone');
-    const liftSteel = voxelBuildMaterial('#4b5660', 'pipe-metal');
-    const liftSteelD = voxelBuildMaterial('#252d34', 'pipe-metal');
-    const liftWood = voxelBuildMaterial('#6a4a2f', 'wood');
-    const liftWoodD = voxelBuildMaterial('#3d2918', 'wood');
-    const liftLabel = voxelBuildMaterial('#a89d85', 'planks');
-    const liftHeat = voxelBuildMaterial('#432018', 'noise');
+    const liftStone = engineBuildMaterial('#6f6a60', 'stone');
+    const liftStoneHi = engineBuildMaterial('#8b8478', 'stone');
+    const liftSteel = engineBuildMaterial('#4b5660', 'pipe-metal');
+    const liftSteelD = engineBuildMaterial('#252d34', 'pipe-metal');
+    const liftWood = engineBuildMaterial('#6a4a2f', 'wood');
+    const liftWoodD = engineBuildMaterial('#3d2918', 'wood');
+    const liftLabel = engineBuildMaterial('#a89d85', 'planks');
+    const liftHeat = engineBuildMaterial('#432018', 'noise');
 
     function sourceCube(parent, x, y, z, sx = 1, sy = 1, sz = 1, mat = liftStone) {
       return vbox(parent, sx, sy, sz, x, y, z, mat, { noGap: true });

--- a/engine/world/09b-voxel-build-factories.js
+++ b/engine/world/09b-voxel-build-factories.js
@@ -20,7 +20,7 @@
   // every engine palette colour toward black to fake the ambient occlusion the
   // geometry above would cast — a "used-universe" shaded look. 1 = untouched,
   // lower = darker. Tune here to taste.
-  const UNDER_ISLAND_ENGINE_SHADE = 0.6;
+  const UNDER_ISLAND_ENGINE_SHADE = 0.45;
   function shadeEngineHex(hex, factor = UNDER_ISLAND_ENGINE_SHADE) {
     const clean = normalizeHexColor(hex) || '#ffffff';
     const n = parseInt(clean.slice(1), 16);

--- a/engine/world/13-distant-dressing-ghost.js
+++ b/engine/world/13-distant-dressing-ghost.js
@@ -132,6 +132,13 @@
     buildDistantWorlds();
   }
 
+  // Hanging under-island dressing (utility pipes/trays/boxes/clamps and the
+  // edge drop cubes) sits in the island's shadow but its Lambert materials still
+  // catch full sky/ambient light, so it reads too bright. Multiply those pieces
+  // toward black to fake the occlusion. Kept separate from (and a touch lighter
+  // than) the engines so the hardware silhouette still reads. 1 = unchanged.
+  const UNDER_ISLAND_DRESSING_SHADE = 0.6;
+
   function addIslandSideBacking(parent) {
     const span = GRID * TILE;
     const half = span * 0.5;
@@ -190,7 +197,7 @@
           const w = 0.12 + cellRand(i, GRID, 2650 + dir.charCodeAt(0)) * 0.22;
           const h = 0.16 + cellRand(i, GRID, 2660 + dir.charCodeAt(0)) * 0.34;
           const d = 0.10 + cellRand(i, GRID, 2670 + dir.charCodeAt(0)) * 0.16;
-          vbox(parent, alongX ? w : d, h, alongX ? d : w, px, -0.16 - h * 0.5, pz, roll < 0.62 ? M.dirtRich : M.boardSide, { noGap: true });
+          vbox(parent, alongX ? w : d, h, alongX ? d : w, px, -0.16 - h * 0.5, pz, shadeLambertMaterial(roll < 0.62 ? M.dirtRich : M.boardSide, UNDER_ISLAND_DRESSING_SHADE), { noGap: true });
         }
         if (roll > 0.72) {
           const s = 0.11 + cellRand(i, GRID, 2680 + dir.charCodeAt(0)) * 0.18;
@@ -198,7 +205,7 @@
           const inset = 0.05 + cellRand(i, GRID, 2700 + dir.charCodeAt(0)) * 0.22;
           const dx = alongX ? (cellRand(i, GRID, 2710) - 0.5) * 0.12 : -sign * inset;
           const dz = alongX ? -sign * inset : (cellRand(i, GRID, 2720) - 0.5) * 0.12;
-          vbox(parent, s, s, s, px + dx, -drop, pz + dz, cellRand(i, GRID, 2730) < 0.45 ? M.islandUnderD : M.boardSide, { noGap: true });
+          vbox(parent, s, s, s, px + dx, -drop, pz + dz, shadeLambertMaterial(cellRand(i, GRID, 2730) < 0.45 ? M.islandUnderD : M.boardSide, UNDER_ISLAND_DRESSING_SHADE), { noGap: true });
         }
       }
     }
@@ -208,7 +215,13 @@
     addEdge('e');
   }
 
-  function addIslandUtilityUnderside(parent) {
+  function addIslandUtilityUnderside(dest) {
+    // Build into a detached group so every piece can be darkened in one pass
+    // below — this hardware hangs in the island's shadow and must read as
+    // occluded, not sunlit. `dest` is at the island origin, so the local
+    // positions computed here are preserved when the group is reparented.
+    const parent = new THREE.Group();
+    parent.name = 'island-utility-underside';
     const span = GRID * TILE;
     const half = span * 0.5;
     const pipeCount = Math.max(10, Math.min(24, Math.round(GRID * 2.0)));
@@ -357,6 +370,13 @@
         vbox(parent, 0.055, 0.038, 0.055, x, y - length * 0.52, z, M.utilityClamp, { noGap: true, noShadow: true });
       }
     }
+
+    // Darken everything we just built so the under-island hardware reads as
+    // shaded, then hand the group to the caller's border group.
+    parent.traverse(node => {
+      if (node.isMesh) node.material = shadeLambertMaterial(node.material, UNDER_ISLAND_DRESSING_SHADE);
+    });
+    dest.add(parent);
   }
 
   function isEditableIslandEngineNode(node) {


### PR DESCRIPTION
## Problem

The lift/turbo propeller engines and the heavy rocket engine hang in the island's shadow, but their `MeshLambertMaterial`s still caught full ambient + sky light. The result: the under-island hardware reads far too bright — freshly-minted rather than weathered and in-shadow — against the dark underside (see attached screenshot).

## Fix

A "used-universe" shade that fakes the ambient occlusion the island above would cast:

- **`engine/world/09b-voxel-build-factories.js`** — new tunable `UNDER_ISLAND_ENGINE_SHADE` (~0.6×) plus `shadeEngineHex` / `engineBuildMaterial` helpers. The lift engine's 8-colour palette now routes through `engineBuildMaterial`, so every voxel is darkened toward black. Darkened colours cache under their own key, so engines still merge by material (no perf regression).
- **`engine/world/03-geometry-materials.js`** — the rocket-only `rocketSteel` / `rocketSteelD` materials are darkened ~0.6× to match. The glowing nozzle (`rocketHeat`) is intentionally left intact.

Tune the look by adjusting the single `UNDER_ISLAND_ENGINE_SHADE` constant (1 = untouched, lower = darker).

## Verification

- `npm run check` ✅ (i18n + duplicate-declaration scan)
- `npm run smoke` ✅

https://claude.ai/code/session_01SYYysXAcC88KuMgvhb2noh

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYYysXAcC88KuMgvhb2noh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rocket components no longer appear overly bright when rendered beneath the island
  * Lift engine materials now display proper shading in under-island areas
  * Decorative dressing elements now render with correct shadow shading throughout the island structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->