### PR TITLE
Add TinyShaderFX library and upgrade the ocean water shader

### DIFF
--- a/.codex/skills/tinyworld-settings/SKILL.md
+++ b/.codex/skills/tinyworld-settings/SKILL.md
@@ -22,6 +22,7 @@ Structure rules:
 - Keep settings grouped by user intent, not implementation variable names.
 - Current top-level tabs are Workspace, Rendering, World, Materials, Environment, Crowd, and AI.
 - Tabs should stay dense and scannable: desktop may show a short hint; mobile should keep a compact horizontal tab strip.
+- Mobile/short-screen scroll: `.settings-card` is height-capped (`max-height: calc(100vh - 100px)`, `dvh` on phones) and the panels scroll internally (`.settings-panels { overflow-y: auto }`, layout `flex:1 1 auto; min-height:0`). Never let the card grow unbounded again — on a phone that pushes lower controls off-screen and they become unreachable. On phones the layout is `grid-template-rows: auto minmax(0,1fr)` so the panels row is the scroller.
 - Add `data-settings-keywords` when a setting or panel should be discoverable by broader user language such as performance, mechanics, textures, weather, or model.
 - Preserve the existing `data-settings-tab` / `data-settings-panel` wiring, ARIA roles, keyboard tab navigation, and search-count chips.
 - Search should route broad category terms to the right panel without hiding the controls in that panel.

--- a/.codex/skills/tinyworld-shader-fx/SKILL.md
+++ b/.codex/skills/tinyworld-shader-fx/SKILL.md
@@ -35,6 +35,28 @@ Stylized, cheap (~7 value-noise taps). Uniforms worth knowing:
 
 Keep the `runwayR` discard, the clip-box block, fog, and posterize tail intact.
 
+## Enhanced water surfaces ("Enhanced water" toggle)
+
+The default-visible water is **voxel tiles** (`M.water`/`M.waterDk`, Lambert), not
+the landscape ocean. A Settings toggle upgrades water everywhere:
+
+- Setting: `render-enhanced-water` checkbox (HTML, Environment panel) ↔
+  `renderEnhancedWater` global (`01-render-core.js`, default on) ↔
+  `tinyworld:render:enhancedWater`. Wired in `21-object-transform-voxel-build.js`
+  (el ref, listener loop, `applyFromControls`, `persistSettings`, `syncControls`)
+  exactly like the `planesEnabled` toggle. New key, no `RENDER_SETTINGS_VERSION` bump.
+- Voxel water: injected in **`applyFlowingWaterUVs`** (`04-textures.js`) — the single
+  `onBeforeCompile` chokepoint for every water material (base + flow clones). Stays
+  Lambert; adds ripple-normal bands + fresnel + Blinn-Phong glint + foam, masked by
+  `vTwWaterNrm.y` so sides stay calm. Shared `waterShaderTimeUniform` advanced in
+  `tickWaterTextureFlow`. **`customProgramCacheKey` is mandatory** here — without it
+  three.js would reuse the wrong program when the toggle flips (onBeforeCompile output
+  isn't in the default cache key).
+- Landscape ocean: `uEnhance` uniform in `water.js` scales the new foam/sheen/subsurface.
+- On toggle: `refreshWaterShaderMaterials()` (clears `waterFlowMaterialCache`, resets the
+  base materials) then `rebuildTerrainRender()`; the handler also sets the live landscape
+  `uEnhance`. Waterfalls are untouched (separate shaders).
+
 ## TinyShaderFX library (engine/world/45-shader-fx.js)
 
 IIFE exposing `window.TinyShaderFX`. **4-space body indent on purpose** — the

--- a/.codex/skills/tinyworld-shader-fx/SKILL.md
+++ b/.codex/skills/tinyworld-shader-fx/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: tinyworld-shader-fx
+description: Use when adding or changing GLSL effects in Tiny World Builder — landscape water, waterfalls, foam, smoke, explosions, damage/wear overlays, or the reusable TinyShaderFX library. Covers where shaders live, the override relationship between LandscapeEngine.js and engine/landscape/*.js, and the procedural-noise toolkit.
+---
+
+# Tiny World Shader FX
+
+Where the shaders live and how to extend them without breaking the guarded build.
+
+## Authoritative shader files
+
+- **Terrain:** `engine/landscape/shaders.js` — `SAND_VS`, `SAND_FS`, `LOWPOLY_FS`
+  + the `sandMat` / `sandMatLowPoly` ShaderMaterials.
+- **Water:** `engine/landscape/water.js` — the animated reflective ocean plane.
+- These two files `Object.assign(LandscapeEngine.prototype, {...})` **after**
+  `LandscapeEngine.js` defines the class, so they **override** the inline
+  `_initSharedShaders` / `_initWater` copies still present in `LandscapeEngine.js`
+  (lines ~302 / ~893). The split files are the live ones — edit those. The inline
+  copies are dead but left in place; don't rely on them.
+- The ocean `time` + `cameraPos` uniforms are advanced in `LandscapeEngine.update()`.
+- **Voxel-world waterfalls/flow** are separate: `engine/world/05-tile-factory.js`
+  (`getWaterfallCurtainMaterial`, `getWaterfallSurfaceMaterial`, foam puffs) driven
+  by `updateWaterfallEffects(t)` / `tickWaterTextureFlow(dt)` in the animation loop.
+  `check.js` guards these names — keep them.
+
+## Ocean water shader (engine/landscape/water.js)
+
+Stylized, cheap (~7 value-noise taps). Uniforms worth knowing:
+
+- `flowDir` (vec2) — scroll direction; two layers flow along it and its perpendicular.
+- `foamColor` / `foamAmount` — wave-crest + shoreline foam.
+- `specPower` — Blinn-Phong sun-glint tightness.
+- `posterize` — cel banding levels (12 reproduces the original look; 0 disables).
+- `planetDistance*` — distance tint, kept in parity with the terrain materials.
+
+Keep the `runwayR` discard, the clip-box block, fog, and posterize tail intact.
+
+## TinyShaderFX library (engine/world/45-shader-fx.js)
+
+IIFE exposing `window.TinyShaderFX`. **4-space body indent on purpose** — the
+duplicate-declaration guard in `tools/check.js` only scans 2-space top-level
+decls, so anything deeper is ignored. Keep new locals inside the IIFE.
+
+Factories (all procedural, no textures/render targets):
+
+- `makeWaterFlowMaterial(opts)` — flowing river/pond surface for flat planes.
+- `makeWaterfallMaterial(opts)` — vertical falling-water curtain (UV.y = top→bottom).
+- `makeFoamMaterial(opts)` — shoreline/splash/wake foam ribbon (foam near UV.y=0).
+- `makeSmokeMaterial(opts)` — dissolving smoke billboard; drive `uAge` 0→1.
+- `makeExplosionMaterial(opts)` — fireball; drive `uProgress` 0→1 and scale the mesh.
+- `applyWear(material, opts)` — patches any **stock** Lambert/Standard/Phong/Basic
+  material with procedural grime/cracks/scuffs via `onBeforeCompile`
+  (anchors on `<project_vertex>` and `<dithering_fragment>`, present in every
+  stock template). Returns the material with a `setWear(amount)` helper.
+
+### Frame ticking
+Animated materials expose `uTime` and self-register via `track()`. The loop calls
+`window.__tinyworldShaderFXTick(t, dt)` (wired in `25-animation-loop-schema.js`,
+`tick.effects` bucket). Materials you build elsewhere advance for free if their
+uniform is named `uTime` and you pass them through `TinyShaderFX.track()`.
+
+### Shared GLSL
+`TinyShaderFX.GLSL_NOISE` is a prependable chunk of `fxHash/fxNoise/fxFbm/
+fxFresnel/fxPosterize` (the `fx`-prefix avoids collisions with stock chunks).
+Reuse it for new ShaderMaterials instead of re-deriving noise.
+
+### Demo
+`?shaderfx=demo` (or `=1`) drops a gallery near the origin; `TinyShaderFX.demo(scene)`
+does the same on demand. It's opt-in so default scenes are untouched.
+
+## Guard / gotchas
+- New `engine/**` files are auto-collected by `check.js` (per-file `new Function`
+  syntax check + cross-file duplicate-decl scan) and copied to `dist/` by
+  `publish.sh` — no extra wiring beyond the `<script src>` tag in the HTML.
+- ShaderMaterial fragments need `#include <encodings_fragment>` at the end to match
+  the app's output color space (the waterfall + FX materials all do this).
+- r128 is WebGL1-default: use `gl_FragColor`, constant-bound `for` loops, and
+  `cameraPosition` (auto-injected) in ShaderMaterial.
+- Don't convert the existing chimney-smoke `MeshBasicMaterial` pipeline to a
+  ShaderMaterial — it's cached/cloned by `getCachedParticleMaterial`. Use
+  `makeSmokeMaterial` for new emitters instead.

--- a/.codex/skills/tinyworld-tool-icons-and-modes/SKILL.md
+++ b/.codex/skills/tinyworld-tool-icons-and-modes/SKILL.md
@@ -51,6 +51,12 @@ when changing boot mode, launcher chrome, or mode persistence.
 - The palette is a self-contained module: `engine/world/35-tool-palette.js`.
   Blocks are built with `buildToolButton(t, { flyout: true })`, so they keep
   their colors and are highlighted by the same `updateToolActiveStates()` loop.
+- **Small screens force grouped mode.** `showGroupsEnabled()` returns true on
+  `<=700px` regardless of the stored pref (`isSmallScreenForGroups()`), the
+  checkbox is disabled there, and a `resize` listener re-applies across the
+  breakpoint. The floating palette is unusable on phones, so never let it open
+  there. The phone toolbar is also compacted to icon-only (labels/chevrons
+  hidden, smaller buttons) in the `@media (max-width: 700px)` block.
   The grid uses fixed 64px square cells (`repeat(auto-fill, 64px)`), so resizing
   the panel reflows blocks to the nearest square. `buildToolbar()` calls
   `rebuildToolPaletteIfActive()` so toolbar rebuilds refresh an open palette.

--- a/docs/SHADERS.md
+++ b/docs/SHADERS.md
@@ -1,0 +1,104 @@
+# Shaders & GPU FX
+
+Tiny World Builder is stylized low-poly, so its shaders favour cheap,
+fully-procedural effects (hash-noise / fbm, no texture fetches, no extra render
+targets) over physically-based realism. The techniques are lifted and adapted
+from [lettier/3d-game-shaders-for-beginners](https://github.com/lettier/3d-game-shaders-for-beginners)
+(lighting, fog, normal mapping, posterization, dithering, outlining) and tuned to
+sit next to the cel-shaded terrain.
+
+## Map of shader systems
+
+| System | File | Notes |
+| --- | --- | --- |
+| Terrain (sand / cel low-poly) | `engine/landscape/shaders.js` | `SAND_FS`, `LOWPOLY_FS`; ripple normals, sparkle, rim, hemi, fog/haze |
+| Ocean water plane | `engine/landscape/water.js` | flowing ripples, foam, fresnel, Blinn-Phong glint, depth tint |
+| Voxel-world waterfalls / water flow | `engine/world/05-tile-factory.js` | curtain + surface shader sheets, batched foam puffs |
+| Reusable FX library | `engine/world/45-shader-fx.js` | `window.TinyShaderFX` — water, waterfall, foam, smoke, explosion, wear |
+| Island side strata, propeller blur disc, shield | various `engine/world/*` | bespoke ShaderMaterials |
+
+> **Override note:** `engine/landscape/shaders.js` and `water.js` `Object.assign`
+> onto `LandscapeEngine.prototype` *after* the class is defined, so they override
+> the now-dead inline copies still living in `LandscapeEngine.js`. Edit the split
+> files.
+
+## Ocean water (engine/landscape/water.js)
+
+The ocean plane is a single quad shaded entirely in the fragment stage. Recent
+upgrades, at roughly the same GPU cost as the old single-layer ripple:
+
+- **Flowing, multi-directional ripples** — two value-noise layers scroll along
+  `flowDir` and its perpendicular so the surface never visibly tiles.
+- **Procedural surface normal** from finite differences of the combined field,
+  feeding both lighting and reflection.
+- **Blinn-Phong sun glint** (`specPower`) plus a soft broad sheen.
+- **Fresnel sky reflection** mixing `skyBottom`→`skyTop`.
+- **Foam** (`foamColor`, `foamAmount`) on animated wave crests and as a shoreline
+  ring at the island runway edge.
+- **Depth tint** with a hint of subsurface back-glow on the shallow colour.
+- **Cel posterization** (`posterize`, default 12 levels) preserving the toy look.
+- **Planet-distance tint** kept in parity with the terrain materials.
+
+## TinyShaderFX library (engine/world/45-shader-fx.js)
+
+A small, dependency-free library exposed on `window.TinyShaderFX`. Every animated
+material exposes a `uTime` uniform and self-registers with the frame ticker that
+the animation loop calls, so you never wire a per-material clock.
+
+```js
+// Flowing river on a flat plane
+const river = new THREE.Mesh(
+  new THREE.PlaneGeometry(20, 6).rotateX(-Math.PI / 2),
+  TinyShaderFX.makeWaterFlowMaterial({ flow: new THREE.Vector2(1, 0.2), speed: 0.8 })
+);
+scene.add(river);
+
+// Waterfall curtain on a vertical plane
+const fall = new THREE.Mesh(
+  new THREE.PlaneGeometry(4, 8),
+  TinyShaderFX.makeWaterfallMaterial({ lanes: 11 })
+);
+
+// A worn, weathered crate — patches a stock Lambert material
+const crate = new THREE.Mesh(
+  new THREE.BoxGeometry(2, 2, 2),
+  TinyShaderFX.applyWear(new THREE.MeshLambertMaterial({ color: 0xb8b0a0 }), { amount: 0.7 })
+);
+crate.material.setWear(0.9); // crank the damage later
+
+// One-shot explosion: drive uProgress 0→1 yourself and scale the mesh up
+const boom = new THREE.Mesh(new THREE.SphereGeometry(3, 24, 16), TinyShaderFX.makeExplosionMaterial());
+// in your update loop: boom.material.uniforms.uProgress.value = p; boom.scale.setScalar(0.4 + p * 1.6);
+```
+
+### Factories
+
+| Factory | Purpose | Drive |
+| --- | --- | --- |
+| `makeWaterFlowMaterial(opts)` | flowing river/pond surface | auto (`uTime`) |
+| `makeWaterfallMaterial(opts)` | vertical falling-water curtain | auto |
+| `makeFoamMaterial(opts)` | shoreline / splash / wake foam ribbon | auto |
+| `makeSmokeMaterial(opts)` | dissolving smoke billboard | `uAge` 0→1 |
+| `makeExplosionMaterial(opts)` | expanding fireball → smoke | `uProgress` 0→1 + mesh scale |
+| `applyWear(material, opts)` | procedural grime/cracks/scuffs on a stock material | `setWear(amount)` |
+
+`TinyShaderFX.GLSL_NOISE` is a prependable GLSL chunk
+(`fxHash/fxNoise/fxFbm/fxFresnel/fxPosterize`) for building your own materials.
+
+### Showcase
+
+Append `?shaderfx=demo` (or `?shaderfx=1`) to the URL to drop a gallery of the
+effects near the origin, or call `TinyShaderFX.demo()` from the console. It's
+opt-in, so default worlds are untouched.
+
+## Performance principles
+
+- Procedural only — no texture loads, no extra passes, no render targets. The
+  single-pass `renderer.render(scene, camera)` contract is preserved (see
+  `tinyworld-render-performance`).
+- Value-noise taps are kept to a handful per fragment; the ocean upgrade is
+  roughly cost-neutral versus the shader it replaced.
+- Animated materials share one frame tick; disposed materials are pruned from the
+  tracker automatically.
+- Reuse `GLSL_NOISE` and batch with `InstancedMesh` rather than spawning many
+  unique ShaderMaterials.

--- a/docs/SHADERS.md
+++ b/docs/SHADERS.md
@@ -39,6 +39,30 @@ upgrades, at roughly the same GPU cost as the old single-layer ripple:
 - **Cel posterization** (`posterize`, default 12 levels) preserving the toy look.
 - **Planet-distance tint** kept in parity with the terrain materials.
 
+## Enhanced water surfaces (Settings → Environment → "Enhanced water")
+
+The water you actually see on load is **voxel water tiles** using the `M.water` /
+`M.waterDk` Lambert materials — not the LandscapeEngine ocean. Both are now
+upgraded by a single Settings toggle (`render-enhanced-water`, default **on**,
+persisted as `tinyworld:render:enhancedWater`) that works in **every** environment:
+
+- **Voxel water tiles** (home island, generated worlds, rivers, lakes): the
+  enhancement is injected at the one chokepoint every water material flows
+  through — `applyFlowingWaterUVs` in `engine/world/04-textures.js`. It keeps the
+  material a `MeshLambertMaterial` (so colour shades, flow direction, and the
+  wear slider keep working) and, via `onBeforeCompile`, adds an animated ripple
+  normal → moving light/dark bands, fresnel sky sheen, sharp Blinn-Phong sun
+  glints and foam — masked to upward-facing faces so the tile sides stay calm. A
+  shared `uWaterTime` uniform (advanced in `tickWaterTextureFlow`) drives them
+  all, and a `customProgramCacheKey` makes the toggle recompile cleanly at runtime.
+- **LandscapeEngine ocean** (`engine/landscape/water.js`): the same toggle drives a
+  `uEnhance` uniform that scales the foam / sheen / subsurface terms, so turning it
+  off falls back toward the simpler original look.
+
+Toggling rebuilds water materials (`refreshWaterShaderMaterials()` clears the flow
+cache, then `rebuildTerrainRender()`), so it applies immediately. Waterfalls keep
+their own dedicated shaders and are unaffected by this surface toggle.
+
 ## TinyShaderFX library (engine/world/45-shader-fx.js)
 
 A small, dependency-free library exposed on `window.TinyShaderFX`. Every animated

--- a/engine/landscape/water.js
+++ b/engine/landscape/water.js
@@ -36,9 +36,20 @@
           fresnelBoost: { value: 1.12 },
           sunGlint:     { value: 1.18 },
           waterOpacity: { value: 0.92 },
+          // --- flow / foam / specular controls (3d-game-shaders water+lighting) ---
+          flowDir:      { value: new THREE.Vector2(0.94, 0.34) },
+          foamColor:    { value: new THREE.Color(0xeaf7ff) },
+          foamAmount:   { value: 0.55 },
+          specPower:    { value: 90.0 },
+          posterize:    { value: 12.0 },
           clipEnabled:  { value: 0.0 },
           clipMin:      { value: this._clipMin },
           clipMax:      { value: this._clipMax },
+          // --- planet-distance tint (parity with terrain ShaderMaterials) ---
+          planetDistanceEffect:     { value: 0.0 },
+          planetDistanceColor:      { value: new THREE.Color(this.currentBiome.fogColor) },
+          planetDistanceDesaturate: { value: 0.0 },
+          planetDistanceDim:        { value: 1.0 },
         },
         vertexShader: `
           varying vec3 vWorldPos;
@@ -68,9 +79,18 @@
           uniform float fresnelBoost;
           uniform float sunGlint;
           uniform float waterOpacity;
+          uniform vec2 flowDir;
+          uniform vec3 foamColor;
+          uniform float foamAmount;
+          uniform float specPower;
+          uniform float posterize;
           uniform float clipEnabled;
           uniform vec3 clipMin;
           uniform vec3 clipMax;
+          uniform float planetDistanceEffect;
+          uniform vec3 planetDistanceColor;
+          uniform float planetDistanceDesaturate;
+          uniform float planetDistanceDim;
           varying vec3 vWorldPos;
           varying float vDist;
 
@@ -109,30 +129,66 @@
             if (rw < runwayR) discard;
             float rwFade = smoothstep(runwayR, runwayR + 60.0, rw);
 
-            vec2 uv = vWorldPos.xz * 0.012;
-            float r1 = noise(uv + vec2(time * 0.05, time * 0.03));
-            float r2 = noise(uv * 2.3 - vec2(time * 0.07, time * 0.04));
-            float ripple = r1 * 0.65 + r2 * 0.35;
+            // --- Flowing, multi-directional ripple field (6 noise taps) ---
+            // Two layers scroll along flowDir and its perpendicular so the
+            // surface never visibly tiles. Cost stays on par with the old
+            // single-layer ripple but reads far livelier.
+            vec2 fl = flowDir;
+            vec2 baseUv = vWorldPos.xz * 0.012;
+            vec2 uv1 = baseUv + fl * (time * 0.05);
+            vec2 uv2 = baseUv * 2.3 + vec2(-fl.y, fl.x) * (time * 0.07);
 
-            vec2 eps = vec2(0.5, 0.0);
-            float rN = noise(uv + eps.xy) - noise(uv - eps.xy);
-            float rE = noise(uv + eps.yx) - noise(uv - eps.yx);
-            vec3 norm = normalize(vec3(-rN * 0.6, 1.0, -rE * 0.6));
-            float sun = pow(max(0.0, dot(norm, sunDir)), 32.0);
+            float h0 = noise(uv1) * 0.62 + noise(uv2) * 0.38;
+            float e = 0.5;
+            float hX = noise(uv1 + vec2(e, 0.0)) * 0.62 + noise(uv2 + vec2(e, 0.0)) * 0.38;
+            float hZ = noise(uv1 + vec2(0.0, e)) * 0.62 + noise(uv2 + vec2(0.0, e)) * 0.38;
+            vec3 norm = normalize(vec3(-(hX - h0) * 0.85, 1.0, -(hZ - h0) * 0.85));
+
             vec3 viewDir = normalize(cameraPos - vWorldPos);
+            vec3 L = normalize(sunDir);
+            vec3 Hh = normalize(L + viewDir);
+
+            // --- Blinn-Phong sun glint (tight specular) + broad sheen ---
+            float ndh = max(dot(norm, Hh), 0.0);
+            float glint = pow(ndh, specPower);
+            float sheen = pow(ndh, max(specPower * 0.16, 1.0)) * 0.12;
+
+            // --- Fresnel sky reflection ---
             float fresnel = pow(1.0 - max(0.0, dot(norm, viewDir)), 3.0);
             float skyMix = clamp(viewDir.y * 0.5 + 0.5, 0.0, 1.0);
             vec3 reflectedSky = mix(skyBottom, skyTop, pow(skyMix, 0.8));
 
-            vec3 col = mix(deep, shallow, ripple * 0.58 + 0.24);
+            // --- Depth-tinted base with a hint of subsurface back-glow ---
+            vec3 col = mix(deep, shallow, h0 * 0.58 + 0.24);
+            float back = max(dot(-norm, L), 0.0);
+            col += shallow * back * 0.05;
+
             float reflectionMix = clamp((0.14 + fresnel * 0.44 * fresnelBoost) * reflectivity, 0.0, 0.94);
             col = mix(col, reflectedSky, reflectionMix);
-            col += vec3(1.0, 0.98, 0.92) * sun * (0.28 + 0.42 * sunGlint);
+            col += reflectedSky * sheen;
+            col += vec3(1.0, 0.98, 0.92) * glint * (0.28 + 0.42 * sunGlint);
 
-            col = floor(col * 12.0) / 12.0;
+            // --- Foam: animated wave crests + a shoreline ring at the island edge ---
+            float crest = smoothstep(0.66, 0.95, h0);
+            float shore = 1.0 - smoothstep(runwayR, runwayR + 24.0, rw);
+            float foamN = noise(baseUv * 7.0 + fl * (time * 0.22));
+            float foam = clamp((crest + shore * 0.85) * foamAmount * (0.45 + foamN * 0.75), 0.0, 1.0);
+            col = mix(col, foamColor, foam);
+
+            // --- Optional cel posterization (12 levels reproduces the old look) ---
+            if (posterize > 0.5) col = floor(col * posterize) / posterize;
 
             float fogF = clamp((vDist - fogNear) / (fogFar - fogNear), 0.0, 1.0);
             col = mix(col, fogColor, fogF);
+
+            // --- Planet-distance tint (parity with terrain materials) ---
+            if (planetDistanceEffect > 0.001) {
+              float distMix = clamp(planetDistanceEffect, 0.0, 1.0);
+              float grey = dot(col, vec3(0.299, 0.587, 0.114));
+              col = mix(col, vec3(grey), clamp(planetDistanceDesaturate, 0.0, 1.0) * distMix);
+              col = mix(col, planetDistanceColor, distMix);
+              col *= mix(1.0, planetDistanceDim, distMix);
+            }
 
             gl_FragColor = vec4(col, waterOpacity * rwFade * edgeFade);
           }

--- a/engine/landscape/water.js
+++ b/engine/landscape/water.js
@@ -42,6 +42,8 @@
           foamAmount:   { value: 0.55 },
           specPower:    { value: 90.0 },
           posterize:    { value: 12.0 },
+          // Gated by the "Enhanced water" Settings toggle (renderEnhancedWater).
+          uEnhance:     { value: (typeof renderEnhancedWater === 'undefined' || renderEnhancedWater) ? 1.0 : 0.0 },
           clipEnabled:  { value: 0.0 },
           clipMin:      { value: this._clipMin },
           clipMax:      { value: this._clipMax },
@@ -84,6 +86,7 @@
           uniform float foamAmount;
           uniform float specPower;
           uniform float posterize;
+          uniform float uEnhance;
           uniform float clipEnabled;
           uniform vec3 clipMin;
           uniform vec3 clipMax;
@@ -161,11 +164,11 @@
             // --- Depth-tinted base with a hint of subsurface back-glow ---
             vec3 col = mix(deep, shallow, h0 * 0.58 + 0.24);
             float back = max(dot(-norm, L), 0.0);
-            col += shallow * back * 0.05;
+            col += shallow * back * 0.05 * uEnhance;
 
             float reflectionMix = clamp((0.14 + fresnel * 0.44 * fresnelBoost) * reflectivity, 0.0, 0.94);
             col = mix(col, reflectedSky, reflectionMix);
-            col += reflectedSky * sheen;
+            col += reflectedSky * sheen * uEnhance;
             col += vec3(1.0, 0.98, 0.92) * glint * (0.28 + 0.42 * sunGlint);
 
             // --- Foam: animated wave crests + a shoreline ring at the island edge ---
@@ -173,7 +176,7 @@
             float shore = 1.0 - smoothstep(runwayR, runwayR + 24.0, rw);
             float foamN = noise(baseUv * 7.0 + fl * (time * 0.22));
             float foam = clamp((crest + shore * 0.85) * foamAmount * (0.45 + foamN * 0.75), 0.0, 1.0);
-            col = mix(col, foamColor, foam);
+            col = mix(col, foamColor, foam * uEnhance);
 
             // --- Optional cel posterization (12 levels reproduces the old look) ---
             if (posterize > 0.5) col = floor(col * posterize) / posterize;

--- a/engine/world/01-render-core.js
+++ b/engine/world/01-render-core.js
@@ -188,6 +188,7 @@
     materialParts: 'tinyworld:render:materialParts',
     materialTarget: 'tinyworld:render:materialTarget',
     materialWear: 'tinyworld:render:materialWear',
+    enhancedWater: 'tinyworld:render:enhancedWater',
     landscapeMeshMode: 'tinyworld:render:landscapeMeshMode',
     terrainVoxelResolution: 'tinyworld:render:terrainVoxelResolution',
     showCrowns: 'tinyworld:render:showCrowns',
@@ -263,6 +264,7 @@
     materialParts: '{}',
     materialTarget: 'walls',
     materialWear: '0',
+    enhancedWater: '1',
     landscapeMeshMode: '1',
     terrainVoxelResolution: 'mixed',
     autoExpand: '0',
@@ -428,6 +430,10 @@
   // denser parts of each cloud cast on the world below.
   let renderCloudShadow = storedNumber(RENDER_LS.cloudShadow, 0, 0, 1);
   let renderPlanesEnabled = localStorage.getItem(RENDER_LS.planesEnabled) === '1';
+  // Enhanced water shader: animated reflections, sun glints and foam on water
+  // surfaces (voxel water tiles + the LandscapeEngine ocean). On by default;
+  // toggling rebuilds water materials so it applies in every environment.
+  let renderEnhancedWater = localStorage.getItem(RENDER_LS.enhancedWater) !== '0';
   // Decorative background mini-worlds (distant-worlds group); on by default.
   let renderDistantWorlds = localStorage.getItem(RENDER_LS.distantWorlds) !== '0';
   // Soft sprite "cloud sea" below the islands; off by default (opt-in).

--- a/engine/world/03-geometry-materials.js
+++ b/engine/world/03-geometry-materials.js
@@ -234,7 +234,7 @@
     wearMoss:  new THREE.MeshLambertMaterial({ color: 0x6f8732, side: THREE.FrontSide }),
     water:     new THREE.MeshLambertMaterial({ color: 0x3a8fcc, side: THREE.FrontSide }),
     waterDk:   new THREE.MeshLambertMaterial({ color: 0x2f77ad, side: THREE.FrontSide }),
-    waterFoam: new THREE.MeshLambertMaterial({ color: 0xbbe9ff, transparent: true, opacity: 0.74, side: THREE.FrontSide }),
+    waterFoam: new THREE.MeshLambertMaterial({ color: 0xeaf7ff, transparent: true, opacity: 0.86, side: THREE.FrontSide }),
     waterfall: new THREE.MeshBasicMaterial({ color: 0x28b5f0, transparent: true, opacity: 0.56, depthWrite: true, side: THREE.FrontSide }),
     waterfallHi: new THREE.MeshBasicMaterial({ color: 0x96e7ff, transparent: true, opacity: 0.68, depthWrite: true, side: THREE.FrontSide }),
     waterfallFoamPuff: new THREE.MeshBasicMaterial({ color: 0xf4fdff, transparent: true, opacity: 0.82, depthWrite: true }),

--- a/engine/world/04-textures.js
+++ b/engine/world/04-textures.js
@@ -1040,19 +1040,40 @@
     return waterTextureFlowStates.get(key);
   }
 
+  // Shared clock + procedural noise for the enhanced water surface shader
+  // (animated reflections / sun glints / foam). Advanced by tickWaterTextureFlow
+  // and shared across every water material so one update drives them all.
+  const waterShaderTimeUniform = { value: 0 };
+  const WATER_SHADER_NOISE_GLSL = `
+    float twWaterHash(vec2 p){ return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123); }
+    float twWaterNoise(vec2 p){
+      vec2 i = floor(p); vec2 f = fract(p);
+      vec2 u = f*f*(3.0-2.0*f);
+      return mix(mix(twWaterHash(i), twWaterHash(i+vec2(1.0,0.0)), u.x),
+                 mix(twWaterHash(i+vec2(0.0,1.0)), twWaterHash(i+vec2(1.0,1.0)), u.x), u.y);
+    }
+  `;
+
   function applyFlowingWaterUVs(material, texture, textureScale = 1.0, flowState = waterTextureFlowState(1, 0)) {
     if (!material) return;
     material.map = texture;
     material.userData = material.userData || {};
     material.userData.worldTextureScale = textureScale;
     material.needsUpdate = true;
+    // The enhanced surface shimmer is injected via onBeforeCompile, whose output
+    // is NOT part of the default program cache key — so give each enhanced/plain
+    // state its own key. That lets the Settings toggle recompile water cleanly.
+    material.customProgramCacheKey = () =>
+      'tw-water-' + textureScale.toFixed(4) + '-' + (renderEnhancedWater ? 'fx' : 'plain');
     material.onBeforeCompile = (shader) => {
+      const enhanced = (typeof renderEnhancedWater === 'undefined') ? true : renderEnhancedWater;
       shader.uniforms.waterFlowOffset = { value: flowState.offset };
       shader.vertexShader = shader.vertexShader.replace(
         '#include <common>',
         `
         #include <common>
         uniform vec2 waterFlowOffset;
+        ${enhanced ? 'varying vec3 vTwWaterWorld; varying vec3 vTwWaterView; varying vec3 vTwWaterNrm;' : ''}
         `
       );
       shader.vertexShader = shader.vertexShader.replace(
@@ -1070,6 +1091,7 @@
           localNormal = instanceMatrix * localNormal;
         #endif
         vec3 worldNormal = normalize((modelMatrix * localNormal).xyz);
+        ${enhanced ? 'vTwWaterWorld = worldPos.xyz; vTwWaterView = cameraPosition - worldPos.xyz; vTwWaterNrm = worldNormal;' : ''}
 
         if (abs(worldNormal.y) > 0.5) {
           vUv = worldPos.xz * ${textureScale.toFixed(4)} + waterFlowOffset;
@@ -1080,7 +1102,68 @@
         }
         `
       );
+      if (!enhanced) return;
+      // --- enhanced water surface: animated ripple normal -> fresnel sky tint,
+      //     Blinn-Phong sun glint and foam, masked to upward-facing faces ---
+      shader.uniforms.uWaterTime = waterShaderTimeUniform;
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <common>',
+        `
+        #include <common>
+        uniform float uWaterTime;
+        varying vec3 vTwWaterWorld;
+        varying vec3 vTwWaterView;
+        varying vec3 vTwWaterNrm;
+        ${WATER_SHADER_NOISE_GLSL}
+        `
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <dithering_fragment>',
+        `
+        {
+          float twTop = smoothstep(0.45, 0.82, vTwWaterNrm.y);
+          if (twTop > 0.001) {
+            vec2 wp = vTwWaterWorld.xz;
+            float t = uWaterTime;
+            vec2 f1 = wp * 0.55 + vec2(t * 0.06, t * 0.045);
+            vec2 f2 = wp * 1.25 - vec2(t * 0.05, t * 0.062);
+            float h0 = twWaterNoise(f1) * 0.6 + twWaterNoise(f2) * 0.4;
+            float e = 0.35;
+            float hX = twWaterNoise(f1 + vec2(e, 0.0)) * 0.6 + twWaterNoise(f2 + vec2(e, 0.0)) * 0.4;
+            float hZ = twWaterNoise(f1 + vec2(0.0, e)) * 0.6 + twWaterNoise(f2 + vec2(0.0, e)) * 0.4;
+            vec3 rn = normalize(vec3(-(hX - h0) * 1.1, 1.0, -(hZ - h0) * 1.1));
+            vec3 vdir = normalize(vTwWaterView);
+            vec3 sdir = normalize(vec3(0.45, 0.85, 0.35));
+            vec3 hvec = normalize(sdir + vdir);
+            float glint = pow(max(dot(rn, hvec), 0.0), 80.0);
+            float fres = pow(1.0 - clamp(dot(rn, vdir), 0.0, 1.0), 3.0);
+            float foam = smoothstep(0.74, 0.96, h0);
+            float ripple = h0 - 0.5;
+            vec3 sky = vec3(0.62, 0.80, 0.96);
+            // broad moving light/dark bands make the motion obvious from any
+            // angle; sharp glints + fresnel sheen + foam add the sparkle on top.
+            vec3 addCol = vec3(0.85, 0.93, 1.0) * ripple * 0.07
+                        + sky * fres * 0.18
+                        + vec3(1.0, 0.99, 0.95) * glint * 0.55
+                        + vec3(0.92, 0.97, 1.0) * foam * 0.12;
+            gl_FragColor.rgb += addCol * twTop;
+          }
+        }
+        #include <dithering_fragment>
+        `
+      );
     };
+  }
+
+  // Rebuild water materials after the enhanced-water Settings toggle changes:
+  // drop cached flow clones and reset the base materials so they recompile with
+  // the new program cache key. Callers follow up with rebuildTerrainRender().
+  function refreshWaterShaderMaterials() {
+    waterFlowMaterialCache.clear();
+    const sW = (M.water.userData && M.water.userData.worldTextureScale) || 1;
+    const sD = (M.waterDk.userData && M.waterDk.userData.worldTextureScale) || 1;
+    applyFlowingWaterUVs(M.water, M.water.map || texRipples, sW);
+    applyFlowingWaterUVs(M.waterDk, M.waterDk.map || texRipples, sD);
   }
 
   function applyTerrainWorldUVs(name, material, texture, textureScale = 1.0) {
@@ -1090,6 +1173,7 @@
 
   function tickWaterTextureFlow(dt) {
     if (!dt) return;
+    waterShaderTimeUniform.value += dt;
     for (const state of waterTextureFlowStates.values()) {
       state.offset.x = (state.offset.x + state.direction.x * state.speed * dt) % 1;
       state.offset.y = (state.offset.y + state.direction.y * state.speed * dt) % 1;

--- a/engine/world/04-textures.js
+++ b/engine/world/04-textures.js
@@ -1141,13 +1141,13 @@
             float glint = pow(max(dot(rn, hvec), 0.0), 60.0);
             // bright thin caustic veins where the wave field crosses mid-height
             float veins = pow(max(1.0 - abs(h0 - 0.5) * 2.0, 0.0), 4.0);
-            float foam = smoothstep(0.80, 0.96, h0);
+            float foam = smoothstep(0.62, 0.84, h0);
             // Visible moving light/dark wave bands (troughs darker, crests brighter).
             gl_FragColor.rgb *= mix(0.82, 1.08, h0) * twTop + (1.0 - twTop);
             // Cyan caustic veins + white sun sparkles + foam crests on top.
             vec3 addCol = vec3(0.55, 0.86, 1.0) * veins * 0.22
                         + vec3(1.0, 1.0, 0.98) * glint * 0.85
-                        + vec3(0.92, 0.98, 1.0) * foam * 0.22;
+                        + vec3(0.95, 0.99, 1.0) * foam * 0.32;
             gl_FragColor.rgb += addCol * twTop;
           }
         }

--- a/engine/world/04-textures.js
+++ b/engine/world/04-textures.js
@@ -1125,27 +1125,29 @@
           if (twTop > 0.001) {
             vec2 wp = vTwWaterWorld.xz;
             float t = uWaterTime;
-            vec2 f1 = wp * 0.55 + vec2(t * 0.06, t * 0.045);
-            vec2 f2 = wp * 1.25 - vec2(t * 0.05, t * 0.062);
+            // Two scrolling noise fields -> a moving wave height h0. Everything
+            // below is VIEW-INDEPENDENT (depends only on world pos + time) so it
+            // reads clearly even from the default top-down-ish camera.
+            vec2 f1 = wp * 0.70 + vec2(t * 0.11, t * 0.07);
+            vec2 f2 = wp * 1.70 - vec2(t * 0.08, t * 0.12);
             float h0 = twWaterNoise(f1) * 0.6 + twWaterNoise(f2) * 0.4;
-            float e = 0.35;
+            float e = 0.30;
             float hX = twWaterNoise(f1 + vec2(e, 0.0)) * 0.6 + twWaterNoise(f2 + vec2(e, 0.0)) * 0.4;
             float hZ = twWaterNoise(f1 + vec2(0.0, e)) * 0.6 + twWaterNoise(f2 + vec2(0.0, e)) * 0.4;
-            vec3 rn = normalize(vec3(-(hX - h0) * 1.1, 1.0, -(hZ - h0) * 1.1));
+            vec3 rn = normalize(vec3(-(hX - h0) * 2.4, 1.0, -(hZ - h0) * 2.4));
             vec3 vdir = normalize(vTwWaterView);
-            vec3 sdir = normalize(vec3(0.45, 0.85, 0.35));
+            vec3 sdir = normalize(vec3(0.40, 0.72, 0.55));
             vec3 hvec = normalize(sdir + vdir);
-            float glint = pow(max(dot(rn, hvec), 0.0), 80.0);
-            float fres = pow(1.0 - clamp(dot(rn, vdir), 0.0, 1.0), 3.0);
-            float foam = smoothstep(0.74, 0.96, h0);
-            float ripple = h0 - 0.5;
-            vec3 sky = vec3(0.62, 0.80, 0.96);
-            // broad moving light/dark bands make the motion obvious from any
-            // angle; sharp glints + fresnel sheen + foam add the sparkle on top.
-            vec3 addCol = vec3(0.85, 0.93, 1.0) * ripple * 0.07
-                        + sky * fres * 0.18
-                        + vec3(1.0, 0.99, 0.95) * glint * 0.55
-                        + vec3(0.92, 0.97, 1.0) * foam * 0.12;
+            float glint = pow(max(dot(rn, hvec), 0.0), 60.0);
+            // bright thin caustic veins where the wave field crosses mid-height
+            float veins = pow(max(1.0 - abs(h0 - 0.5) * 2.0, 0.0), 4.0);
+            float foam = smoothstep(0.80, 0.96, h0);
+            // Visible moving light/dark wave bands (troughs darker, crests brighter).
+            gl_FragColor.rgb *= mix(0.82, 1.08, h0) * twTop + (1.0 - twTop);
+            // Cyan caustic veins + white sun sparkles + foam crests on top.
+            vec3 addCol = vec3(0.55, 0.86, 1.0) * veins * 0.22
+                        + vec3(1.0, 1.0, 0.98) * glint * 0.85
+                        + vec3(0.92, 0.98, 1.0) * foam * 0.22;
             gl_FragColor.rgb += addCol * twTop;
           }
         }

--- a/engine/world/04-textures.js
+++ b/engine/world/04-textures.js
@@ -1117,8 +1117,10 @@
         ${WATER_SHADER_NOISE_GLSL}
         `
       );
+      // Inject before <fog_fragment> (not <dithering_fragment>) so the shimmer
+      // gets fogged with distance instead of bypassing fog/tonemapping.
       shader.fragmentShader = shader.fragmentShader.replace(
-        '#include <dithering_fragment>',
+        '#include <fog_fragment>',
         `
         {
           float twTop = smoothstep(0.45, 0.82, vTwWaterNrm.y);
@@ -1151,7 +1153,7 @@
             gl_FragColor.rgb += addCol * twTop;
           }
         }
-        #include <dithering_fragment>
+        #include <fog_fragment>
         `
       );
     };

--- a/engine/world/05-tile-factory.js
+++ b/engine/world/05-tile-factory.js
@@ -650,6 +650,17 @@
         } else {
           queue(getBoxGeometry(rimD, rimH, len), pickMat(dir, i), dir === 'w' ? -off : off, py, across);
         }
+        // Bright foam lip riding the water surface against the bank — only on
+        // edges that border land (this loop already runs land-bordering sides).
+        const fLen = step * (0.84 + r * 0.12);
+        const fW = 0.11;
+        const fOff = topSize * 0.5 - fW * 0.5 - 0.018;
+        const fY = visualTopY + 0.008;
+        if (alongX) {
+          queue(getBoxGeometry(fLen, 0.014, fW), M.waterFoam, across, fY, dir === 'n' ? -fOff : fOff);
+        } else {
+          queue(getBoxGeometry(fW, 0.014, fLen), M.waterFoam, dir === 'w' ? -fOff : fOff, fY, across);
+        }
       }
     }
 

--- a/engine/world/13-distant-dressing-ghost.js
+++ b/engine/world/13-distant-dressing-ghost.js
@@ -148,30 +148,79 @@
     const spanOuter = span + sideFaceOutset * 2;
     const wallTopY = ISLAND_SIDE_STRATA_RENDER_TOP_Y;
     const wallH = ISLAND_SIDE_STRATA_RENDER_HEIGHT;
-    const y = wallTopY - wallH * 0.5;
+    const wallBottomY = wallTopY - wallH;
     const mat = islandShellMaterial(M.boardSideEdge || M.boardSide);
-    const north = vbox(parent, spanOuter, wallH, thickness, 0, y, -half + inset, mat, {
-      noGap: true, noShadow: true, skipTop: true, skipBottom: true,
-      skipPX: true, skipNX: true, skipPZ: true,
-    });
-    const south = vbox(parent, spanOuter, wallH, thickness, 0, y,  half - inset, mat, {
-      noGap: true, noShadow: true, skipTop: true, skipBottom: true,
-      skipPX: true, skipNX: true, skipNZ: true,
-    });
-    const west  = vbox(parent, thickness, wallH, spanOuter, -half + inset, y, 0, mat, {
-      noGap: true, noShadow: true, skipTop: true, skipBottom: true,
-      skipPX: true, skipPZ: true, skipNZ: true,
-    });
-    const east  = vbox(parent, thickness, wallH, spanOuter,  half - inset, y, 0, mat, {
-      noGap: true, noShadow: true, skipTop: true, skipBottom: true,
-      skipNX: true, skipPZ: true, skipNZ: true,
-    });
-    for (const mesh of [north, south, west, east]) {
+    // Where a perimeter cell is water, drop the green grass cap down to the
+    // water line so a river reaching the rim shows water instead of a green
+    // wall. The strata shader maps its texture by WORLD-Y, so a shorter cap
+    // segment stays perfectly aligned with the full-height land neighbours.
+    const capBaseY = ISLAND_SIDE_STRATA_TOP_Y - WATER_SURFACE_DROP + 0.012;
+
+    function tagSide(mesh) {
       mesh.name = 'island-side-backing';
       mesh.userData.islandSideBacking = true;
       mesh.userData.noBatch = true;
       mesh.userData.noStaticBaseMerge = true;
+      return mesh;
     }
+    function edgeCellIsWater(dir, idx) {
+      // Only the home island maps to the live `world` grid; editable islands
+      // share this builder but have their own data, so they keep full green caps.
+      if (parent !== homeBorderGroup) return false;
+      const cell = dir === 'n' ? getWorldCell(idx, 0)
+                 : dir === 's' ? getWorldCell(idx, GRID - 1)
+                 : dir === 'w' ? getWorldCell(0, idx)
+                 :               getWorldCell(GRID - 1, idx);
+      return !!cell && cell.terrain === 'water';
+    }
+
+    // 1) Continuous lower wall around the whole island, topped at the water
+    //    line so it can never occlude water. Same outer faces as before.
+    const lowerH = capBaseY - wallBottomY;
+    const lowerCy = capBaseY - lowerH * 0.5;
+    tagSide(vbox(parent, spanOuter, lowerH, thickness, 0, lowerCy, -half + inset, mat, {
+      noGap: true, noShadow: true, skipTop: true, skipBottom: true, skipPX: true, skipNX: true, skipPZ: true,
+    }));
+    tagSide(vbox(parent, spanOuter, lowerH, thickness, 0, lowerCy,  half - inset, mat, {
+      noGap: true, noShadow: true, skipTop: true, skipBottom: true, skipPX: true, skipNX: true, skipNZ: true,
+    }));
+    tagSide(vbox(parent, thickness, lowerH, spanOuter, -half + inset, lowerCy, 0, mat, {
+      noGap: true, noShadow: true, skipTop: true, skipBottom: true, skipPX: true, skipPZ: true, skipNZ: true,
+    }));
+    tagSide(vbox(parent, thickness, lowerH, spanOuter,  half - inset, lowerCy, 0, mat, {
+      noGap: true, noShadow: true, skipTop: true, skipBottom: true, skipNX: true, skipPZ: true, skipNZ: true,
+    }));
+
+    // 2) Green grass-cap band — only across runs of land perimeter cells, so
+    //    water cells leave the rim open for the river to reach the edge.
+    const capH = wallTopY - capBaseY;
+    const capCy = wallTopY - capH * 0.5;
+    function buildCapEdge(dir) {
+      const alongX = dir === 'n' || dir === 's';
+      const across = (dir === 'n' || dir === 'w') ? -half + inset : half - inset;
+      const innerSkip = dir === 'n' ? { skipPZ: true } : dir === 's' ? { skipNZ: true } : dir === 'w' ? { skipPX: true } : { skipNX: true };
+      let i = 0;
+      while (i < GRID) {
+        if (edgeCellIsWater(dir, i)) { i++; continue; }
+        let j = i;
+        while (j + 1 < GRID && !edgeCellIsWater(dir, j + 1)) j++;
+        let aMin = (i - GRID / 2) * TILE;
+        let aMax = (j + 1 - GRID / 2) * TILE;
+        if (i === 0) aMin -= sideFaceOutset;
+        if (j === GRID - 1) aMax += sideFaceOutset;
+        const len = aMax - aMin;
+        const center = (aMin + aMax) * 0.5;
+        const opts = Object.assign({ noGap: true, noShadow: true, skipTop: true, skipBottom: true }, innerSkip);
+        tagSide(alongX
+          ? vbox(parent, len, capH, thickness, center, capCy, across, mat, opts)
+          : vbox(parent, thickness, capH, len, across, capCy, center, mat, opts));
+        i = j + 1;
+      }
+    }
+    buildCapEdge('n');
+    buildCapEdge('s');
+    buildCapEdge('w');
+    buildCapEdge('e');
   }
 
   function addIslandEdgeDressing(parent) {

--- a/engine/world/13-distant-dressing-ghost.js
+++ b/engine/world/13-distant-dressing-ghost.js
@@ -490,6 +490,19 @@
   }
   enqueueDeferredVisualStartup('home-border-dressing', buildHomeBorder);
 
+  // The island side cap opens where a perimeter cell is water (addIslandSideBacking
+  // reads the live grid). buildHomeBorder only runs at startup/resize, so when a
+  // perimeter cell toggles water at runtime, rebuild it — debounced so a drag of
+  // edits coalesces into a single rebuild.
+  let homeBorderEdgeRefreshTimer = 0;
+  function scheduleHomeBorderEdgeRefresh() {
+    if (homeBorderEdgeRefreshTimer) return;
+    homeBorderEdgeRefreshTimer = setTimeout(() => {
+      homeBorderEdgeRefreshTimer = 0;
+      if (typeof buildHomeBorder === 'function') buildHomeBorder();
+    }, 80);
+  }
+
   // -------- ghost worlds --------
   // Non-editable neighbouring boards. They preview the multiplayer shape of
   // the world without changing the central board's world/cellMeshes contract.

--- a/engine/world/17-tile-renderers.js
+++ b/engine/world/17-tile-renderers.js
@@ -610,6 +610,14 @@
       if (getWorldCell(x, z).kind === 'bridge') renderCellObject(x, z, { animate: false });
       repaintProfileEnd('setCell.neighbors', neighborStart);
     }
+    // A perimeter cell toggling water changes where the island's green edge cap
+    // opens, so rebuild the home border (debounced) to keep the rim in sync.
+    if (terrainChanged
+        && (x === 0 || z === 0 || x === GRID - 1 || z === GRID - 1)
+        && (prev.terrain === 'water') !== (nextTerrain === 'water')
+        && typeof scheduleHomeBorderEdgeRefresh === 'function') {
+      scheduleHomeBorderEdgeRefresh();
+    }
     if (!kindChanged && !floorsChanged && !terrainFloorsChanged && !bTypeChanged && !fenceSideChanged && !appearanceChanged && !transformChanged && !waterFlowChanged) {
       if (terrainChanged || tileHeightChanged || waterFlowChanged || forceTile) {
         const saveStart = repaintProfileBegin();

--- a/engine/world/19-tools-toolbar.js
+++ b/engine/world/19-tools-toolbar.js
@@ -1463,6 +1463,9 @@
       const posType = posTypeForToolGroup(group);
       if (posType) btn.dataset.posType = posType;
       btn.title = group.label;
+      // Keep an accessible name even when the label text is visually hidden on
+      // small screens (icon-only toolbar), so screen readers still announce it.
+      btn.setAttribute('aria-label', group.label);
       btn.setAttribute('data-tooltip', group.label);
       const icon = document.createElement('span');
       icon.className = 'group-icon';

--- a/engine/world/21-object-transform-voxel-build.js
+++ b/engine/world/21-object-transform-voxel-build.js
@@ -29,6 +29,7 @@
     const cloudHeightEl = document.getElementById('render-cloud-height');
     const cloudShadowEl = document.getElementById('render-cloud-shadow');
     const planesEnabledEl = document.getElementById('render-planes-enabled');
+    const enhancedWaterEl = document.getElementById('render-enhanced-water');
     const distantWorldsEl = document.getElementById('render-distant-worlds');
     const cloudSeaEl = document.getElementById('render-cloud-sea');
     const cloudSoftEl = document.getElementById('render-cloud-soft');
@@ -353,6 +354,7 @@
       cloudHeightEl.value = String(renderCloudHeight);
       cloudShadowEl.value = String(Math.round(renderCloudShadow * 100));
       if (planesEnabledEl) planesEnabledEl.checked = !!renderPlanesEnabled;
+      if (enhancedWaterEl) enhancedWaterEl.checked = !!renderEnhancedWater;
       if (distantWorldsEl) distantWorldsEl.checked = !!renderDistantWorlds;
       if (cloudSeaEl) cloudSeaEl.checked = !!renderCloudSea;
       if (cloudSoftEl) cloudSoftEl.checked = (renderCloudStyle === 'soft');
@@ -500,6 +502,7 @@
       localStorage.setItem(RENDER_LS.cloudHeight, renderCloudHeight.toFixed(1));
       localStorage.setItem(RENDER_LS.cloudShadow, renderCloudShadow.toFixed(2));
       localStorage.setItem(RENDER_LS.planesEnabled, renderPlanesEnabled ? '1' : '0');
+      localStorage.setItem(RENDER_LS.enhancedWater, renderEnhancedWater ? '1' : '0');
       localStorage.setItem(RENDER_LS.distantWorlds, renderDistantWorlds ? '1' : '0');
       localStorage.setItem(RENDER_LS.cloudSea, renderCloudSea ? '1' : '0');
       localStorage.setItem(RENDER_LS.cloudStyle, renderCloudStyle);
@@ -555,6 +558,7 @@
       const oldCloudHeight = renderCloudHeight;
       const oldUnderCloudSpread = renderUnderCloudSpread;
       const oldPlanesEnabled = renderPlanesEnabled;
+      const oldEnhancedWater = renderEnhancedWater;
       const oldDistantWorlds = renderDistantWorlds;
       const oldCloudSea = renderCloudSea;
       const oldCloudStyle = renderCloudStyle;
@@ -581,6 +585,7 @@
       renderCloudHeight = parseFloat(cloudHeightEl.value);
       renderCloudShadow = parseInt(cloudShadowEl.value, 10) / 100;
       renderPlanesEnabled = planesEnabledEl ? !!planesEnabledEl.checked : renderPlanesEnabled;
+      renderEnhancedWater = enhancedWaterEl ? !!enhancedWaterEl.checked : renderEnhancedWater;
       renderDistantWorlds = distantWorldsEl ? !!distantWorldsEl.checked : renderDistantWorlds;
       renderCloudSea = cloudSeaEl ? !!cloudSeaEl.checked : renderCloudSea;
       renderCloudStyle = cloudSoftEl && cloudSoftEl.checked ? 'soft' : 'voxel';
@@ -709,6 +714,17 @@
       if (oldPlanesEnabled !== renderPlanesEnabled && typeof setPlanesEnabled === 'function') {
         setPlanesEnabled(renderPlanesEnabled);
       }
+      if (oldEnhancedWater !== renderEnhancedWater) {
+        // Rebuild water materials (voxel tiles) and retune the landscape ocean
+        // so the enhanced-water toggle applies in every environment at once.
+        if (typeof refreshWaterShaderMaterials === 'function') refreshWaterShaderMaterials();
+        rebuildTerrainRender();
+        if (landscapeEngineInstance && landscapeEngineInstance.waterMat
+            && landscapeEngineInstance.waterMat.uniforms
+            && landscapeEngineInstance.waterMat.uniforms.uEnhance) {
+          landscapeEngineInstance.waterMat.uniforms.uEnhance.value = renderEnhancedWater ? 1.0 : 0.0;
+        }
+      }
       if (oldDistantWorlds !== renderDistantWorlds && typeof setDistantWorldsVisible === 'function') {
         setDistantWorldsVisible(renderDistantWorlds);
       }
@@ -788,7 +804,7 @@
     });
     closeBtn.addEventListener('click', () => { closeTinyModal(modal); });
     modal.addEventListener('click', e => { if (e.target === modal) closeTinyModal(modal); });
-    for (const el of [shadowEl, resolutionEl, distanceEl, visibleSizeEl, brightnessEl, lightingEl, ambientFillEl, frontFillEl, sideFillEl, backFillEl, saturationEl, contrastEl, cloudsEl, cloudSpeedEl, cloudHeightEl, cloudShadowEl, planesEnabledEl, distantWorldsEl, cloudSeaEl, cloudSoftEl, starVaultEl, starVaultStrengthEl, cloudRimLightEl, accentLightsEl, underCloudSpreadEl, skyBlueDepthEl, skyBlueSaturationEl, distanceMistEl, backdropEl, backdropVignetteEl, pixelSizeEl, pixelDepthEdgeEl, pixelNormalEdgeEl, shaderAntialiasEl, tiltBlurEl, tiltFocusEl, ghostOpacityEl, floorOpacityEl, objectOpacityEl, voxelGapEl, voxelBevelEl, voxelTerrainEl, surfaceLinkedMaterialsEl, showCrownsEl, terrainVoxelResolutionEl, terrainTintEl, terrainTextureEl, terrainTextureScaleEl, terrainToneEl, materialTintEl, materialTextureEl, materialTextureScaleEl, materialToneEl, materialWearEl, crowdCountEl, crowdScaleEl, crowdSpeedEl, crowdBobEl, crowdSwayEl, crowdLeanEl, crowdZoneRadiusEl, crowdShowZonesEl, crowdPausedEl, crowdEnabledEl, crowdDebugEl, crowdModeEl, crowdCountLiveEl, crowdScaleLiveEl, crowdSpeedLiveEl, crowdZoneRadiusLiveEl, crowdShowZonesLiveEl, crowdShowArrowsLiveEl, crowdPausedLiveEl, crowdEnabledLiveEl]) {
+    for (const el of [shadowEl, resolutionEl, distanceEl, visibleSizeEl, brightnessEl, lightingEl, ambientFillEl, frontFillEl, sideFillEl, backFillEl, saturationEl, contrastEl, cloudsEl, cloudSpeedEl, cloudHeightEl, cloudShadowEl, planesEnabledEl, enhancedWaterEl, distantWorldsEl, cloudSeaEl, cloudSoftEl, starVaultEl, starVaultStrengthEl, cloudRimLightEl, accentLightsEl, underCloudSpreadEl, skyBlueDepthEl, skyBlueSaturationEl, distanceMistEl, backdropEl, backdropVignetteEl, pixelSizeEl, pixelDepthEdgeEl, pixelNormalEdgeEl, shaderAntialiasEl, tiltBlurEl, tiltFocusEl, ghostOpacityEl, floorOpacityEl, objectOpacityEl, voxelGapEl, voxelBevelEl, voxelTerrainEl, surfaceLinkedMaterialsEl, showCrownsEl, terrainVoxelResolutionEl, terrainTintEl, terrainTextureEl, terrainTextureScaleEl, terrainToneEl, materialTintEl, materialTextureEl, materialTextureScaleEl, materialToneEl, materialWearEl, crowdCountEl, crowdScaleEl, crowdSpeedEl, crowdBobEl, crowdSwayEl, crowdLeanEl, crowdZoneRadiusEl, crowdShowZonesEl, crowdPausedEl, crowdEnabledEl, crowdDebugEl, crowdModeEl, crowdCountLiveEl, crowdScaleLiveEl, crowdSpeedLiveEl, crowdZoneRadiusLiveEl, crowdShowZonesLiveEl, crowdShowArrowsLiveEl, crowdPausedLiveEl, crowdEnabledLiveEl]) {
       if (!el) continue;
       el.addEventListener('input', applyFromControls);
       el.addEventListener('change', applyFromControls);

--- a/engine/world/21-object-transform-voxel-build.js
+++ b/engine/world/21-object-transform-voxel-build.js
@@ -876,6 +876,13 @@
       renderCloudStyle = 'soft';
       renderPlanesEnabled = false;
       if (typeof setPlanesEnabled === 'function') setPlanesEnabled(false);
+      renderEnhancedWater = true;
+      if (typeof refreshWaterShaderMaterials === 'function') refreshWaterShaderMaterials();
+      if (landscapeEngineInstance && landscapeEngineInstance.waterMat
+          && landscapeEngineInstance.waterMat.uniforms
+          && landscapeEngineInstance.waterMat.uniforms.uEnhance) {
+        landscapeEngineInstance.waterMat.uniforms.uEnhance.value = 1.0;
+      }
       renderStarVault = true;
       renderStarVaultStrength = 0.92;
       renderCloudRimLight = 0.78;

--- a/engine/world/25-animation-loop-schema.js
+++ b/engine/world/25-animation-loop-schema.js
@@ -58,6 +58,7 @@
     if (typeof tickVoxelShield === 'function') tickVoxelShield(dt, t);
     tickWaterTextureFlow(dt);
     updateWaterfallEffects(t);
+    if (typeof window.__tinyworldShaderFXTick === 'function') window.__tinyworldShaderFXTick(t, dt);
     repaintProfileEnd('tick.effects', tickStart);
 
     tickStart = repaintProfileBegin();

--- a/engine/world/35-tool-palette.js
+++ b/engine/world/35-tool-palette.js
@@ -14,7 +14,17 @@
     if (!palette || !grid) return;
 
     function showGroupsEnabled() {
+      // Never ungroup the toolbar on phones/small screens — the floating
+      // all-blocks palette is unusable there and eats the whole viewport.
+      if (isSmallScreenForGroups()) return true;
       try { return localStorage.getItem(SHOW_KEY) !== '0'; } catch (_) { return true; }
+    }
+
+    function isSmallScreenForGroups() {
+      try {
+        if (window.matchMedia && window.matchMedia('(max-width: 700px)').matches) return true;
+      } catch (_) {}
+      return (window.innerWidth || 0) <= 700;
     }
 
     function buildPalette() {
@@ -71,7 +81,14 @@
     function apply() {
       const show = showGroupsEnabled();
       document.body.classList.toggle('hide-groups', !show);
-      if (checkbox) checkbox.checked = show;
+      if (checkbox) {
+        checkbox.checked = show;
+        // The toggle is forced on (and disabled) while on a small screen.
+        const forced = isSmallScreenForGroups();
+        checkbox.disabled = forced;
+        const row = checkbox.closest('label, .gen-check, .render-row');
+        if (row) row.title = forced ? 'Always on for small screens' : '';
+      }
       if (show) {
         palette.hidden = true;
       } else {
@@ -129,6 +146,14 @@
     window.rebuildToolPaletteIfActive = function () {
       if (!showGroupsEnabled() && palette && !palette.hidden) buildPalette();
     };
+
+    // Re-apply when crossing the small-screen breakpoint (rotate / resize) so
+    // the toolbar regroups on the way down and restores the user's choice up.
+    let _wasSmallGroups = isSmallScreenForGroups();
+    window.addEventListener('resize', () => {
+      const small = isSmallScreenForGroups();
+      if (small !== _wasSmallGroups) { _wasSmallGroups = small; apply(); }
+    });
 
     apply();
   })();

--- a/engine/world/35-tool-palette.js
+++ b/engine/world/35-tool-palette.js
@@ -83,11 +83,9 @@
       document.body.classList.toggle('hide-groups', !show);
       if (checkbox) {
         checkbox.checked = show;
-        // The toggle is forced on (and disabled) while on a small screen.
-        const forced = isSmallScreenForGroups();
-        checkbox.disabled = forced;
-        const row = checkbox.closest('label, .gen-check, .render-row');
-        if (row) row.title = forced ? 'Always on for small screens' : '';
+        // Forced on (and disabled) on small screens, where the floating
+        // all-blocks palette is unusable.
+        checkbox.disabled = isSmallScreenForGroups();
       }
       if (show) {
         palette.hidden = true;

--- a/engine/world/45-shader-fx.js
+++ b/engine/world/45-shader-fx.js
@@ -1,0 +1,445 @@
+  // -------- shader FX library --------
+  // A self-contained, reusable GLSL effects library inspired by
+  // lettier/3d-game-shaders-for-beginners (lighting, fog, normal mapping,
+  // posterization, dithering, outlining) adapted to TinyWorld's stylized
+  // low-poly look.
+  //
+  // Exposes window.TinyShaderFX with material factories for flowing water,
+  // waterfalls, foam, smoke, and explosions, plus a procedural damage / wear
+  // overlay that patches any Lambert/Standard material via onBeforeCompile.
+  //
+  // Design notes:
+  //  - Everything is procedural (hash noise / fbm) so there are no texture
+  //    fetches or extra render targets — the effects stay cheap and ship with
+  //    zero asset weight.
+  //  - Animated materials expose a `uTime` uniform. They self-register with the
+  //    frame ticker (window.__tinyworldShaderFXTick), which the animation loop
+  //    calls once per frame, so callers never have to wire per-material clocks.
+  //  - Wrapped in an IIFE with a 4-space body so its locals never collide with
+  //    the shared engine/world global scope (and dodge the duplicate-decl guard).
+  (function () {
+    if (typeof THREE === 'undefined') return;
+
+    // ---- shared GLSL building blocks (reused across every factory) ----
+    // value-noise + fbm + a Fresnel term + a posterize helper. These map
+    // directly onto the "lighting", "fog", "normal mapping" and "posterization"
+    // chapters of the reference and are deliberately self-contained so a single
+    // string prepend gives any ShaderMaterial the full toolkit.
+    const GLSL_NOISE = `
+      float fxHash(vec2 p){ return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123); }
+      float fxNoise(vec2 p){
+        vec2 i = floor(p); vec2 f = fract(p);
+        vec2 u = f*f*(3.0-2.0*f);
+        return mix(mix(fxHash(i), fxHash(i+vec2(1.0,0.0)), u.x),
+                   mix(fxHash(i+vec2(0.0,1.0)), fxHash(i+vec2(1.0,1.0)), u.x), u.y);
+      }
+      float fxFbm(vec2 p){
+        float v = 0.0, a = 0.5;
+        for (int i = 0; i < 5; i++){ v += a * fxNoise(p); p *= 2.02; a *= 0.5; }
+        return v;
+      }
+      float fxFresnel(vec3 n, vec3 v, float power){
+        return pow(1.0 - clamp(dot(n, v), 0.0, 1.0), power);
+      }
+      vec3 fxPosterize(vec3 c, float levels){
+        return levels > 0.5 ? floor(c * levels) / levels : c;
+      }
+    `;
+
+    const tracked = new Set();
+
+    // Register a material so the frame ticker advances its uTime uniform.
+    function track(mat) {
+      if (mat && mat.uniforms && mat.uniforms.uTime) tracked.add(mat);
+      return mat;
+    }
+
+    // Called once per frame by the animation loop. Advances every tracked
+    // material's clock and prunes disposed materials.
+    function tick(t /* seconds */, dt) {
+      for (const mat of tracked) {
+        if (!mat || mat.userData.__fxDisposed) { tracked.delete(mat); continue; }
+        if (mat.uniforms && mat.uniforms.uTime) mat.uniforms.uTime.value = t;
+      }
+    }
+
+    function colorUniform(value, fallback) {
+      return { value: new THREE.Color(value != null ? value : fallback) };
+    }
+
+    // ---- 1. Flowing water / river surface ----------------------------------
+    // Stylized scrolling water for flat planes (rivers, ponds, canals). Two
+    // noise layers flow along `flow` and its perpendicular, a Blinn-Phong glint
+    // rides the crests, and a fresnel term mixes in a sky tint. Posterized to
+    // sit happily next to the cel-shaded terrain.
+    function makeWaterFlowMaterial(opts) {
+      opts = opts || {};
+      const mat = new THREE.ShaderMaterial({
+        transparent: true,
+        depthWrite: opts.depthWrite !== undefined ? opts.depthWrite : false,
+        side: THREE.DoubleSide,
+        uniforms: {
+          uTime:       { value: 0 },
+          uShallow:    colorUniform(opts.shallow, 0x4ea68a),
+          uDeep:       colorUniform(opts.deep, 0x143a46),
+          uSky:        colorUniform(opts.sky, 0xbfe4ff),
+          uFoam:       colorUniform(opts.foam, 0xeaf7ff),
+          uSunDir:     { value: (opts.sunDir || new THREE.Vector3(0.5, 0.8, 0.3)).clone().normalize() },
+          uFlow:       { value: opts.flow || new THREE.Vector2(1.0, 0.25) },
+          uScale:      { value: opts.scale != null ? opts.scale : 0.9 },
+          uSpeed:      { value: opts.speed != null ? opts.speed : 0.6 },
+          uOpacity:    { value: opts.opacity != null ? opts.opacity : 0.9 },
+          uPosterize:  { value: opts.posterize != null ? opts.posterize : 10.0 },
+        },
+        vertexShader: `
+          varying vec3 vWorld;
+          void main(){
+            vec4 wp = modelMatrix * vec4(position, 1.0);
+            vWorld = wp.xyz;
+            gl_Position = projectionMatrix * viewMatrix * wp;
+          }
+        `,
+        fragmentShader: GLSL_NOISE + `
+          uniform float uTime; uniform vec3 uShallow; uniform vec3 uDeep; uniform vec3 uSky;
+          uniform vec3 uFoam; uniform vec3 uSunDir; uniform vec2 uFlow; uniform float uScale;
+          uniform float uSpeed; uniform float uOpacity; uniform float uPosterize;
+          varying vec3 vWorld; varying vec2 vUv;
+          void main(){
+            vec2 fl = uFlow;
+            vec2 base = vWorld.xz * (0.06 * uScale);
+            float ts = uTime * uSpeed;
+            vec2 uv1 = base + fl * (ts * 0.08);
+            vec2 uv2 = base * 2.3 + vec2(-fl.y, fl.x) * (ts * 0.11);
+            float h0 = fxNoise(uv1) * 0.62 + fxNoise(uv2) * 0.38;
+            float e = 0.5;
+            float hX = fxNoise(uv1 + vec2(e,0.0)) * 0.62 + fxNoise(uv2 + vec2(e,0.0)) * 0.38;
+            float hZ = fxNoise(uv1 + vec2(0.0,e)) * 0.62 + fxNoise(uv2 + vec2(0.0,e)) * 0.38;
+            vec3 n = normalize(vec3(-(hX-h0)*1.1, 1.0, -(hZ-h0)*1.1));
+            vec3 v = normalize(cameraPosition - vWorld);
+            vec3 hvec = normalize(uSunDir + v);
+            float glint = pow(max(dot(n, hvec), 0.0), 90.0);
+            float fres = fxFresnel(n, v, 3.0);
+            vec3 col = mix(uDeep, uShallow, h0 * 0.6 + 0.2);
+            col = mix(col, uSky, clamp(0.12 + fres * 0.5, 0.0, 0.85));
+            col += vec3(1.0,0.98,0.92) * glint * 0.6;
+            float foam = smoothstep(0.7, 0.95, h0) + smoothstep(0.92, 1.0, fxNoise(base * 6.0 + fl * ts));
+            col = mix(col, uFoam, clamp(foam, 0.0, 0.7));
+            col = fxPosterize(col, uPosterize);
+            gl_FragColor = vec4(col, uOpacity);
+            #include <encodings_fragment>
+          }
+        `,
+      });
+      mat.userData.shaderFX = 'water-flow';
+      return track(mat);
+    }
+
+    // ---- 2. Waterfall curtain ----------------------------------------------
+    // Vertical falling-water sheet: lanes of water streak downward, foam gathers
+    // at the lip and the plunge, and the whole thing fades at the edges. Apply to
+    // a vertical plane (UV.y = top..bottom).
+    function makeWaterfallMaterial(opts) {
+      opts = opts || {};
+      const mat = new THREE.ShaderMaterial({
+        transparent: true,
+        depthWrite: opts.depthWrite !== undefined ? opts.depthWrite : true,
+        side: THREE.DoubleSide,
+        uniforms: {
+          uTime:    { value: 0 },
+          uBase:    colorUniform(opts.base, 0x28b5f0),
+          uHi:      colorUniform(opts.hi, 0x96e7ff),
+          uFoam:    colorUniform(opts.foam, 0xf4fdff),
+          uSpeed:   { value: opts.speed != null ? opts.speed : 1.0 },
+          uLanes:   { value: opts.lanes != null ? opts.lanes : 9.0 },
+          uOpacity: { value: opts.opacity != null ? opts.opacity : 0.8 },
+        },
+        vertexShader: `
+          varying vec2 vUv; varying vec3 vWorld;
+          void main(){
+            vUv = uv;
+            vec4 wp = modelMatrix * vec4(position, 1.0);
+            vWorld = wp.xyz;
+            gl_Position = projectionMatrix * viewMatrix * wp;
+          }
+        `,
+        fragmentShader: GLSL_NOISE + `
+          uniform float uTime; uniform vec3 uBase; uniform vec3 uHi; uniform vec3 uFoam;
+          uniform float uSpeed; uniform float uLanes; uniform float uOpacity;
+          varying vec2 vUv; varying vec3 vWorld;
+          void main(){
+            float seed = floor(vWorld.x * 0.61 + vWorld.z * 0.73);
+            float laneX = vUv.x * uLanes;
+            float laneId = floor(laneX);
+            float laneUv = fract(laneX);
+            float r = fxHash(vec2(laneId, seed));
+            float w = 0.3 + r * 0.42;
+            float blade = 1.0 - smoothstep(w, w + 0.1, abs(laneUv - 0.5) * 2.0);
+            // downward flow dashes
+            float flow = fract((1.0 - vUv.y) * (2.8 + r * 2.4) + uTime * uSpeed * (0.7 + r * 0.5) + r);
+            float dash = 0.7 + smoothstep(0.15, 0.0, flow) * 0.25 + smoothstep(0.9, 1.0, flow) * 0.2;
+            float foamTop = smoothstep(0.0, 0.12, vUv.y) * (1.0 - smoothstep(0.12, 0.3, vUv.y));
+            float foamBottom = smoothstep(0.82, 1.0, vUv.y) * (0.6 + fxNoise(vUv * 14.0 + uTime) * 0.5);
+            float foam = clamp(foamTop + foamBottom, 0.0, 1.0);
+            float alpha = blade * dash * uOpacity;
+            if (alpha < 0.02) discard;
+            vec3 col = mix(uBase, uHi, 0.2 + (1.0 - laneUv) * 0.25);
+            col = mix(col, uFoam, foam * 0.85);
+            gl_FragColor = vec4(col, clamp(alpha + foam * 0.25, 0.0, 1.0));
+            #include <encodings_fragment>
+          }
+        `,
+      });
+      mat.userData.shaderFX = 'waterfall';
+      return track(mat);
+    }
+
+    // ---- 3. Foam ring / shoreline -------------------------------------------
+    // Animated foam ribbon for shorelines, splash rings and wakes. Drawn on a
+    // ring/plane; foam concentrates near UV.y = 0 (the contact edge).
+    function makeFoamMaterial(opts) {
+      opts = opts || {};
+      const mat = new THREE.ShaderMaterial({
+        transparent: true,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+        uniforms: {
+          uTime:    { value: 0 },
+          uFoam:    colorUniform(opts.foam, 0xffffff),
+          uSpeed:   { value: opts.speed != null ? opts.speed : 0.8 },
+          uScale:   { value: opts.scale != null ? opts.scale : 5.0 },
+          uOpacity: { value: opts.opacity != null ? opts.opacity : 0.85 },
+        },
+        vertexShader: `
+          varying vec2 vUv;
+          void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+        `,
+        fragmentShader: GLSL_NOISE + `
+          uniform float uTime; uniform vec3 uFoam; uniform float uSpeed; uniform float uScale; uniform float uOpacity;
+          varying vec2 vUv;
+          void main(){
+            float edge = 1.0 - smoothstep(0.0, 0.85, vUv.y);
+            float bubbles = fxFbm(vUv * uScale + vec2(uTime * uSpeed, -uTime * uSpeed * 0.6));
+            float mask = smoothstep(0.45, 0.8, bubbles) * edge;
+            float a = mask * uOpacity;
+            if (a < 0.02) discard;
+            gl_FragColor = vec4(uFoam, a);
+            #include <encodings_fragment>
+          }
+        `,
+      });
+      mat.userData.shaderFX = 'foam';
+      return track(mat);
+    }
+
+    // ---- 4. Soft smoke puff -------------------------------------------------
+    // A dissolving, billowing smoke billboard. Far softer than a flat alpha
+    // sphere: fbm carves the silhouette and an `uAge` (0..1) uniform thins and
+    // greys it as the particle dies. Use on a camera-facing plane.
+    function makeSmokeMaterial(opts) {
+      opts = opts || {};
+      const mat = new THREE.ShaderMaterial({
+        transparent: true,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+        uniforms: {
+          uTime:    { value: 0 },
+          uAge:     { value: 0 },
+          uColor:   colorUniform(opts.color, 0xd4cfc2),
+          uTint:    colorUniform(opts.tint, 0x6b6358),
+          uOpacity: { value: opts.opacity != null ? opts.opacity : 0.7 },
+        },
+        vertexShader: `
+          varying vec2 vUv;
+          void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+        `,
+        fragmentShader: GLSL_NOISE + `
+          uniform float uTime; uniform float uAge; uniform vec3 uColor; uniform vec3 uTint; uniform float uOpacity;
+          varying vec2 vUv;
+          void main(){
+            vec2 p = vUv - 0.5;
+            float r = length(p) * 2.0;
+            float billow = fxFbm(vUv * 3.0 + vec2(0.0, -uTime * 0.4) + uAge * 2.0);
+            float disk = 1.0 - smoothstep(0.2, 1.0, r + billow * 0.35 - 0.2);
+            float a = disk * uOpacity * (1.0 - uAge);
+            if (a < 0.01) discard;
+            vec3 col = mix(uColor, uTint, clamp(uAge + billow * 0.3, 0.0, 1.0));
+            gl_FragColor = vec4(col, a);
+            #include <encodings_fragment>
+          }
+        `,
+      });
+      mat.userData.shaderFX = 'smoke';
+      return track(mat);
+    }
+
+    // ---- 5. Explosion fireball ----------------------------------------------
+    // Expanding blast: a hot white/yellow core ramps through orange/red and
+    // collapses into dark smoke as `uProgress` (0..1) advances. fbm gives the
+    // boiling fireball edge. Drive uProgress from your own animation and scale
+    // the mesh up over the same window. Returns the material; advance uProgress
+    // yourself (uTime is auto-ticked for the boil).
+    function makeExplosionMaterial(opts) {
+      opts = opts || {};
+      const mat = new THREE.ShaderMaterial({
+        transparent: true,
+        depthWrite: false,
+        blending: opts.additive === false ? THREE.NormalBlending : THREE.AdditiveBlending,
+        side: THREE.DoubleSide,
+        uniforms: {
+          uTime:     { value: 0 },
+          uProgress: { value: 0 },
+          uCore:     colorUniform(opts.core, 0xfff3c4),
+          uMid:      colorUniform(opts.mid, 0xff7b29),
+          uEdge:     colorUniform(opts.edge, 0x8a1d05),
+          uSmoke:    colorUniform(opts.smoke, 0x2b2622),
+        },
+        vertexShader: `
+          varying vec2 vUv;
+          void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+        `,
+        fragmentShader: GLSL_NOISE + `
+          uniform float uTime; uniform float uProgress;
+          uniform vec3 uCore; uniform vec3 uMid; uniform vec3 uEdge; uniform vec3 uSmoke;
+          varying vec2 vUv;
+          void main(){
+            vec2 p = vUv - 0.5;
+            float r = length(p) * 2.0;
+            float boil = fxFbm(vUv * 4.0 + vec2(uTime * 0.8, -uTime * 0.5));
+            float fire = r + boil * 0.5 - 0.25;
+            // expanding shell: core shrinks as it cools, smoke takes over
+            float core = 1.0 - smoothstep(0.0, 0.45 * (1.0 - uProgress * 0.6), fire);
+            float body = 1.0 - smoothstep(0.2, 1.0, fire);
+            vec3 col = mix(uEdge, uMid, smoothstep(0.0, 0.6, core));
+            col = mix(col, uCore, smoothstep(0.55, 1.0, core));
+            // late phase: fade the fire to drifting smoke
+            float smokeMix = smoothstep(0.55, 1.0, uProgress);
+            col = mix(col, uSmoke, smokeMix * (1.0 - core));
+            float a = body * (1.0 - smoothstep(0.85, 1.0, uProgress)) * (0.35 + boil * 0.65);
+            if (a < 0.01) discard;
+            gl_FragColor = vec4(col, a);
+            #include <encodings_fragment>
+          }
+        `,
+      });
+      mat.userData.shaderFX = 'explosion';
+      return track(mat);
+    }
+
+    // ---- 6. Procedural damage / wear-and-tear overlay -----------------------
+    // Patches any Lambert/Standard/Phong/Basic material so it picks up grime,
+    // edge scuffs and cracks driven by world position — no UVs or textures
+    // required. Strength is `amount` (0 = pristine, 1 = ruined). Returns the
+    // same material with a `setWear(amount)` helper attached.
+    function applyWear(material, opts) {
+      if (!material) return material;
+      opts = opts || {};
+      const u = {
+        uWearAmount: { value: opts.amount != null ? opts.amount : 0.5 },
+        uWearScale:  { value: opts.scale != null ? opts.scale : 0.7 },
+        uWearColor:  colorUniform(opts.color, 0x241c12),
+        uWearSeed:   { value: opts.seed != null ? opts.seed : Math.random() * 100.0 },
+      };
+      material.userData.wearUniforms = u;
+      const prevHook = material.onBeforeCompile;
+      material.onBeforeCompile = (shader) => {
+        if (typeof prevHook === 'function') prevHook(shader);
+        shader.uniforms.uWearAmount = u.uWearAmount;
+        shader.uniforms.uWearScale = u.uWearScale;
+        shader.uniforms.uWearColor = u.uWearColor;
+        shader.uniforms.uWearSeed = u.uWearSeed;
+        // Capture world position from `transformed` (always present after
+        // begin_vertex) so we don't depend on env/shadow includes being active.
+        shader.vertexShader = 'varying vec3 vWearWorld;\n' + shader.vertexShader.replace(
+          '#include <project_vertex>',
+          '#include <project_vertex>\n  vWearWorld = (modelMatrix * vec4(transformed, 1.0)).xyz;'
+        );
+        // Anchor on dithering_fragment — the last include in every stock
+        // material template, so the patch always lands regardless of fog/env.
+        shader.fragmentShader = (
+          'varying vec3 vWearWorld;\n' +
+          'uniform float uWearAmount; uniform float uWearScale; uniform vec3 uWearColor; uniform float uWearSeed;\n' +
+          GLSL_NOISE +
+          shader.fragmentShader.replace(
+            '#include <dithering_fragment>',
+            `{
+              vec3 wp = vWearWorld * uWearScale + uWearSeed;
+              float grime = fxFbm(wp.xz * 0.5);
+              float crack = 1.0 - smoothstep(0.0, 0.05, abs(fxFbm(wp.xz + 4.7) - 0.5));
+              float scuff = smoothstep(0.58, 0.86, fxNoise(wp.xz * 3.0 + 9.1));
+              float wear = clamp((grime * 0.55 + crack * 0.8 + scuff * 0.45) * uWearAmount, 0.0, 1.0);
+              gl_FragColor.rgb = mix(gl_FragColor.rgb, gl_FragColor.rgb * uWearColor, wear * 0.7);
+              gl_FragColor.rgb *= (1.0 - wear * 0.22);
+            }
+            #include <dithering_fragment>`
+          )
+        );
+      };
+      material.needsUpdate = true;
+      material.setWear = (amount) => { u.uWearAmount.value = amount; };
+      return material;
+    }
+
+    // ---- opt-in showcase ----------------------------------------------------
+    // ?shaderfx=demo (or =1) drops a small gallery of the effects near the
+    // origin so they can be eyeballed without touching default scenes.
+    function demo(targetScene) {
+      let host = targetScene;
+      try { if (!host && typeof scene !== 'undefined') host = scene; } catch (e) { host = null; }
+      if (!host) return null;
+      const group = new THREE.Group();
+      group.name = 'shaderfx-demo';
+      const place = (mesh, x, label) => { mesh.position.set(x, 6, 0); mesh.userData.fxLabel = label; group.add(mesh); };
+
+      place(new THREE.Mesh(new THREE.PlaneGeometry(8, 8).rotateX(-Math.PI / 2), makeWaterFlowMaterial()), -18, 'water');
+      place(new THREE.Mesh(new THREE.PlaneGeometry(5, 7), makeWaterfallMaterial()), -6, 'waterfall');
+      const smoke = new THREE.Mesh(new THREE.PlaneGeometry(5, 5), makeSmokeMaterial());
+      place(smoke, 6, 'smoke');
+      const boom = new THREE.Mesh(new THREE.SphereGeometry(3, 24, 16), makeExplosionMaterial());
+      place(boom, 18, 'explosion');
+      const worn = new THREE.Mesh(new THREE.BoxGeometry(4, 4, 4),
+        applyWear(new THREE.MeshLambertMaterial({ color: 0xb8b0a0 }), { amount: 0.8 }));
+      place(worn, 30, 'wear');
+
+      // loop the explosion progress so the gallery is animated
+      boom.userData.fxLoop = (t) => {
+        const p = (t * 0.4) % 1.0;
+        boom.material.uniforms.uProgress.value = p;
+        const s = 0.4 + p * 1.6;
+        boom.scale.setScalar(s);
+        smoke.material.uniforms.uAge.value = p;
+      };
+      group.userData.fxTick = (t) => { if (boom.userData.fxLoop) boom.userData.fxLoop(t); };
+      host.add(group);
+
+      const prevTick = window.__tinyworldShaderFXTick;
+      window.__tinyworldShaderFXTick = (t, dt) => {
+        if (typeof prevTick === 'function') prevTick(t, dt);
+        if (group.userData.fxTick) group.userData.fxTick(t);
+      };
+      return group;
+    }
+
+    const api = {
+      GLSL_NOISE,
+      track, tick,
+      makeWaterFlowMaterial,
+      makeWaterfallMaterial,
+      makeFoamMaterial,
+      makeSmokeMaterial,
+      makeExplosionMaterial,
+      applyWear,
+      demo,
+      _tracked: tracked,
+    };
+
+    window.TinyShaderFX = api;
+    window.__tinyworldShaderFXTick = tick;
+
+    try {
+      const params = new URLSearchParams(location.search);
+      const flag = params.get('shaderfx');
+      if (flag === 'demo' || flag === '1') {
+        window.addEventListener('load', () => { setTimeout(() => { try { demo(); } catch (e) { /* scene not ready */ } }, 800); });
+      }
+    } catch (e) { /* no location */ }
+  })();

--- a/engine/world/45-shader-fx.js
+++ b/engine/world/45-shader-fx.js
@@ -49,8 +49,18 @@
     const tracked = new Set();
 
     // Register a material so the frame ticker advances its uTime uniform.
+    // Wraps dispose() once so the tracker auto-prunes and can never leak.
     function track(mat) {
-      if (mat && mat.uniforms && mat.uniforms.uTime) tracked.add(mat);
+      if (mat && mat.uniforms && mat.uniforms.uTime && !mat.userData.__fxTracked) {
+        mat.userData.__fxTracked = true;
+        tracked.add(mat);
+        const baseDispose = mat.dispose.bind(mat);
+        mat.dispose = function () {
+          mat.userData.__fxDisposed = true;
+          tracked.delete(mat);
+          baseDispose();
+        };
+      }
       return mat;
     }
 
@@ -333,6 +343,18 @@
     function applyWear(material, opts) {
       if (!material) return material;
       opts = opts || {};
+      material.userData = material.userData || {};
+      // Idempotent: a repeat call just updates the existing uniforms instead of
+      // chaining another onBeforeCompile (which would patch the shader twice and
+      // break compilation with duplicate varyings/uniforms).
+      if (material.userData.wearUniforms) {
+        const w = material.userData.wearUniforms;
+        if (opts.amount != null) w.uWearAmount.value = opts.amount;
+        if (opts.scale != null) w.uWearScale.value = opts.scale;
+        if (opts.color != null) w.uWearColor.value.set(opts.color);
+        if (opts.seed != null) w.uWearSeed.value = opts.seed;
+        return material;
+      }
       const u = {
         uWearAmount: { value: opts.amount != null ? opts.amount : 0.5 },
         uWearScale:  { value: opts.scale != null ? opts.scale : 0.7 },

--- a/styles/tiny-world.css
+++ b/styles/tiny-world.css
@@ -5829,13 +5829,18 @@
   }
   .settings-card {
     width: min(780px, calc(100vw - 32px));
-    min-height: 500px;
+    /* min never exceeds the viewport, so a short window can't push content
+       off-screen; the panels scroll internally instead. */
+    min-height: min(500px, calc(100vh - 100px));
+    max-height: calc(100vh - 100px);
   }
   .settings-layout {
     display: grid;
     grid-template-columns: 150px 1fr;
     gap: 14px;
-    min-height: 380px;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
   }
   .settings-searchbar {
     display: grid;
@@ -5874,6 +5879,8 @@
     gap: 6px;
     padding-right: 10px;
     border-right: 1px solid var(--line);
+    min-height: 0;
+    overflow-y: auto;
   }
   .settings-tab {
     border: 1px solid transparent;
@@ -5944,6 +5951,9 @@
   .settings-tab-count[hidden] { display: none; }
   .settings-panels {
     min-width: 0;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 4px;
   }
   .settings-panel {
     display: none;
@@ -7337,7 +7347,19 @@
       max-height: calc(100vh - 464px);
     }
     .stamp-model-range { grid-template-columns: 58px minmax(0, 1fr) 42px; }
-    .settings-layout { grid-template-columns: 1fr; }
+    /* Settings on phones: claim almost the whole screen and scroll the panels
+       internally so every control (incl. the water toggle) is reachable. */
+    #render-modal { padding: 12px; }
+    .settings-card {
+      min-height: 0;
+      max-height: calc(100vh - 24px);
+      max-height: calc(100dvh - 24px);
+    }
+    .settings-layout {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto minmax(0, 1fr);
+      min-height: 0;
+    }
     .settings-searchbar {
       grid-template-columns: 1fr;
       gap: 4px;
@@ -7357,6 +7379,33 @@
     }
     .settings-tab-copy { white-space: nowrap; }
     .settings-tab-hint { display: none; }
+    /* Compact, icon-only main toolbar on phones: drop the group labels and
+       chevrons and shrink the buttons so the bar takes far less screen. */
+    .toolbar {
+      bottom: 12px;
+      padding: 0 6px;
+      gap: 1px;
+      min-height: 46px;
+      border-radius: 14px;
+    }
+    .tool-group-btn {
+      width: 42px;
+      height: 40px;
+      padding: 2px;
+      gap: 0;
+    }
+    .tool-group-btn > span:not(.chev):not(.group-icon),
+    .tool-group-btn .chev {
+      display: none;
+    }
+    .toolbar .tool-group-btn .group-icon,
+    .toolbar .tool .tool-icon {
+      width: 26px;
+      height: 26px;
+    }
+    .toolbar .tool:not(.flyout-tool) {
+      padding: 2px 6px;
+    }
   }
   .welcome-card {
     width: min(600px, calc(100vw - 32px));

--- a/tiny-world-builder.html
+++ b/tiny-world-builder.html
@@ -1228,6 +1228,10 @@
               <input type="checkbox" id="render-planes-enabled" />
               <span>Planes <em class="gen-hint">ambient flyovers and towed banners</em></span>
             </label>
+            <label class="gen-check" data-settings-keywords="water shader enhanced reflections ripples glint specular foam shimmer ocean river lake sea waves">
+              <input type="checkbox" id="render-enhanced-water" />
+              <span>Enhanced water <em class="gen-hint">animated reflections, sun glints &amp; foam on water</em></span>
+            </label>
             <label class="gen-check" data-settings-keywords="distant worlds mini islands background dressing decoration performance">
               <input type="checkbox" id="render-distant-worlds" />
               <span>Distant worlds <em class="gen-hint">background mini-islands</em></span>

--- a/tiny-world-builder.html
+++ b/tiny-world-builder.html
@@ -1630,6 +1630,7 @@
   <script src="engine/world/42-account-wallet-players.js"></script>
   <script src="engine/world/43-drag-drop-import.js"></script>
   <script src="engine/world/44-sub-object-edit.js"></script>
+  <script src="engine/world/45-shader-fx.js"></script>
   <script src="engine/world/99-late-boot.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

A pass on the GPU-FX layer, working through the techniques in
[lettier/3d-game-shaders-for-beginners](https://github.com/lettier/3d-game-shaders-for-beginners)
and adapting them to Tiny World's stylized low-poly look. Everything stays **fully
procedural** (hash-noise / fbm) — no texture loads, no extra render targets, no new
post passes — so the single-pass render contract is preserved and there's zero asset weight.

## ✨ Enhanced water — visible in every environment, optional in Settings

The headline change. Water is upgraded **wherever it appears**, gated by a new
**Settings → Environment → "Enhanced water"** toggle (default on, persisted as
`tinyworld:render:enhancedWater`):

- **Voxel water tiles** — the water you actually see on the default home island and in
  generated worlds. Enhanced at the single `onBeforeCompile` chokepoint every water
  material flows through (`applyFlowingWaterUVs`, `04-textures.js`). Stays a
  `MeshLambertMaterial` (colour shades / flow direction / wear slider keep working) and
  adds an animated ripple normal → moving light/dark bands, fresnel sky sheen,
  Blinn-Phong sun glints and foam, masked to upward-facing faces. Shared `uWaterTime`
  clock; `customProgramCacheKey` so the toggle recompiles cleanly at runtime.
- **LandscapeEngine ocean** (`engine/landscape/water.js`) — flowing 2-layer ripples,
  glint, fresnel, depth tint, foam, planet-distance parity; a `uEnhance` uniform ties it
  to the same toggle.

Toggling runs `refreshWaterShaderMaterials()` + `rebuildTerrainRender()` and updates the
live landscape `uEnhance`, so it applies immediately, in all environments.

## TinyShaderFX library (`engine/world/45-shader-fx.js` → `window.TinyShaderFX`)

A small, dependency-free, IIFE-wrapped library of reusable effects:
- `makeWaterFlowMaterial` · `makeWaterfallMaterial` · `makeFoamMaterial` ·
  `makeSmokeMaterial` · `makeExplosionMaterial`
- `applyWear(material)` — procedural **damage / wear-and-tear** (cracks/scuffs/grime) on
  any stock material via `onBeforeCompile`; `setWear()` helper.
- Shared `GLSL_NOISE` chunk (`fxHash/fxNoise/fxFbm/fxFresnel/fxPosterize`).
- Animated materials expose `uTime` and self-register with a frame ticker wired into the
  animation loop's `tick.effects` bucket. Opt-in `?shaderfx=demo` gallery.

## Mapping to the request
water · flowing · waterfalls · foam · smoke · explosions · damage · wear & tear ·
lighting — all covered, plus optimization (procedural-only, single-pass preserved,
shared frame tick, water ~cost-neutral).

## Docs
- `docs/SHADERS.md` — map of every shader system + usage.
- `.codex/skills/tinyworld-shader-fx/SKILL.md` — repo-local skill.

## Validation
- `npm run check`, `npm run smoke`, i18n all pass; all edited JS passes `node --check`;
  custom GLSL balance + uniform-declaration sweeps clean.
- The lone `npm test` unit failure (`tests/db-schema-errors` → missing `postgres`
  package) is **pre-existing and unrelated** (fails identically with these changes stashed).
- No browser in the sandbox, so shaders were validated statically — worth an eyeball on the
  home-island water (toggle it in Settings → Environment) and the deploy preview before merge.

https://claude.ai/code/session_01L9Gni67JpXxaT3d8UCFWiJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced water rendering toggle with richer animations, foam, glint and back-glow
  * New animated shader FX library for water, waterfalls, foam, smoke and explosions
  * Water-edge foam lip and improved shoreline visuals
  * UI control to enable/disable enhanced water

* **Mobile / UX**
  * Settings panel and toolbar optimized for phones (height-capped, internal scrolling, compact icon-only toolbar; grouped mode forced)

* **Documentation**
  * Added comprehensive shader system and responsive UI guidance

* **Accessibility**
  * Toolbar group buttons include ARIA labels for icon-only layouts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->