### PR TITLE
Sandbox terrain digging — adapt UnrealSandboxTerrain to the tile boards

### DIFF
--- a/.codex/skills/tinyworld-sandbox-terrain/SKILL.md
+++ b/.codex/skills/tinyworld-sandbox-terrain/SKILL.md
@@ -44,15 +44,39 @@ walls change; ordinary cliffs stay flat. Bands come from `strataBandsForTerrain`
 and reuse existing `M.*` materials — no new textures, no extra render passes.
 (The unused instanced-panel `addVoxelTerrainRiser` is strata-aware too, for parity.)
 
-## Input
+## Two elevation systems
 
-- **Sculpt tool** (id `sculpt`, shortcut `K`, terrain group) with variants
-  `Lower` (default = dig) / `Raise`. Click steps one level; drag carves/builds a
-  run (one step per visited cell). It is drag-paintable (`isDrawablePlacementTool`)
-  and has no ghost preview (returns null from `buildGhostMesh`).
-- **`R` / `F`** and the command palette call `sculptCellElevation(x, z, up)`:
-  raising fills a pit (`dig → 0`) before stacking `terrainFloors`; lowering drops
-  to the base then digs below it. One continuous control from deep pit to tall column.
+1. **Whole-tile** (`terrainFloors` + `dig`): coarse, the whole slab moves. Driven
+   by **`R`/`F`** and the command palette via `sculptCellElevation(x, z, up)`
+   (raising fills a pit then stacks floors; lowering drops to base then digs).
+2. **Per-tile voxel sculpt** (`voxels`): the **Sculpt tool** edits an N×N sub-grid
+   so the surface becomes a blocky voxel *mesh* instead of a flat tower. This is
+   what the user means by "should be voxels … per tile."
+
+## Per-tile voxel sculpt (`voxels`)
+
+- Field: `voxels = { n, h:[n*n] }` — `n` is the sub-grid resolution (the **Voxel
+  Resolution** setting: 4/6/8/10, mixed→8 via `sculptResolutionNumeric()`), `h` is
+  row-major signed integer height offsets in cubic-voxel steps (`vstep = TILE/n`),
+  clamped to ±`MAX_VOX`. `null`/all-zero = flat (`normalizeVoxels` enforces this).
+- Render: `addVoxelSculptTop` (parallel to `addVoxelTerrainTop`, called from
+  `makeTile` only when `cellSculptData` is non-null, gated on voxel mode). It emits
+  per-sub-cell top caps at `rise + h*vstep` plus strata step walls. Walls: the
+  taller of two in-tile neighbours draws the wall down to the lower; at a tile edge
+  it samples the **adjacent tile's** matching edge sub-cell (`neighborEdgeOffset`)
+  so two equally-sculpted tiles meet seamlessly, and reconciles to the base plane
+  against a flat/unsculpted neighbour (no see-through). `setCell` re-renders the 4
+  neighbours on `voxelsChanged` so those edge walls stay in sync.
+- Input: the **Sculpt tool** (id `sculpt`, `K`, Lower/Raise variants) routes to
+  `sculptVoxelBrush(tileX, tileZ, localX, localZ, up)`. It maps the cursor
+  (`currentHover.localX/localZ`, = hit point − tile centre, ±0.5) to a sub-cell,
+  edits a small radius in *global* sub-cell space (spills across tile borders →
+  continuous craters), and commits each touched tile. Strokes paint one step per
+  sub-cell: `drawKeyForHit` returns a `x,z:vI,J` key and `applyDrawToolToHit`
+  applies directly at the live cursor for sculpt (the tile-coord interpolation
+  would skip within-tile voxels).
+- Object/hover/picking Y still use the tile base (`tileLevelForCell`); per-sub-cell
+  surface height is visual only in v1.
 
 ## Persistence (single chokepoint each way)
 

--- a/.codex/skills/tinyworld-sandbox-terrain/SKILL.md
+++ b/.codex/skills/tinyworld-sandbox-terrain/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: tinyworld-sandbox-terrain
+description: Use when changing Tiny World Builder terrain excavation / sandbox digging — the per-cell `dig` field, signed render elevation, pit walls, geological strata, the Sculpt tool, or R/F raise-dig. Adapts the UnrealSandboxTerrain "add/remove material with layers by depth" mechanic to the tile grid.
+---
+
+# Tiny World Sandbox Terrain (dig / sculpt)
+
+The board stays a **grid of tiles**. The only new capability is that a cell can be
+carved *below* the base plane, exposing geological strata on the resulting pit
+walls — the [UnrealSandboxTerrain](https://github.com/bw2012/UnrealSandboxTerrain)
+"remove material, layers by depth" idea, adapted additively.
+
+## Data model
+
+- New optional per-cell field **`dig`** (0..`MAX_DIG`, default 0). 0 = undug.
+- `terrainFloors` (1..8) still raises the ground (hills). `dig` lowers it.
+- The **signed render level** is the single hook:
+  `tileLevelForCell(cell) = terrainLevelForCell(cell) - cellDigDepth(cell)`
+  (`engine/world/05-tile-factory.js`). It can be `< 1` only when `dig > 0`.
+- `terrainRiseForLevel(level)` is **signed** — it returns a negative rise for
+  `level < 1`. Do NOT re-add a `Math.max(0, …)` clamp; every undug cell still
+  passes `level >= 1`, so the result stays `>= 0` and the classic look is intact.
+
+## Why it doesn't break undug worlds
+
+`tileLevelForCell` feeds both a cell's own geometry and `getLevelNeighbors`
+side-culling, so digging just makes a cell read as "lower" everywhere. In
+`makeTile` (`engine/world/06-history-object-factories.js`) the riser bottom is
+`cliffBottomY = min(-DIRT_H, topOfRiser - DIRT_H, deepest lower-neighbour floor)`.
+For an undug grid every neighbour is equal-or-shallower, so it resolves to exactly
+`-DIRT_H` and the riser geometry is **byte-identical** to before (verified
+numerically: flat grass / hills / dirt all match the old `DIRT_H + rise` formula).
+
+A higher neighbour automatically draws its cliff **down to the pit floor** (no gap),
+because a lower (dug) neighbour fails the `hideSide` cull. Two equal-depth dug
+cells hide their shared wall, so a wide pit floor reads as one surface.
+
+## Strata walls
+
+`addVoxelTerrainRiserBacking(…, bottomY, strata)` stacks thin per-band boxes
+(soil → dirt → clay → rock → bedrock by depth below y=0) when `strata` is true.
+`strataWall` is enabled for a cell that is dug OR borders a dug cell, so only pit
+walls change; ordinary cliffs stay flat. Bands come from `strataBandsForTerrain`
+and reuse existing `M.*` materials — no new textures, no extra render passes.
+(The unused instanced-panel `addVoxelTerrainRiser` is strata-aware too, for parity.)
+
+## Input
+
+- **Sculpt tool** (id `sculpt`, shortcut `K`, terrain group) with variants
+  `Lower` (default = dig) / `Raise`. Click steps one level; drag carves/builds a
+  run (one step per visited cell). It is drag-paintable (`isDrawablePlacementTool`)
+  and has no ghost preview (returns null from `buildGhostMesh`).
+- **`R` / `F`** and the command palette call `sculptCellElevation(x, z, up)`:
+  raising fills a pit (`dig → 0`) before stacking `terrainFloors`; lowering drops
+  to the base then digs below it. One continuous control from deep pit to tall column.
+
+## Persistence (single chokepoint each way)
+
+- Write: `serializeCell` (`05-tile-factory.js`) appends `dig` as the last optional
+  tuple slot **and** materialises the earlier optional slots when `dig > 0` so the
+  positional parser stays stable. A cell with only `dig > 0` is no longer "default".
+- Read: the `applyState` parser (`29-persistence-api.js`) reads `dig` from tuple
+  index 12 / object `.dig`, clamps it, and threads it through both apply paths and
+  `writeWorldIntentCell`. Undo/redo + autosave + export all flow through these two.
+- Schema: `dig` is an optional `0..6` integer on the **object** cell form in
+  `world.schema.json` AND the embedded copy in `25-animation-loop-schema.js` — keep
+  them byte-identical (the `check.js` parity guard compares the parsed JSON).
+
+## Gotchas / follow-ups
+
+- LandscapeEngine mode doesn't render discrete tiles, so `dig` has no visual effect
+  there (data is still preserved).
+- The pit **floor** currently keeps the cell's own terrain material; making it read
+  as exposed earth/stratum is a deliberate v1 follow-up (would need a top-face
+  material override in `addVoxelTerrainTop` without disturbing path/water adjacency).
+- If you touch the riser call sites, the `check.js` guard expects
+  `addVoxelTerrainRiserBacking(g, terrain, riserSize, riserHeight,` — update it
+  together with the call, and never switch the wall to thousands of side panels.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,14 +69,16 @@ Guidance for AI coding agents working in this repo. Read this before touching
 Two parallel data structures:
 
 ```
-world[x][z]                  // intent  — { terrain, terrainFloors, dig, kind, floors }
+world[x][z]                  // intent  — { terrain, terrainFloors, dig, voxels, kind, floors }
 cellMeshes['x,z']            // render — { tile: Group, object: Group|null }
 ```
 
-`terrainFloors` (1..8) raises the ground; `dig` (0..`MAX_DIG`) carves it BELOW the
-base plane (sandbox excavation). The signed render level a tile uses is
+`terrainFloors` (1..8) raises the whole tile; `dig` (0..`MAX_DIG`) carves it BELOW
+the base plane. The signed render level a tile uses is
 `tileLevelForCell(cell) = terrainFloors - dig`, which feeds riser side-culling and
-every "sits on the surface" Y lookup. Dug pit walls expose geological strata. See
+every "sits on the surface" Y lookup. `voxels = { n, h[] }` is a per-tile N×N
+sculpt heightmap (the Sculpt tool) rendered by `addVoxelSculptTop` as a blocky
+voxel mesh. Dug walls and sculpt steps expose geological strata. See
 `.codex/skills/tinyworld-sandbox-terrain`.
 
 Mutate via **`setCell(x, z, opts)`**. It:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,15 @@ Guidance for AI coding agents working in this repo. Read this before touching
 Two parallel data structures:
 
 ```
-world[x][z]                  // intent  — { terrain, terrainFloors, kind, floors }
+world[x][z]                  // intent  — { terrain, terrainFloors, dig, kind, floors }
 cellMeshes['x,z']            // render — { tile: Group, object: Group|null }
 ```
+
+`terrainFloors` (1..8) raises the ground; `dig` (0..`MAX_DIG`) carves it BELOW the
+base plane (sandbox excavation). The signed render level a tile uses is
+`tileLevelForCell(cell) = terrainFloors - dig`, which feeds riser side-culling and
+every "sits on the surface" Y lookup. Dug pit walls expose geological strata. See
+`.codex/skills/tinyworld-sandbox-terrain`.
 
 Mutate via **`setCell(x, z, opts)`**. It:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ netlify deploy --build
 | Orbit             | drag                                   |
 | Zoom              | scroll wheel                           |
 | Stack/enhance item | click the same object tool on an existing object (max 8) |
-| Raise/lower terrain | `R` / `F` over the hovered cell      |
+| Sculpt terrain    | `Sculpt` tool (`K`) — click/drag to dig a pit or raise a mound |
+| Raise/dig terrain | `R` / `F` over the hovered cell (lowers to base, then **digs** below, exposing strata) |
 | Switch tool       | `1`–`9`, then letter shortcuts shown in the toolbar |
 | Back to Select    | `Esc` (disarms any build/paint/erase tool)          |
 | Toggle camera     | `P` or `I` (isometric ⇄ soft ⇄ perspective) |
@@ -109,6 +110,7 @@ window.__getVehicleRuntimeSnapshot()
 ## Tools
 
 `Grass` · `Path` · `Dirt` · `Water` · `Stone` · `Lava` · `Sand` · `Snow` ·
+`Sculpt` (dig/raise) ·
 `House` · `Tree` · `Fence` · `Rock` · `Bridge` · `Crop` · `Corn` · `Wheat` ·
 `Pumpkin` · `Carrot` · `Sunflower` · `Tuft` · `Flower` · `Bush` · `Cow` ·
 `Sheep` · `Erase`.
@@ -126,7 +128,10 @@ outcrops.
 Single `<script>` block, currently ~29k lines of vanilla JS, organised by section
 comments (`// -------- xyz --------`). The model is split cleanly:
 
-- **`world[x][z]`** — intent: `{ terrain, kind, floors }` per cell.
+- **`world[x][z]`** — intent: `{ terrain, terrainFloors, dig, kind, floors }` per cell.
+  `terrainFloors` raises the ground (hills); `dig` carves it *below* the base
+  plane (sandbox excavation). A cell's signed render elevation is
+  `terrainFloors - dig`, and dug pit walls expose geological strata.
 - **`cellMeshes['x,z']`** — rendered Three.js groups for each cell.
 - **`setCell(x, z, opts)`** — single mutation entry point. Updates `world`,
   rebuilds the cell's tile/object meshes, and re-renders any neighbors that

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ netlify deploy --build
 | Orbit             | drag                                   |
 | Zoom              | scroll wheel                           |
 | Stack/enhance item | click the same object tool on an existing object (max 8) |
-| Sculpt terrain    | `Sculpt` tool (`K`) — click/drag to dig a pit or raise a mound |
-| Raise/dig terrain | `R` / `F` over the hovered cell (lowers to base, then **digs** below, exposing strata) |
+| Sculpt terrain    | `Sculpt` tool (`K`) — click/drag carves the tile's voxel sub-grid (4/6/8/10 per tile) into a shaped mesh; Lower/Raise variants |
+| Raise/dig terrain | `R` / `F` over the hovered cell — whole-tile: lowers to base, then **digs** below, exposing strata |
 | Switch tool       | `1`–`9`, then letter shortcuts shown in the toolbar |
 | Back to Select    | `Esc` (disarms any build/paint/erase tool)          |
 | Toggle camera     | `P` or `I` (isometric ⇄ soft ⇄ perspective) |
@@ -128,10 +128,12 @@ outcrops.
 Single `<script>` block, currently ~29k lines of vanilla JS, organised by section
 comments (`// -------- xyz --------`). The model is split cleanly:
 
-- **`world[x][z]`** — intent: `{ terrain, terrainFloors, dig, kind, floors }` per cell.
-  `terrainFloors` raises the ground (hills); `dig` carves it *below* the base
-  plane (sandbox excavation). A cell's signed render elevation is
-  `terrainFloors - dig`, and dug pit walls expose geological strata.
+- **`world[x][z]`** — intent: `{ terrain, terrainFloors, dig, voxels, kind, floors }` per cell.
+  `terrainFloors` raises the whole tile (hills); `dig` carves it *below* the base
+  plane (sandbox excavation, signed render elevation `terrainFloors - dig`).
+  `voxels = { n, h[] }` is the per-tile blocky sculpt heightmap (N×N voxel
+  sub-grid) the Sculpt tool edits, so a tile becomes a shaped voxel mesh rather
+  than a flat slab. Both dug walls and sculpt steps expose geological strata.
 - **`cellMeshes['x,z']`** — rendered Three.js groups for each cell.
 - **`setCell(x, z, opts)`** — single mutation entry point. Updates `world`,
   rebuilds the cell's tile/object meshes, and re-renders any neighbors that

--- a/engine/world/01-render-core.js
+++ b/engine/world/01-render-core.js
@@ -467,7 +467,7 @@
   let renderSurfaceLinkedMaterials = localStorage.getItem(RENDER_LS.surfaceLinkedMaterials) !== '0';
   let renderTerrainVoxelResolution = localStorage.getItem(RENDER_LS.terrainVoxelResolution) || 'mixed';
   let showCrowns = false;
-  if (!['mixed', '4', '6', '8', '12'].includes(renderTerrainVoxelResolution)) renderTerrainVoxelResolution = 'mixed';
+  if (!['mixed', '4', '6', '8', '10', '12'].includes(renderTerrainVoxelResolution)) renderTerrainVoxelResolution = 'mixed';
   if (!renderAutoExpand) renderVisibleSize = 0;
   function applyBackdropSettings() {
     const d = Math.max(0, Math.min(1, renderSkyBlueDepth || 0));

--- a/engine/world/05-tile-factory.js
+++ b/engine/world/05-tile-factory.js
@@ -1,7 +1,16 @@
   // -------- tile factory --------
+  function terrainStepHeight() {
+    return useLandscapeEngine ? 1.12 : 0.20;
+  }
+  // Signed vertical offset of a cell's surface from the board base plane.
+  // Levels above 1 raise the ground (hills); levels below 1 are excavated
+  // (sandbox digging) and return a negative rise so the surface drops into a
+  // pit. Undug worlds only ever pass level >= 1, so the result is >= 0 and the
+  // classic terrain look is unchanged.
   function terrainRiseForLevel(level) {
-    const step = useLandscapeEngine ? 1.12 : 0.20;
-    return Math.max(0, (Math.min(MAX_FLOORS, level || 1) - 1) * step);
+    const step = terrainStepHeight();
+    const lv = (level === undefined || level === null) ? 1 : level;
+    return (Math.min(MAX_FLOORS, lv) - 1) * step;
   }
 
   const HEAVY_TERRAIN_KERB_DROP = 0.048;
@@ -33,8 +42,18 @@
     return cell.kind ? 1 : (cell.floors || 1);
   }
 
+  // How deep a cell is excavated below the base plane (0 = undug). Clamped so a
+  // pit can never punch through the world's structural depth budget.
+  function cellDigDepth(cell) {
+    if (!cell || !cell.dig) return 0;
+    return Math.max(0, Math.min(MAX_DIG, Math.round(cell.dig)));
+  }
+
+  // The signed render level used for tile geometry, riser side-culling, and
+  // every "sits on the surface" Y lookup (objects, hover, crowd, vehicles).
+  // = terrainFloors - dig, so digging lowers the cell and everything riding it.
   function tileLevelForCell(cell) {
-    return terrainLevelForCell(cell);
+    return terrainLevelForCell(cell) - cellDigDepth(cell);
   }
 
   function terrainVisualRiseForCell(cell) {
@@ -169,6 +188,54 @@
       low: terrainShadeMaterial(base, -12),
       edge: terrainShadeMaterial(base, -18),
     };
+  }
+
+  // Geological strata revealed on excavated (dug) pit walls — the
+  // UnrealSandboxTerrain "layers by depth" look, adapted to the tile grid.
+  // `depth` is how far below the board base plane (world y = 0) a wall panel
+  // sits. The shallowest band keeps the cell's own terrain so the lip under the
+  // surface still reads correctly; deeper bands transition soil → clay → rock →
+  // bedrock. Materials are all existing shared `M.*` (no new textures/loads).
+  const _strataBandCache = new Map();
+  function strataBandsForTerrain(terrain) {
+    if (_strataBandCache.has(terrain)) return _strataBandCache.get(terrain);
+    const top = terrainRiserMaterials(terrain);
+    const bands = [
+      { maxDepth: 0.16, mats: top },
+      { maxDepth: 0.52, mats: {
+        base: M.dirtRich,
+        hi: terrainShadeMaterial(M.dirtRich, 14),
+        low: terrainShadeMaterial(M.dirtRich, -14),
+        edge: terrainShadeMaterial(M.dirtRich, -8),
+      } },
+      { maxDepth: 0.98, mats: {
+        base: terrainShadeMaterial(M.dirtRich, -20),
+        hi: terrainShadeMaterial(M.sandDk, -6),
+        low: terrainShadeMaterial(M.dirtRich, -30),
+        edge: terrainShadeMaterial(M.dirtRich, -26),
+      } },
+      { maxDepth: 1.7, mats: {
+        base: M.stone,
+        hi: terrainShadeMaterial(M.stone, 12),
+        low: M.stoneDk,
+        edge: M.stoneDk,
+      } },
+      { maxDepth: Infinity, mats: {
+        base: M.stoneDk,
+        hi: terrainShadeMaterial(M.stone, -12),
+        low: terrainShadeMaterial(M.stoneDk, -18),
+        edge: terrainShadeMaterial(M.stoneDk, -22),
+      } },
+    ];
+    _strataBandCache.set(terrain, bands);
+    return bands;
+  }
+  function strataMatsForDepth(terrain, depth) {
+    const bands = strataBandsForTerrain(terrain);
+    for (const band of bands) {
+      if (depth <= band.maxDepth) return band.mats;
+    }
+    return bands[bands.length - 1].mats;
   }
 
   function terrainVoxelCellCount(terrain) {
@@ -421,7 +488,8 @@
     return buckets;
   }
 
-  function addVoxelTerrainRiser(g, terrain, x, z, rise, riserSize, riserHeight, hiddenSides) {
+  function addVoxelTerrainRiser(g, terrain, x, z, rise, riserSize, riserHeight, hiddenSides, bottomY, strata) {
+    if (bottomY === undefined) bottomY = -DIRT_H;
     const mats = terrainRiserMaterials(terrain);
     const cells = terrainVoxelCellCount(terrain);
     const cellSize = riserSize / cells;
@@ -431,8 +499,16 @@
     const sideDepth = Math.min(0.028, Math.max(0.016, cellSize * 0.12));
     const half = riserSize * 0.5;
     const buckets = new Map();
-    function pickMat(ix, iy, dir) {
+    function pickMat(ix, iy, dir, py) {
       const r = cellRand(x * cells + ix, z * verticalCells + iy, 180 + dir.charCodeAt(0));
+      // Excavated walls: pick the geological band for this panel's depth so a
+      // dug pit shows soil → clay → rock → bedrock instead of one flat colour.
+      if (strata && py < -0.02) {
+        const band = strataMatsForDepth(terrain, -py);
+        if (r > 0.82) return band.hi;
+        if (r < 0.20) return band.low;
+        return band.base;
+      }
       if (iy === verticalCells - 1 && terrain === 'grass' && r > 0.28) return mats.edge;
       if (r > 0.82) return mats.hi;
       if (r < 0.20) return mats.low;
@@ -460,8 +536,8 @@
         for (let j = 0; j < verticalCells; j++) {
           const px = alongX ? -half + cellSize * (i + 0.5) : (dir === 'w' ? -half : half);
           const pz = alongX ? (dir === 'n' ? -half : half) : -half + cellSize * (i + 0.5);
-          const py = -DIRT_H + panelH * 0.5 + (riserHeight / verticalCells) * j;
-          queuePanel(geo, pickMat(i, j, dir), px, py, pz);
+          const py = bottomY + panelH * 0.5 + (riserHeight / verticalCells) * j;
+          queuePanel(geo, pickMat(i, j, dir, py), px, py, pz);
         }
       }
     }
@@ -485,21 +561,49 @@
     }
   }
 
-  function addVoxelTerrainRiserBacking(g, terrain, riserSize, riserHeight, hiddenSides) {
+  function addVoxelTerrainRiserBacking(g, terrain, riserSize, riserHeight, hiddenSides, bottomY, strata) {
+    if (bottomY === undefined) bottomY = -DIRT_H;
     const solidSize = Math.max(0.05, riserSize);
+    const sideFlags = [
+      hiddenSides && hiddenSides.e,
+      hiddenSides && hiddenSides.w,
+      hiddenSides && hiddenSides.s,
+      hiddenSides && hiddenSides.n,
+    ];
+    const topY = bottomY + riserHeight;
+    // Excavated walls: stack thin per-band boxes so the exposed cliff reads as
+    // geological strata (soil → clay → rock → bedrock) by depth instead of one
+    // flat colour. Only side faces draw (top/bottom culled), so it stays cheap.
+    if (strata) {
+      const bands = strataBandsForTerrain(terrain);
+      let slabTop = topY;
+      for (let i = 0; i < bands.length && slabTop > bottomY + 1e-4; i++) {
+        const bandBottomY = (bands[i].maxDepth === Infinity) ? -Infinity : -bands[i].maxDepth;
+        const slabBottom = Math.max(bottomY, bandBottomY);
+        const h = slabTop - slabBottom;
+        if (h > 1e-4) {
+          const slabGeo = getOpenBoxGeometry(solidSize, h, solidSize, true, true, sideFlags[0], sideFlags[1], sideFlags[2], sideFlags[3]);
+          const slab = new THREE.Mesh(slabGeo, bands[i].mats.base);
+          slab.position.y = slabBottom + h * 0.5;
+          g.add(slab);
+        }
+        slabTop = slabBottom;
+      }
+      return;
+    }
     const geo = getOpenBoxGeometry(
       solidSize,
       riserHeight,
       solidSize,
       true,
       true,
-      hiddenSides && hiddenSides.e,
-      hiddenSides && hiddenSides.w,
-      hiddenSides && hiddenSides.s,
-      hiddenSides && hiddenSides.n
+      sideFlags[0],
+      sideFlags[1],
+      sideFlags[2],
+      sideFlags[3]
     );
     const mesh = new THREE.Mesh(geo, terrainRiserMaterial(terrain));
-    mesh.position.y = -DIRT_H + riserHeight * 0.5;
+    mesh.position.y = bottomY + riserHeight * 0.5;
     g.add(mesh);
   }
 
@@ -1235,14 +1339,19 @@
     const hasTransform = ry || ox || oz || oy;
     const appearance = normalizeAppearance(c.appearance);
     const wf = normalizeWaterFlow(c.waterFlow);
-    if (c.terrain !== 'grass' || c.kind || f !== 1 || tf !== 1 || bt || fs || extras || hasTransform || appearance || wf !== 'auto') {
+    const dig = cellDigDepth(c);
+    if (c.terrain !== 'grass' || c.kind || f !== 1 || tf !== 1 || bt || fs || extras || hasTransform || appearance || wf !== 'auto' || dig) {
       const out = [x, z, c.terrain, c.kind, f, bt, tf, fs];
       // Always push extras (or null) before the transform / appearance so
       // tuple positions stay stable. Transform is [ry, ox, oz, oy].
+      // `dig` (sandbox excavation depth) is the last optional slot, so when it
+      // is present every earlier optional slot is materialised to keep the
+      // positions stable for the array parser.
       out.push(extras || null);
       out.push(hasTransform ? [ry, ox, oz, oy] : null);
-      if (appearance || wf !== 'auto') out.push(appearance || null);
-      if (wf !== 'auto') out.push(wf);
+      if (appearance || wf !== 'auto' || dig) out.push(appearance || null);
+      if (wf !== 'auto' || dig) out.push(wf);
+      if (dig) out.push(dig);
       return out;
     }
     return null;

--- a/engine/world/05-tile-factory.js
+++ b/engine/world/05-tile-factory.js
@@ -245,6 +245,48 @@
       : ((terrain === 'path' || terrain === 'water' || terrain === 'dirt') ? 8 : 6);
   }
 
+  // -------- per-tile voxel sculpting --------
+  // A sculpted tile carries `voxels = { n, h:[n*n] }`: a signed integer height
+  // offset per sub-cell, so the tile surface is a blocky N×N voxel mesh instead
+  // of one flat slab. `n` is the sub-grid resolution (the Voxel Resolution
+  // setting: 4/6/8/10). Heights are in cubic-voxel steps (one sub-cell wide).
+  const MAX_VOX = 16; // clamp on a sub-cell height offset (± steps)
+  function sculptResolutionNumeric() {
+    const n = parseInt(renderTerrainVoxelResolution, 10);
+    return Number.isFinite(n) ? Math.max(2, Math.min(16, n)) : 8;
+  }
+  // Normalised sculpt data, or null when the tile is flat (all-zero / absent).
+  function cellSculptData(cell) {
+    const v = cell && cell.voxels;
+    if (!v) return null;
+    const n = v.n | 0;
+    if (n < 2 || n > 16 || !Array.isArray(v.h) || v.h.length !== n * n) return null;
+    for (let k = 0; k < v.h.length; k++) { if (v.h[k]) return { n, h: v.h }; }
+    return null;
+  }
+  // Clamp + dedupe a sculpt heightmap to a stored form; null when flat so a
+  // flattened tile serialises like an ordinary one.
+  function normalizeVoxels(v) {
+    if (!v) return null;
+    const n = v.n | 0;
+    if (n < 2 || n > 16 || !Array.isArray(v.h) || v.h.length !== n * n) return null;
+    const h = new Array(n * n);
+    let any = false;
+    for (let k = 0; k < h.length; k++) {
+      const o = Math.max(-MAX_VOX, Math.min(MAX_VOX, Math.round(v.h[k]) || 0));
+      h[k] = o;
+      if (o) any = true;
+    }
+    return any ? { n, h } : null;
+  }
+  function sameVoxels(a, b) {
+    const na = normalizeVoxels(a), nb = normalizeVoxels(b);
+    if (!na && !nb) return true;
+    if (!na || !nb || na.n !== nb.n) return false;
+    for (let k = 0; k < na.h.length; k++) { if (na.h[k] !== nb.h[k]) return false; }
+    return true;
+  }
+
   const waterfallEffectMeshes = new Set();
   const waterfallTimeUniform = { value: 0 };
 
@@ -327,6 +369,126 @@
       g.add(mesh);
     }
     addVoxelTerrainSurfaceDetails(g, terrain, x, z, topSize, rise + topHeight + 0.012, pathN, terrainN);
+  }
+
+  // Blocky voxel heightfield top for a sculpted tile. Each sub-cell gets its own
+  // surface height (`rise + off*vstep`); vertical strata walls fill the steps
+  // between differing sub-cells (and between a raised edge sub-cell and the tile
+  // base, so the surface meets the outer riser). Self-contained per tile: equal-
+  // height columns abut seamlessly within and across tiles, so a continuous
+  // brush reads continuously. Only sculpted tiles run this path.
+  function addVoxelSculptTop(g, terrain, x, z, rise, topSize, topHeight, pathN, terrainN, hiddenSides, vox) {
+    const N = vox.n;
+    const h = vox.h;
+    const mats = terrainVoxelMaterials(terrain, x, z, terrainN);
+    const cellSize = topSize / N;
+    const vstep = cellSize; // cubic voxels
+    const panelOverlap = Math.min(0.014, Math.max(0.006, cellSize * 0.06));
+    const panelSize = cellSize + panelOverlap;
+    const sideDepth = Math.min(0.03, Math.max(0.012, cellSize * 0.14));
+    const half = topSize * 0.5;
+    const offAt = (i, j) => (i >= 0 && i < N && j >= 0 && j < N) ? (h[i * N + j] || 0) : 0;
+    const surfTop = o => rise + o * vstep + topHeight;        // world Y of a sub-cell surface
+    const centerX = i => -half + cellSize * (i + 0.5);
+    const centerZ = j => -half + cellSize * (j + 0.5);
+
+    const buckets = new Map();
+    function queue(geo, mat, m) {
+      const key = (geo.id || geo.uuid) + ':' + (mat.id || mat.uuid);
+      let b = buckets.get(key);
+      if (!b) { b = { geo, mat, mats: [] }; buckets.set(key, b); }
+      b.mats.push(m);
+    }
+    const dummy = addVoxelSculptTop._dummy || (addVoxelSculptTop._dummy = new THREE.Object3D());
+
+    // --- top caps (thin slab under each sub-cell surface) ---
+    const capGeo = getOpenBoxGeometry(panelSize, topHeight, panelSize, false, true, true, true, true, true);
+    for (let i = 0; i < N; i++) {
+      for (let j = 0; j < N; j++) {
+        const o = offAt(i, j);
+        const r = cellRand(x * N + i, z * N + j, 53);
+        let mat = mats.base;
+        if (r > 0.86) mat = mats.hi;
+        else if (r < 0.16) mat = mats.low;
+        else if (terrain !== 'water' && r > 0.68) mat = mats.scuff;
+        dummy.position.set(centerX(i), surfTop(o) - topHeight * 0.5, centerZ(j));
+        dummy.rotation.set(0, 0, 0);
+        dummy.scale.set(1, 1, 1);
+        dummy.updateMatrix();
+        queue(capGeo, mat, dummy.matrix.clone());
+      }
+    }
+
+    // --- strata step walls between a sub-cell and its lower neighbour ---
+    // Unit-height, double-sided wall (scaled per instance) so heights vary freely.
+    const wallGeoNS = getOpenBoxGeometry(panelSize, 1, sideDepth, true, true, false, false, false, false);
+    const wallGeoEW = getOpenBoxGeometry(sideDepth, 1, panelSize, true, true, false, false, false, false);
+    const DIRS = [['n', 0, -1], ['s', 0, 1], ['w', -1, 0], ['e', 1, 0]];
+    // Sample the matching edge sub-cell of an adjacent tile so walls stay seamless
+    // across two sculpted tiles, and cap cleanly against a flat (unsculpted) one.
+    // Returns the neighbour offset, or null when the neighbour tile is flat/at a
+    // different resolution (→ reconcile this tile's edge down to the base plane).
+    function neighborEdgeOffset(dir, i, j) {
+      if (typeof getWorldCell !== 'function') return null;
+      let nx = x, nz = z, ni = i, nj = j;
+      if (dir === 'e') { nx = x + 1; ni = 0; }
+      else if (dir === 'w') { nx = x - 1; ni = N - 1; }
+      else if (dir === 'n') { nz = z - 1; nj = N - 1; }
+      else { nz = z + 1; nj = 0; }
+      const nc = getWorldCell(nx, nz);
+      const v = nc && nc.voxels;
+      if (!v || v.n !== N || !Array.isArray(v.h)) return null;
+      return v.h[ni * N + nj] || 0;
+    }
+    function drawWall(dir, i, j, loY, hiY) {
+      const wallH = hiY - loY;
+      if (wallH <= 1e-4) return;
+      const midY = (loY + hiY) * 0.5;
+      const depth = Math.max(0, -midY); // below the board base plane → strata
+      const band = strataMatsForDepth(terrain, depth);
+      const rr = cellRand(x * N + i, z * N + j, 200 + dir.charCodeAt(0));
+      const wmat = rr > 0.8 ? band.hi : (rr < 0.22 ? band.low : band.base);
+      const alongX = dir === 'n' || dir === 's';
+      const px = alongX ? centerX(i) : (dir === 'w' ? centerX(i) - cellSize * 0.5 : centerX(i) + cellSize * 0.5);
+      const pz = alongX ? (dir === 'n' ? centerZ(j) - cellSize * 0.5 : centerZ(j) + cellSize * 0.5) : centerZ(j);
+      dummy.position.set(px, midY, pz);
+      dummy.rotation.set(0, 0, 0);
+      dummy.scale.set(1, wallH, 1);
+      dummy.updateMatrix();
+      queue(alongX ? wallGeoNS : wallGeoEW, wmat, dummy.matrix.clone());
+    }
+    for (let i = 0; i < N; i++) {
+      for (let j = 0; j < N; j++) {
+        const o = offAt(i, j);
+        for (const [dir, di, dj] of DIRS) {
+          const ni = i + di, nj = j + dj;
+          if (ni >= 0 && ni < N && nj >= 0 && nj < N) {
+            // Interior step: the taller sub-cell draws the wall down to the lower.
+            const no = offAt(ni, nj);
+            if (no < o) drawWall(dir, i, j, surfTop(no), surfTop(o));
+          } else {
+            const nb = neighborEdgeOffset(dir, i, j);
+            if (nb === null) {
+              // Flat / unsculpted neighbour: reconcile this edge to the base
+              // plane (offset 0) in both directions so there is no see-through.
+              if (o !== 0) drawWall(dir, i, j, surfTop(Math.min(o, 0)), surfTop(Math.max(o, 0)));
+            } else if (nb < o) {
+              // Adjacent sculpted tile: only the taller side draws the wall, so
+              // two equally-sculpted tiles meet seamlessly.
+              drawWall(dir, i, j, surfTop(nb), surfTop(o));
+            }
+          }
+        }
+      }
+    }
+
+    for (const b of buckets.values()) {
+      const mesh = new THREE.InstancedMesh(b.geo, b.mat, b.mats.length);
+      for (let i = 0; i < b.mats.length; i++) mesh.setMatrixAt(i, b.mats[i]);
+      mesh.instanceMatrix.needsUpdate = true;
+      g.add(mesh);
+    }
+    // No flat surface flecks here — they would float over the sculpted relief.
   }
 
   function addVoxelTerrainSurfaceDetails(g, terrain, x, z, topSize, y, pathN = null, terrainN = null) {
@@ -1340,18 +1502,20 @@
     const appearance = normalizeAppearance(c.appearance);
     const wf = normalizeWaterFlow(c.waterFlow);
     const dig = cellDigDepth(c);
-    if (c.terrain !== 'grass' || c.kind || f !== 1 || tf !== 1 || bt || fs || extras || hasTransform || appearance || wf !== 'auto' || dig) {
+    const vox = normalizeVoxels(c.voxels);
+    if (c.terrain !== 'grass' || c.kind || f !== 1 || tf !== 1 || bt || fs || extras || hasTransform || appearance || wf !== 'auto' || dig || vox) {
       const out = [x, z, c.terrain, c.kind, f, bt, tf, fs];
       // Always push extras (or null) before the transform / appearance so
       // tuple positions stay stable. Transform is [ry, ox, oz, oy].
-      // `dig` (sandbox excavation depth) is the last optional slot, so when it
-      // is present every earlier optional slot is materialised to keep the
-      // positions stable for the array parser.
+      // `dig` (excavation depth) then `voxels` (per-tile sculpt heightmap) are
+      // the last optional slots, so when a later one is present every earlier
+      // optional slot is materialised to keep the array-parser positions stable.
       out.push(extras || null);
       out.push(hasTransform ? [ry, ox, oz, oy] : null);
-      if (appearance || wf !== 'auto' || dig) out.push(appearance || null);
-      if (wf !== 'auto' || dig) out.push(wf);
-      if (dig) out.push(dig);
+      if (appearance || wf !== 'auto' || dig || vox) out.push(appearance || null);
+      if (wf !== 'auto' || dig || vox) out.push(wf);
+      if (dig || vox) out.push(dig);
+      if (vox) out.push(vox);
       return out;
     }
     return null;

--- a/engine/world/06-history-object-factories.js
+++ b/engine/world/06-history-object-factories.js
@@ -263,7 +263,16 @@
       // still read as full panels aligned to the board grid.
       const seamOverlap = 0.006;
       const topHeight = TOP_H + seamOverlap;
-      if (useVoxelTerrainForTile) {
+      const sculptData = (opts && opts.voxels) ? cellSculptData({ voxels: opts.voxels }) : null;
+      if (useVoxelTerrainForTile && sculptData) {
+        // Sculpted tile: blocky voxel heightfield surface instead of a flat slab.
+        addVoxelSculptTop(g, terrain, x, z, visualRise - seamOverlap * 0.5, topSize, topHeight, pathN, terrainN, {
+          e: skipE,
+          w: skipW,
+          s: skipS,
+          n: skipN,
+        }, sculptData);
+      } else if (useVoxelTerrainForTile) {
         addVoxelTerrainTop(g, terrain, x, z, visualRise - seamOverlap * 0.5, topSize, topHeight, pathN, terrainN, {
           e: skipE,
           w: skipW,

--- a/engine/world/06-history-object-factories.js
+++ b/engine/world/06-history-object-factories.js
@@ -168,7 +168,24 @@
     const kerbDrop = Math.abs(Math.min(0, terrainOffset));
     const visualRise = rise + terrainOffset;
     const positiveTerrainOffset = Math.max(0, terrainOffset);
-    const riserHeight = DIRT_H + rise + positiveTerrainOffset;
+    // Riser depth. Normally a tile's dirt cliff drops to the fixed board floor
+    // (-DIRT_H). Sandbox digging breaks that: an excavated cell (level < 1) gets
+    // its own dirt body below its lowered floor, and any neighbour that sits
+    // higher than this cell must extend its cliff DOWN to the deepest adjacent
+    // pit floor so the pit wall has no gap. For an undug grid every neighbour is
+    // equal-or-shallower so `cliffBottomY` resolves to -DIRT_H and the geometry
+    // is byte-identical to before.
+    const topOfRiser = rise + positiveTerrainOffset;
+    const RISER_SEAM = 0.02;
+    let cliffBottomY = Math.min(-DIRT_H, topOfRiser - DIRT_H);
+    let strataWall = level < 1;
+    for (const dir of ['n', 's', 'e', 'w']) {
+      const lv = levelN[dir];
+      if (typeof lv !== 'number') continue;
+      if (lv < 1) strataWall = true;
+      if (lv < level) cliffBottomY = Math.min(cliffBottomY, terrainRiseForLevel(lv) - RISER_SEAM);
+    }
+    const riserHeight = topOfRiser - cliffBottomY;
     const topY = visualRise + TOP_H;
     // Weather impact decals sit above the rounded/beveled slab, not at the
     // mathematical tile height, otherwise rain ripples and snow buildup hide
@@ -207,23 +224,23 @@
       if (hasVisibleRiser) {
         const riserMat = terrainRiserMaterial(terrain);
         if (useVoxelTerrainForTile) {
-          addVoxelTerrainRiserBacking(g, terrain, riserSize, DIRT_H + rise + positiveTerrainOffset, {
+          addVoxelTerrainRiserBacking(g, terrain, riserSize, riserHeight, {
             e: skipE,
             w: skipW,
             s: skipS,
             n: skipN,
-          });
+          }, cliffBottomY, strataWall);
           const bottom = new THREE.Mesh(getOpenBoxGeometry(riserSize, 0.012, riserSize, false, true, true, true, true, true), riserMat);
-          bottom.position.y = -DIRT_H - 0.006;
+          bottom.position.y = cliffBottomY - 0.006;
           bottom.userData.noShadow = true;
           g.add(bottom);
         } else {
           const riserGeo = getOpenBoxGeometry(riserSize, riserHeight, riserSize, true, true, skipE, skipW, skipS, skipN);
           const riser = new THREE.Mesh(riserGeo, riserMat);
-          riser.position.y = -DIRT_H + riserHeight * 0.5;
+          riser.position.y = cliffBottomY + riserHeight * 0.5;
           g.add(riser);
           const bottom = new THREE.Mesh(getOpenBoxGeometry(riserSize, 0.012, riserSize, false, true, true, true, true, true), riserMat);
-          bottom.position.y = -DIRT_H - 0.006;
+          bottom.position.y = cliffBottomY - 0.006;
           bottom.userData.noShadow = true;
           g.add(bottom);
         }

--- a/engine/world/10-world-data.js
+++ b/engine/world/10-world-data.js
@@ -234,6 +234,12 @@
   // objects at startup as the home board cap changes.
 
   const MAX_FLOORS = 8;
+  // Sandbox-terrain excavation depth (UnrealSandboxTerrain-style digging).
+  // A cell's signed render elevation is `terrainFloors - dig`; dig is how many
+  // levels the ground is carved *below* the board base plane. Tiles stay a grid
+  // — dig only lowers a cell's surface and exposes geological strata on the
+  // resulting pit walls. 0 means undug (default, byte-identical to old worlds).
+  const MAX_DIG = 6;
 
   const worldGroup = new THREE.Group();
   xrWorldRoot.add(worldGroup);

--- a/engine/world/12-selection-tool.js
+++ b/engine/world/12-selection-tool.js
@@ -518,7 +518,7 @@
   };
 
   function defaultCell() {
-    return { terrain: 'grass', terrainFloors: 1, kind: null, floors: 1, buildingType: null, fenceSide: null, extras: [], appearance: null, waterFlow: 'auto' };
+    return { terrain: 'grass', terrainFloors: 1, dig: 0, kind: null, floors: 1, buildingType: null, fenceSide: null, extras: [], appearance: null, waterFlow: 'auto' };
   }
 
   function cloneExtras(extras) {
@@ -535,6 +535,7 @@
     const cell = {
       terrain: (src && src.terrain) || 'grass',
       terrainFloors: (src && src.terrainFloors) || 1,
+      dig: Math.max(0, Math.min(MAX_DIG, Math.round((src && src.dig) || 0))),
       kind: (src && src.kind) || null,
       floors: (src && src.floors) || 1,
       buildingType: (src && src.buildingType) || null,

--- a/engine/world/12-selection-tool.js
+++ b/engine/world/12-selection-tool.js
@@ -518,7 +518,7 @@
   };
 
   function defaultCell() {
-    return { terrain: 'grass', terrainFloors: 1, dig: 0, kind: null, floors: 1, buildingType: null, fenceSide: null, extras: [], appearance: null, waterFlow: 'auto' };
+    return { terrain: 'grass', terrainFloors: 1, dig: 0, voxels: null, kind: null, floors: 1, buildingType: null, fenceSide: null, extras: [], appearance: null, waterFlow: 'auto' };
   }
 
   function cloneExtras(extras) {
@@ -536,6 +536,7 @@
       terrain: (src && src.terrain) || 'grass',
       terrainFloors: (src && src.terrainFloors) || 1,
       dig: Math.max(0, Math.min(MAX_DIG, Math.round((src && src.dig) || 0))),
+      voxels: normalizeVoxels(src && src.voxels),
       kind: (src && src.kind) || null,
       floors: (src && src.floors) || 1,
       buildingType: (src && src.buildingType) || null,

--- a/engine/world/17-tile-renderers.js
+++ b/engine/world/17-tile-renderers.js
@@ -496,7 +496,7 @@
   }
 
   function setCellImpl(x, z, opts) {
-    const { terrain, terrainFloors, kind = null, floors, buildingType, fenceSide, tileDelay = 0, objectDelay = 0, animate = true, impactDust = true, forceTile = false, rotationY, offsetX, offsetY, offsetZ, appearance, waterFlow } = opts;
+    const { terrain, terrainFloors, dig, kind = null, floors, buildingType, fenceSide, tileDelay = 0, objectDelay = 0, animate = true, impactDust = true, forceTile = false, rotationY, offsetX, offsetY, offsetZ, appearance, waterFlow } = opts;
     const historyStart = repaintProfileBegin();
     pushWorldHistorySnapshot();
     repaintProfileEnd('state.history', historyStart);
@@ -519,6 +519,11 @@
     const floorsChanged = (prev.floors || 1) !== newFloors;
     const newTerrainFloors = (terrainFloors !== undefined) ? terrainFloors : terrainLevelForCell(prev);
     const terrainFloorsChanged = terrainLevelForCell(prev) !== newTerrainFloors;
+    // Sandbox excavation depth. Clamp to the structural budget; preserve the
+    // previous value when the caller does not mention dig (so unrelated edits
+    // never accidentally fill a pit).
+    const newDig = (dig !== undefined) ? Math.max(0, Math.min(MAX_DIG, Math.round(dig) || 0)) : cellDigDepth(prev);
+    const digChanged = cellDigDepth(prev) !== newDig;
     // buildingType: when caller passes undefined, preserve previous unless the
     // kind is changing (a fresh kind clears any old building-type override).
     let newBType = (buildingType !== undefined) ? (buildingType || null)
@@ -531,7 +536,7 @@
     else newFenceSide = null;
     const fenceSideChanged = (prev.fenceSide || null) !== newFenceSide;
     const prevTileLevel = tileLevelForCell(prev);
-    const nextTileLevel = tileLevelForCell({ terrain: nextTerrain, terrainFloors: newTerrainFloors, kind: nextKind, floors: newFloors, buildingType: newBType, fenceSide: newFenceSide });
+    const nextTileLevel = tileLevelForCell({ terrain: nextTerrain, terrainFloors: newTerrainFloors, dig: newDig, kind: nextKind, floors: newFloors, buildingType: newBType, fenceSide: newFenceSide });
     const tileHeightChanged = prevTileLevel !== nextTileLevel;
     // Preserve `extras` (decorative tufts / fences sitting alongside the
     // main kind) across setCell unless the caller explicitly clears them.
@@ -559,7 +564,7 @@
       : 'auto';
     const waterFlowChanged = normalizeWaterFlow(prev.waterFlow) !== newWaterFlow;
     const userEdited = !!(prev.userEdited || (opts && opts.userEdited));
-    world[x][z] = { terrain: nextTerrain, terrainFloors: newTerrainFloors, kind: nextKind, floors: newFloors, buildingType: newBType, fenceSide: newFenceSide, extras: carriedExtras, rotationY: newRotationY, offsetX: newOffsetX, offsetY: newOffsetY, offsetZ: newOffsetZ, appearance: newAppearance, waterFlow: newWaterFlow };
+    world[x][z] = { terrain: nextTerrain, terrainFloors: newTerrainFloors, dig: newDig, kind: nextKind, floors: newFloors, buildingType: newBType, fenceSide: newFenceSide, extras: carriedExtras, rotationY: newRotationY, offsetX: newOffsetX, offsetY: newOffsetY, offsetZ: newOffsetZ, appearance: newAppearance, waterFlow: newWaterFlow };
     if (userEdited) world[x][z].userEdited = true;
     const vehicleDrivableChanged = prevVehicleDrivable !== isVehicleDrivableCell(world[x][z]);
     if (vehicleDrivableChanged) refreshVehiclesForWorldObstacleChange(x, z);
@@ -618,7 +623,7 @@
         && typeof scheduleHomeBorderEdgeRefresh === 'function') {
       scheduleHomeBorderEdgeRefresh();
     }
-    if (!kindChanged && !floorsChanged && !terrainFloorsChanged && !bTypeChanged && !fenceSideChanged && !appearanceChanged && !transformChanged && !waterFlowChanged) {
+    if (!kindChanged && !floorsChanged && !terrainFloorsChanged && !digChanged && !bTypeChanged && !fenceSideChanged && !appearanceChanged && !transformChanged && !waterFlowChanged) {
       if (terrainChanged || tileHeightChanged || waterFlowChanged || forceTile) {
         const saveStart = repaintProfileBegin();
         saveState();

--- a/engine/world/17-tile-renderers.js
+++ b/engine/world/17-tile-renderers.js
@@ -80,7 +80,7 @@
       path: getPathNeighbors(x, z),
       terrain: getTerrainNeighbors(x, z),
       levels: getLevelNeighbors(x, z),
-    }, x, z, tileLevelForCell(cell), { simpleTerrain });
+    }, x, z, tileLevelForCell(cell), { simpleTerrain, voxels: cell.voxels });
     repaintProfileEnd('tile.make', makeStart);
 
     const p = cellRenderPositionForCell(x, z);
@@ -496,7 +496,7 @@
   }
 
   function setCellImpl(x, z, opts) {
-    const { terrain, terrainFloors, dig, kind = null, floors, buildingType, fenceSide, tileDelay = 0, objectDelay = 0, animate = true, impactDust = true, forceTile = false, rotationY, offsetX, offsetY, offsetZ, appearance, waterFlow } = opts;
+    const { terrain, terrainFloors, dig, voxels, kind = null, floors, buildingType, fenceSide, tileDelay = 0, objectDelay = 0, animate = true, impactDust = true, forceTile = false, rotationY, offsetX, offsetY, offsetZ, appearance, waterFlow } = opts;
     const historyStart = repaintProfileBegin();
     pushWorldHistorySnapshot();
     repaintProfileEnd('state.history', historyStart);
@@ -524,6 +524,10 @@
     // never accidentally fill a pit).
     const newDig = (dig !== undefined) ? Math.max(0, Math.min(MAX_DIG, Math.round(dig) || 0)) : cellDigDepth(prev);
     const digChanged = cellDigDepth(prev) !== newDig;
+    // Per-tile voxel sculpt heightmap. Preserve when the caller omits it; store
+    // normalised (null when flat) so flattened tiles serialise like plain ones.
+    const newVoxels = (voxels !== undefined) ? normalizeVoxels(voxels) : (prev.voxels || null);
+    const voxelsChanged = !sameVoxels(prev.voxels, newVoxels);
     // buildingType: when caller passes undefined, preserve previous unless the
     // kind is changing (a fresh kind clears any old building-type override).
     let newBType = (buildingType !== undefined) ? (buildingType || null)
@@ -564,7 +568,7 @@
       : 'auto';
     const waterFlowChanged = normalizeWaterFlow(prev.waterFlow) !== newWaterFlow;
     const userEdited = !!(prev.userEdited || (opts && opts.userEdited));
-    world[x][z] = { terrain: nextTerrain, terrainFloors: newTerrainFloors, dig: newDig, kind: nextKind, floors: newFloors, buildingType: newBType, fenceSide: newFenceSide, extras: carriedExtras, rotationY: newRotationY, offsetX: newOffsetX, offsetY: newOffsetY, offsetZ: newOffsetZ, appearance: newAppearance, waterFlow: newWaterFlow };
+    world[x][z] = { terrain: nextTerrain, terrainFloors: newTerrainFloors, dig: newDig, voxels: newVoxels, kind: nextKind, floors: newFloors, buildingType: newBType, fenceSide: newFenceSide, extras: carriedExtras, rotationY: newRotationY, offsetX: newOffsetX, offsetY: newOffsetY, offsetZ: newOffsetZ, appearance: newAppearance, waterFlow: newWaterFlow };
     if (userEdited) world[x][z].userEdited = true;
     const vehicleDrivableChanged = prevVehicleDrivable !== isVehicleDrivableCell(world[x][z]);
     if (vehicleDrivableChanged) refreshVehiclesForWorldObstacleChange(x, z);
@@ -591,7 +595,7 @@
       }
     }
 
-    if (terrainChanged || tileHeightChanged || waterFlowChanged || forceTile) {
+    if (terrainChanged || tileHeightChanged || waterFlowChanged || voxelsChanged || forceTile) {
       renderCellTile(x, z, { animate, delay: tileDelay });
     } else if (!hasCellTileMesh(x, z)) {
       // Defensive: if for any reason this cell has no ground mesh
@@ -605,7 +609,7 @@
     // orientation all depend on 4-neighbour terrain; riser side-culling
     // depends on 4-neighbour tile levels. Either kind of change requires
     // re-rendering the immediate neighbours so faces don't go stale.
-    if ((terrainChanged || tileHeightChanged) && !forceTile) {
+    if ((terrainChanged || tileHeightChanged || voxelsChanged) && !forceTile) {
       const neighborStart = repaintProfileBegin();
       for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
         const nx = x + dx, nz = z + dz;
@@ -624,7 +628,7 @@
       scheduleHomeBorderEdgeRefresh();
     }
     if (!kindChanged && !floorsChanged && !terrainFloorsChanged && !digChanged && !bTypeChanged && !fenceSideChanged && !appearanceChanged && !transformChanged && !waterFlowChanged) {
-      if (terrainChanged || tileHeightChanged || waterFlowChanged || forceTile) {
+      if (terrainChanged || tileHeightChanged || waterFlowChanged || voxelsChanged || forceTile) {
         const saveStart = repaintProfileBegin();
         saveState();
         repaintProfileEnd('state.save', saveStart);

--- a/engine/world/19-tools-toolbar.js
+++ b/engine/world/19-tools-toolbar.js
@@ -10,6 +10,12 @@
     { id: 'lava',   label: 'Lava',   terrain: 'lava',  color: '#e7592b', group: 'terrain' },
     { id: 'sand',   label: 'Sand',   terrain: 'sand',  color: '#e6cc7c', group: 'terrain' },
     { id: 'snow',   label: 'Snow',   terrain: 'snow',  color: '#f2f5fa', group: 'terrain' },
+    { id: 'sculpt', label: 'Sculpt', sculpt: true, color: '#7a5a3c', shortcut: 'k', group: 'terrain',
+      variants: [
+        { id: 'sculpt-lower', label: 'Lower', mode: 'lower', hint: 'dig a pit / trench — reveals soil, clay and rock strata' },
+        { id: 'sculpt-raise', label: 'Raise', mode: 'raise', hint: 'build the ground up into a mound or hill' },
+      ],
+    },
     { id: 'new-island', label: 'Island', island: true, color: '#73a853', group: 'build' },
     { id: 'house',  label: 'House',  kind: 'house', color: '#3a72c8', shortcut: '5', group: 'build',
       variants: [
@@ -47,7 +53,7 @@
   ];
 
   const TOOL_GROUPS = [
-    { id: 'terrain', label: 'Terrain', toolIds: ['grass', 'path', 'dirt', 'water', 'stone', 'lava', 'sand', 'snow', 'rock'], iconTool: 'grass' },
+    { id: 'terrain', label: 'Terrain', toolIds: ['grass', 'path', 'dirt', 'water', 'stone', 'lava', 'sand', 'snow', 'rock', 'sculpt'], iconTool: 'grass' },
     { id: 'plants', label: 'Plants', toolIds: ['tree', 'tuft', 'flower', 'bush'], iconTool: 'tree' },
     { id: 'build', label: 'Build', toolIds: ['house', 'new-island'], iconTool: 'house' },
     { id: 'infra', label: 'Infra', toolIds: ['fence', 'bridge', 'lamp-post', 'spotlight', 'mooring'], iconTool: 'fence' },
@@ -1247,6 +1253,7 @@
     "lamp-post": "<svg viewBox=\"0 0 512 512\"><path d=\"M244 30h24v26h-24z\"/><path d=\"M256 52l66 104H190z\"/><path d=\"M186 156h140v34H186z\"/><path d=\"M240 190h32v266h-32z\"/><path d=\"M166 456h180v28H166z\"/></svg>",
     "spotlight": "<svg viewBox=\"0 0 512 512\"><path d=\"M104 122l152 70-36 78-152-70z\"/><path d=\"M230 178L470 270V152z\"/></svg>",
     "mooring": "<svg viewBox=\"0 0 512 512\"><path fill=\"currentColor\" d=\"M128 96a64 64 0 1 0 0 128a64 64 0 0 0 0-128zm256 192a64 64 0 1 0 0 128a64 64 0 0 0 0-128zM166 238c44 70 106 116 191 138l10-36c-75-20-126-58-167-124zm162-112c-80 11-141 48-184 112l31 20c37-55 87-85 159-96zM318 54l128 54l-98 96l-17-74l-74-17z\"/></svg>",
+    "sculpt": "<svg viewBox=\"0 0 512 512\"><path fill=\"currentColor\" d=\"M176 80h160v44h-58v160h-44V124h-58z M146 286h220v66l-110 114-110-114z\"/></svg>",
   };
   // tool id (or kind) -> glyph name
   const TOOL_GLYPH_NAME = {
@@ -1277,7 +1284,8 @@
       "sheep": "sheep",
       "lamp-post": "lamp-post",
       "spotlight": "spotlight",
-      "mooring": "mooring"
+      "mooring": "mooring",
+      "sculpt": "sculpt"
   };
   // House variants get distinct building glyphs so they stay easy to tell apart.
   const HOUSE_VARIANT_GLYPH = { cottage: 'house', manor: 'family-house', tower: 'watchtower', turret: 'castle', skyscraper: 'modern-city' };
@@ -1298,7 +1306,7 @@
   //  tertiary = overlays that stack onto a tile with a primary (fence/mooring)
   function posTypeForTool(t) {
     if (!t || t.select || t.erase || t.eraser || t.auto) return null;
-    if (t.terrain) return 'terrain';
+    if (t.terrain || t.sculpt) return 'terrain';
     if (t.id === 'fence' || t.kind === 'fence' || t.mooring) return 'tertiary';
     return 'primary';
   }

--- a/engine/world/20-input-place-erase.js
+++ b/engine/world/20-input-place-erase.js
@@ -192,12 +192,15 @@
       return;
     }
     if (selectedTool.sculpt) {
-      // Sandbox terrain brush: lower (dig) by default, raise (mound) when the
-      // Raise variant is active. One step per click; drag carves/builds a run
-      // since each cell is visited once per stroke.
+      // Sandbox terrain brush: edits the tile's N×N voxel sub-grid under the
+      // cursor (a small radius, spilling across tile borders) so the surface
+      // becomes a shaped voxel mesh — not a flat tower. Lower (dig) by default,
+      // raise (mound) on the Raise variant. Drag paints one step per sub-cell.
       const variant = selectedTool.activeVariant;
       const up = !!(variant && variant.mode === 'raise');
-      sculptCellElevation(x, z, up);
+      const lx = currentHover ? (currentHover.localX || 0) : 0;
+      const lz = currentHover ? (currentHover.localZ || 0) : 0;
+      sculptVoxelBrush(x, z, lx, lz, up);
       return;
     }
     if (selectedTool.kind === 'asset-template') {
@@ -600,6 +603,18 @@
     if (selectedTool && selectedTool.kind === 'fence') {
       return x + ',' + z + ':' + fenceSideFromHover(hit);
     }
+    if (selectedTool && selectedTool.sculpt) {
+      // Per-sub-cell stroke key so a drag paints individual voxels within a tile
+      // (not just once per tile), and revisiting the same voxel in one stroke
+      // doesn't keep deepening it.
+      const c = getWorldCell(x, z);
+      const n = (c.voxels && c.voxels.n) || sculptResolutionNumeric();
+      const lx = Number.isFinite(hit.localX) ? hit.localX : 0;
+      const lz = Number.isFinite(hit.localZ) ? hit.localZ : 0;
+      const li = Math.max(0, Math.min(n - 1, Math.floor((Math.max(-0.5, Math.min(0.5, lx)) + 0.5) * n)));
+      const lj = Math.max(0, Math.min(n - 1, Math.floor((Math.max(-0.5, Math.min(0.5, lz)) + 0.5) * n)));
+      return x + ',' + z + ':v' + li + ',' + lj;
+    }
     return x + ',' + z;
   }
 
@@ -668,6 +683,14 @@
   function applyDrawToolToHit(hit) {
     const coord = drawWorldCoordForHit(hit);
     if (!coord) return false;
+    // Sculpt paints in sub-cell space; the per-tile coord interpolation below
+    // would skip within-tile voxels, so apply directly at the live cursor (the
+    // sub-cell stroke key still prevents re-hitting the same voxel).
+    if (selectedTool && selectedTool.sculpt) {
+      const changedSculpt = applyDrawToolToSingleHit(hit);
+      drawLastWorldCoord = coord;
+      return changedSculpt;
+    }
     let changed = false;
     if (drawLastWorldCoord) {
       const dx = coord.x - drawLastWorldCoord.x;
@@ -1976,6 +1999,68 @@
       userEdited: isOutsideHomeGrid(x, z) || undefined,
     });
     return true;
+  }
+
+  // Per-tile voxel sculpt brush. Maps the cursor's within-tile position to a
+  // sub-cell on the tile's N×N grid and nudges a small radius of sub-cells up or
+  // down by one voxel step. The radius is computed in a global sub-cell space so
+  // a brush near a tile edge spills into the neighbour tile and craters/mounds
+  // stay continuous across the board. Each affected tile is committed via setCell
+  // with its updated heightmap.
+  let sculptBrushRadius = 1; // in sub-cells
+  function sculptVoxelBrush(tileX, tileZ, localX, localZ, up) {
+    const baseCell = getWorldCell(tileX, tileZ);
+    const N = (baseCell.voxels && baseCell.voxels.n) || sculptResolutionNumeric();
+    const delta = up ? 1 : -1;
+    const r = sculptBrushRadius;
+    // Brush centre in global sub-cell coordinates (tile index * N + within-tile).
+    const fx = Math.max(0, Math.min(0.9999, Math.max(-0.5, Math.min(0.5, localX)) + 0.5));
+    const fz = Math.max(0, Math.min(0.9999, Math.max(-0.5, Math.min(0.5, localZ)) + 0.5));
+    const gcx = tileX * N + fx * N;
+    const gcz = tileZ * N + fz * N;
+    const edits = new Map(); // 'tx,tz' -> { tx, tz, h:Array(N*N) }
+    function tileHeights(tx, tz) {
+      const key = tx + ',' + tz;
+      let e = edits.get(key);
+      if (!e) {
+        const c = getWorldCell(tx, tz);
+        const h = new Array(N * N).fill(0);
+        if (c.voxels && c.voxels.n === N && Array.isArray(c.voxels.h)) {
+          for (let k = 0; k < N * N; k++) h[k] = c.voxels.h[k] || 0;
+        }
+        e = { tx, tz, h };
+        edits.set(key, e);
+      }
+      return e;
+    }
+    const gi0 = Math.floor(gcx - r - 1), gi1 = Math.ceil(gcx + r + 1);
+    const gj0 = Math.floor(gcz - r - 1), gj1 = Math.ceil(gcz + r + 1);
+    for (let gi = gi0; gi <= gi1; gi++) {
+      for (let gj = gj0; gj <= gj1; gj++) {
+        const dist = Math.hypot((gi + 0.5) - gcx, (gj + 0.5) - gcz);
+        if (dist > r + 0.5) continue;
+        const tx = Math.floor(gi / N), tz = Math.floor(gj / N);
+        const li = gi - tx * N, lj = gj - tz * N;
+        if (li < 0 || li >= N || lj < 0 || lj >= N) continue;
+        const e = tileHeights(tx, tz);
+        const idx = li * N + lj;
+        e.h[idx] = Math.max(-MAX_VOX, Math.min(MAX_VOX, e.h[idx] + delta));
+      }
+    }
+    for (const e of edits.values()) {
+      const c = getWorldCell(e.tx, e.tz);
+      setCell(e.tx, e.tz, {
+        terrain: c.terrain,
+        terrainFloors: terrainLevelForCell(c),
+        dig: cellDigDepth(c),
+        voxels: { n: N, h: e.h },
+        kind: c.kind || null,
+        floors: c.floors || 1,
+        buildingType: c.buildingType || null,
+        fenceSide: c.fenceSide || null,
+        userEdited: isOutsideHomeGrid(e.tx, e.tz) || undefined,
+      });
+    }
   }
 
   // Item 7 — raise/lower (now sculpt) terrain at the hovered cell. Acts on the

--- a/engine/world/20-input-place-erase.js
+++ b/engine/world/20-input-place-erase.js
@@ -191,6 +191,15 @@
     if (selectedTool.select) {
       return;
     }
+    if (selectedTool.sculpt) {
+      // Sandbox terrain brush: lower (dig) by default, raise (mound) when the
+      // Raise variant is active. One step per click; drag carves/builds a run
+      // since each cell is visited once per stroke.
+      const variant = selectedTool.activeVariant;
+      const up = !!(variant && variant.mode === 'raise');
+      sculptCellElevation(x, z, up);
+      return;
+    }
     if (selectedTool.kind === 'asset-template') {
       const template = selectedTool.assetTemplate || assetTemplateById(selectedTool.assetTemplateId || selectedAssetTemplateId);
       const clipboard = normalizeClipboardPayload(template && template.clipboard);
@@ -576,6 +585,7 @@
     return !!(tool && !tool.auto && !tool.select && (
       tool.erase ||
       tool.terrain ||
+      tool.sculpt ||
       tool.kind === 'fence' ||
       tool.kind === 'bridge'
     ));
@@ -1938,26 +1948,44 @@
     setCameraMode(next);
   }
 
-  // Item 7 — raise/lower terrain at the hovered cell.  Acts on the
-  // current cell under the hover indicator, clamped 1..8 to match the
-  // schema's terrainFloors range.  No-op if nothing is hovered.
+  // Sandbox sculpt: one continuous control from a deep pit up to a tall column.
+  // Raising fills an excavation back in (dig -> 0) before stacking terrainFloors
+  // up; lowering drops terrainFloors down to the base, then DIGS below it (the
+  // UnrealSandboxTerrain "remove material" half). Returns true if it changed.
+  function sculptCellElevation(x, z, up) {
+    const cell = getWorldCell(x, z);
+    let tf = terrainLevelForCell(cell);
+    let dig = cellDigDepth(cell);
+    if (up) {
+      if (dig > 0) dig -= 1;
+      else if (tf < MAX_FLOORS) tf += 1;
+      else return false;
+    } else {
+      if (tf > 1) tf -= 1;
+      else if (dig < MAX_DIG) dig += 1;
+      else return false;
+    }
+    setCell(x, z, {
+      terrain: cell.terrain,
+      terrainFloors: tf,
+      dig,
+      kind: cell.kind || null,
+      floors: cell.floors || 1,
+      buildingType: cell.buildingType || null,
+      fenceSide: cell.fenceSide || null,
+      userEdited: isOutsideHomeGrid(x, z) || undefined,
+    });
+    return true;
+  }
+
+  // Item 7 — raise/lower (now sculpt) terrain at the hovered cell. Acts on the
+  // cell under the hover indicator. No-op if nothing is hovered.
   function adjustHoverTerrainHeight(delta) {
     if (window.__tinyworldIsPlayMode && window.__tinyworldIsPlayMode()) return;
     if (!currentHover) return;
     const x = currentHover.x + (currentHover.boardX || 0) * GRID;
     const z = currentHover.z + (currentHover.boardZ || 0) * GRID;
-    const cell = getWorldCell(x, z);
-    const prev = terrainLevelForCell(cell);
-    const next = Math.max(1, Math.min(8, prev + (delta > 0 ? 1 : -1)));
-    if (next === prev) return;
-    setCell(x, z, {
-      terrain: cell.terrain,
-      terrainFloors: next,
-      kind: cell.kind || null,
-      floors: cell.floors || 1,
-      buildingType: cell.buildingType || null,
-      fenceSide: cell.fenceSide || null,
-    });
+    sculptCellElevation(x, z, delta > 0);
   }
   // Expose for the command palette.
   window.__adjustHoverTerrainHeight = adjustHoverTerrainHeight;

--- a/engine/world/25-animation-loop-schema.js
+++ b/engine/world/25-animation-loop-schema.js
@@ -796,6 +796,16 @@
             "maximum": 6,
             "description": "Sandbox excavation depth: how many levels this cell's ground is carved BELOW the board base plane (0 = undug). The cell stays a grid tile; digging lowers its surface and exposes geological strata (soil/clay/rock) on the resulting pit walls. The cell's signed render elevation is terrainFloors - dig."
           },
+          "voxels": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["n", "h"],
+            "description": "Per-tile blocky voxel sculpt heightmap. The tile surface becomes an n×n grid of voxel columns instead of one flat slab. Used by the Sculpt tool; omit for flat tiles.",
+            "properties": {
+              "n": { "type": "integer", "minimum": 2, "maximum": 16, "description": "Sub-grid resolution per tile (matches the Voxel Resolution setting: 4/6/8/10)." },
+              "h": { "type": "array", "description": "Row-major n*n signed sub-cell height offsets in voxel steps.", "items": { "type": "integer", "minimum": -16, "maximum": 16 } }
+            }
+          },
           "buildingType": {
             "$ref": "#/$defs/buildingType"
           },

--- a/engine/world/25-animation-loop-schema.js
+++ b/engine/world/25-animation-loop-schema.js
@@ -790,6 +790,12 @@
             "maximum": 8,
             "description": "Ground height stack for the terrain layer only. Terrain repeat taps raise this value. Object repeat taps raise floors instead."
           },
+          "dig": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 6,
+            "description": "Sandbox excavation depth: how many levels this cell's ground is carved BELOW the board base plane (0 = undug). The cell stays a grid tile; digging lowers its surface and exposes geological strata (soil/clay/rock) on the resulting pit walls. The cell's signed render elevation is terrainFloors - dig."
+          },
           "buildingType": {
             "$ref": "#/$defs/buildingType"
           },

--- a/engine/world/29-persistence-api.js
+++ b/engine/world/29-persistence-api.js
@@ -341,12 +341,12 @@
       // Accept either tuple form [x,z,terrain,kind,floors,buildingType,terrainFloors,fenceSide]
       // (storage / export) or object form {x,z,terrain,kind,floors,buildingType,terrainFloors,fenceSide}
       // (canonical schema, AI generation output).
-      let x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow;
+      let x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig;
       if (Array.isArray(entry)) {
         if (entry.length < 4) continue;
-        [x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow] = entry;
+        [x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig] = entry;
       } else if (entry && typeof entry === 'object') {
-        ({ x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow } = entry);
+        ({ x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig } = entry);
       } else {
         continue;
       }
@@ -397,9 +397,11 @@
         offsetZ   = +transform.offsetZ   || 0;
         offsetY   = +transform.offsetY   || 0;
       }
+      const normalizedDig = Math.max(0, Math.min(MAX_DIG, Math.round(+dig || 0)));
       overrides.set(x + ',' + z, {
         terrain: terrain || 'grass',
         terrainFloors: normalizedTerrainFloors,
+        dig: normalizedDig,
         kind: normalizedKind,
         floors: normalizedFloors,
         buildingType: buildingType || null,
@@ -425,6 +427,7 @@
         setCell(o.__x, o.__z, {
           terrain: o.terrain,
           terrainFloors: o.terrainFloors,
+          dig: o.dig,
           kind: o.kind,
           floors: o.floors,
           buildingType: o.buildingType,
@@ -514,6 +517,7 @@
       const base = {
         terrain: o ? o.terrain : 'grass',
         terrainFloors: o ? o.terrainFloors : 1,
+        dig: o ? o.dig : 0,
         tileDelay: (itemIndex % CHUNK) * TILE_STAGGER,
         objectDelay: (itemIndex % CHUNK) * TILE_STAGGER + 0.04,
         impactDust: false,

--- a/engine/world/29-persistence-api.js
+++ b/engine/world/29-persistence-api.js
@@ -341,12 +341,12 @@
       // Accept either tuple form [x,z,terrain,kind,floors,buildingType,terrainFloors,fenceSide]
       // (storage / export) or object form {x,z,terrain,kind,floors,buildingType,terrainFloors,fenceSide}
       // (canonical schema, AI generation output).
-      let x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig;
+      let x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig, voxels;
       if (Array.isArray(entry)) {
         if (entry.length < 4) continue;
-        [x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig] = entry;
+        [x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig, voxels] = entry;
       } else if (entry && typeof entry === 'object') {
-        ({ x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig } = entry);
+        ({ x, z, terrain, kind, floors, buildingType, terrainFloors, fenceSide, extras, transform, appearance, waterFlow, dig, voxels } = entry);
       } else {
         continue;
       }
@@ -398,10 +398,12 @@
         offsetY   = +transform.offsetY   || 0;
       }
       const normalizedDig = Math.max(0, Math.min(MAX_DIG, Math.round(+dig || 0)));
+      const normalizedVoxels = (typeof normalizeVoxels === 'function') ? normalizeVoxels(voxels) : null;
       overrides.set(x + ',' + z, {
         terrain: terrain || 'grass',
         terrainFloors: normalizedTerrainFloors,
         dig: normalizedDig,
+        voxels: normalizedVoxels,
         kind: normalizedKind,
         floors: normalizedFloors,
         buildingType: buildingType || null,
@@ -428,6 +430,7 @@
           terrain: o.terrain,
           terrainFloors: o.terrainFloors,
           dig: o.dig,
+          voxels: o.voxels,
           kind: o.kind,
           floors: o.floors,
           buildingType: o.buildingType,
@@ -518,6 +521,7 @@
         terrain: o ? o.terrain : 'grass',
         terrainFloors: o ? o.terrainFloors : 1,
         dig: o ? o.dig : 0,
+        voxels: o ? o.voxels : null,
         tileDelay: (itemIndex % CHUNK) * TILE_STAGGER,
         objectDelay: (itemIndex % CHUNK) * TILE_STAGGER + 0.04,
         impactDust: false,

--- a/engine/world/30-ui-boot-wiring.js
+++ b/engine/world/30-ui-boot-wiring.js
@@ -3048,11 +3048,11 @@
       items.push({ group: 'Camera', label: 'Toggle perspective', hint: 'orbit vs orthographic', kbd: 'P', run: topBtnAction('persp') });
       items.push({ group: 'Camera', label: 'Pick camera view…', hint: 'top-down / perspective / first-person', run: topBtnAction('view-modes') });
       items.push({ group: 'Camera', label: 'Center on home grid', hint: 'frame the home board', kbd: 'H', run: topBtnAction('home') });
-      // Terrain — raise/lower the hovered cell
-      items.push({ group: 'Terrain', label: 'Raise terrain at cursor', hint: 'terrainFloors +1 (max 8)', kbd: 'R', run: () => {
+      // Terrain — sculpt (raise / dig) the hovered cell
+      items.push({ group: 'Terrain', label: 'Raise terrain at cursor', hint: 'fill any pit, then build up (max 8)', kbd: 'R', run: () => {
         if (typeof window.__adjustHoverTerrainHeight === 'function') window.__adjustHoverTerrainHeight(+1);
       } });
-      items.push({ group: 'Terrain', label: 'Lower terrain at cursor', hint: 'terrainFloors -1 (min 1)', kbd: 'F', run: () => {
+      items.push({ group: 'Terrain', label: 'Lower / dig terrain at cursor', hint: 'lower to base, then excavate a pit (reveals strata)', kbd: 'F', run: () => {
         if (typeof window.__adjustHoverTerrainHeight === 'function') window.__adjustHoverTerrainHeight(-1);
       } });
       // Scene

--- a/status.MD
+++ b/status.MD
@@ -2,69 +2,51 @@
 
 ## Goal
 
-Improve Tiny World Builder's LandscapeEngine terrain mode so it works as a real hidden-board continuous landscape, then add shadows/atmosphere without regressing low-poly rendering.
+Adapt the UnrealSandboxTerrain destructible/sculptable voxel-terrain mechanic
+(https://github.com/bw2012/UnrealSandboxTerrain) to Tiny World Builder's boards
+**without breaking anything** — the boards stay grids of tiles, they just gain the
+ability to dig/sculpt: carve a tile below the base plane into a pit/trench that
+exposes geological strata, or raise it into a mound.
+
+## Approach
+
+- Additive per-cell `dig` field (0..`MAX_DIG`); a cell's signed render elevation is
+  `terrainFloors - dig`, routed through the existing single hook `tileLevelForCell`.
+- `terrainRiseForLevel` made signed (negative for dug cells); riser bottom
+  generalised so a higher neighbour's cliff reaches the pit floor (no gaps) while
+  undug grids stay byte-identical (verified numerically vs the old formula).
+- Excavated walls render as stacked strata bands (soil→clay→rock→bedrock) reusing
+  existing `M.*` materials — no new textures/passes.
+- New **Sculpt** tool (K, Lower/Raise variants) + extended **R/F** continuous
+  raise/dig + command palette. Full persistence (serialize/parse/undo/redo/schema).
 
 ## Completed
 
-- Reviewed project context and relevant repo skills.
-- Read `context.md`, `PORT-NOTES.md`, and `LandscapeEngine.js`.
-- Confirmed there was no existing `status.md` / `STATUS.md` before this file.
-- Integrated LandscapeEngine rendering fixes for normal fixed boards and auto-expand.
-- Fixed LandscapeEngine clip coordinates for fixed 8x8 / 20x20 boards.
-- Kept the board as hidden logical/reference cells in LandscapeEngine mode.
-- Prevented discrete base tile meshes from rendering in LandscapeEngine mode.
-- Removed synthetic cut-cap/fog/base helper geometry from the active LandscapeEngine render path.
-- Suppressed and cleared legacy ghost/cheap preview boards while LandscapeEngine mode is active.
-- Added `removeLandscapeLegacyMeshes()` cleanup.
-- Added `landscapeGhostBoardsSuppressed` and wired it into ghost-board enablement.
-- Updated `updateLandscapeClipBounds()` so auto-expand moves a LandscapeEngine clip window around the camera target / visible size.
-- Added clip-bound updates during panning and per-frame LandscapeEngine auto-expand streaming.
-- Projected hover, selection overlays, ghost preview, picking, crowd height, objects, and extras onto `landscapeHeightAtCell(...)`.
-- Prevented out-of-home objects/extras from rendering behind the landscape in LandscapeEngine mode.
-- Restored old-style generation so LandscapeEngine is opt-in only via `Terrain style = Landscape`.
-- Ensured low-poly and voxel generation dispose LandscapeEngine and rebuild normal tile/object worlds.
-- Added LandscapeEngine shadow support:
-  - realistic terrain uses a native vertex-color Lambert material,
-  - near terrain receives shadows,
-  - near rocks/flora cast and receive shadows,
-  - far LOD terrain stays non-shadowed for GPU budget.
-- Added LandscapeEngine atmosphere support for realistic terrain via native `scene.fog` / distance mist participation.
-- Fixed the low-poly LandscapeEngine regression caused by the shadow change:
-  - low-poly Landscape now uses the original `sandMatLowPoly` cel shader again,
-  - realistic Landscape keeps the Lambert material for native shadows/fog.
-- Updated `.codex/skills/tinyworld-tile-variation/SKILL.md` with LandscapeEngine mode notes.
-- Updated `.codex/skills/tinyworld-render-performance/SKILL.md` with shadow/fog and low-poly shader preservation guidance.
-- Fixed pixel outline normal pass ghosting of clipped meshes by copying `landscapeMeshEngine._clipPlanes` to `pixelState.normalMaterial.clippingPlanes` inside `renderScene`.
-- Enabled free camera target panning when `landscapeMeshMode` is active (in `clampTargetToHomeBoard`).
-- Enabled dynamic terrain generation bounds expansion (up to 48x48) when first panning in landscape mode (in `expandVisibleSizeOnFirstMove`, `maxRenderVisibleSizeForGrid`, and `updateLandscapeClipBounds`).
-- Reset panning exploration state on new generation/loading in `applyState`.
-- Linked continuous landscape bounds directly to the user-configured "Preview distance" setting (`renderVisibleDistance`), enabling infinite expansion that matches distance visibility.
-- Implemented smooth gradient edge fading for low-poly (`sandMatLowPoly`), sand (`sandMat`), and realistic (`terrainMat` via `onBeforeCompile`) terrain styles, as well as the custom `waterMat` water material, fading color and opacity seamlessly into the background sky/fog near the clip boundaries.
-- Ran `npm test` after changes; checks passed.
-
-## Files Changed
-
-- `tiny-world-builder.html`
-- `LandscapeEngine.js`
-- `.codex/skills/tinyworld-tile-variation/SKILL.md`
-- `.codex/skills/tinyworld-render-performance/SKILL.md`
-- `.codex/skills/tinyworld-opacity-torch/SKILL.md`
-- `status.MD`
+- `dig` data model + `MAX_DIG` (`10-world-data.js`), signed elevation +
+  `cellDigDepth`/`tileLevelForCell`/strata helpers (`05-tile-factory.js`).
+- Generalised riser depth + `strataWall` in `makeTile` (`06`), banded backing slabs.
+- Threaded `dig` through `setCell` (`17`), `defaultCell`/`writeWorldIntentCell`
+  (`12`), serialize (`05`) + parser/both apply paths (`29`).
+- Sculpt tool + glyph + group + posType (`19`), dispatch + `sculptCellElevation` +
+  drawable + R/F (`20`), palette hints (`30`).
+- Optional `dig` in `world.schema.json` + embedded copy (`25`); updated the
+  matching `check.js` riser-backing guard.
+- Docs: README controls/tools/data-model, AGENTS.md mental model, new skill
+  `.codex/skills/tinyworld-sandbox-terrain`.
 
 ## Validation
 
-- `npm test` passes:
-  - `npm run check` → `ok`
-  - `npm run smoke` → `smoke ok`
+- `npm test` passes: `check` → ok (incl. schema parity + i18n 213×4), `smoke` →
+  smoke ok, unit `# pass 45 # fail 0`.
+- `node --check` clean on every changed engine module.
+- Numeric invariant check: undug flat/hill/dirt cells produce IDENTICAL
+  riserHeight/bottom to the old formula; dug + deep-pit-neighbour walls reach the
+  pit floor with no gap.
 
-## Still Needs Visual QA
+## Still needs visual QA (no browser in this env)
 
-- Browser-check Landscape mode on fixed boards: no hidden base/helper outlines.
-- Browser-check Landscape auto-expand while panning: real terrain streams/reveals with no ghost/base boards.
-- Browser-check low-poly and voxel terrain styles: legacy generation renders normally.
-- Browser-check both Landscape render modes:
-  - `Low-poly (Cel)` should look low-poly/cel again,
-  - `Realistic` should receive shadows/fog.
-- Verify that setting the pixels to "Outline: Normal" displays no outline ghosts for clipped landscape tiles, rocks, or trees.
-- Verify that panning dynamically generates and paints in continuous terrain around the camera, complying exactly with the visible distance setting.
-- Verify that the boundaries of the clipped landscape map (terrain and water) show a soft gradient fade-out blending into the background sky/fog color.
+- Browser-check digging with the Sculpt tool and R/F: pit lowers, neighbour walls
+  show soil/clay/rock strata, objects on a dug cell ride down with it.
+- Confirm shallow dig (1–2) on a flat grass board shows a clean dirt-rimmed dip and
+  deep digs reveal rock/bedrock bands; undug default island looks unchanged.
+- Confirm dig round-trips through save/reload, export/import, and undo/redo.

--- a/status.MD
+++ b/status.MD
@@ -43,10 +43,24 @@ exposes geological strata, or raise it into a mound.
   riserHeight/bottom to the old formula; dug + deep-pit-neighbour walls reach the
   pit floor with no gap.
 
+## Follow-up: per-tile VOXEL sculpting (user feedback)
+
+The first pass moved a whole tile as one flat slab. Per user feedback ("should be
+voxels — 4×4/6×6/8×8/10×10 per tile … actually it's a mesh") the **Sculpt tool**
+now edits a per-tile N×N voxel sub-grid (`voxels = { n, h[] }`) so the surface
+becomes a blocky voxel mesh:
+
+- Added `10×10` to the Voxel Resolution setting; sculpt grid follows that setting.
+- New `addVoxelSculptTop` renderer (caps + strata step walls, cross-tile seamless,
+  flat-neighbour capped). `sculptVoxelBrush` paints a small radius across tile
+  borders; per-sub-cell stroke keys. Whole-tile `R/F` (`sculptCellElevation`) kept.
+- `voxels` persisted through setCell/serialize/parser/schema; `setCell` re-renders
+  neighbours on `voxelsChanged`.
+
 ## Still needs visual QA (no browser in this env)
 
-- Browser-check digging with the Sculpt tool and R/F: pit lowers, neighbour walls
-  show soil/clay/rock strata, objects on a dug cell ride down with it.
-- Confirm shallow dig (1–2) on a flat grass board shows a clean dirt-rimmed dip and
-  deep digs reveal rock/bedrock bands; undug default island looks unchanged.
-- Confirm dig round-trips through save/reload, export/import, and undo/redo.
+- Sculpt tool (K): click/drag carves a voxel-stepped mesh within a tile (not a flat
+  tower); craters/mounds flow across tile borders; Lower/Raise variants both work.
+- Strata bands show on the cut walls; deeper cuts reveal rock/bedrock.
+- Undug/unsculpted default island is unchanged; voxel resolution 4/6/8/10 all render.
+- Sculpt + dig + whole-tile raise round-trip through save/reload, export, undo/redo.

--- a/tiny-world-builder.html
+++ b/tiny-world-builder.html
@@ -1109,6 +1109,7 @@
                 <option value="4">4 × 4</option>
                 <option value="6">6 × 6</option>
                 <option value="8">8 × 8</option>
+                <option value="10">10 × 10</option>
                 <option value="12">12 × 12</option>
               </select>
             </label>

--- a/tools/check.js
+++ b/tools/check.js
@@ -392,7 +392,7 @@ const materialBootBody = sourceFunctionBody(html, 'applyPersistedMaterialSetting
 if (!/hasPersistedMaterialSettings\(\)/.test(materialBootBody) || !/commitPartMaterialAdjustments\(\)/.test(materialBootBody) || !/rebuildTerrainRender\(\)/.test(materialBootBody) || !/rebuildObjectsRender\(\)/.test(materialBootBody) || !/applyPersistedMaterialSettingsOnBoot\(\)/.test(html)) {
   fail('persisted material wear/adjustments must be applied at late boot without needing slider movement');
 }
-if (!/function addVoxelTerrainRiserBacking/.test(html) || !/addVoxelTerrainRiserBacking\(g, terrain, riserSize, DIRT_H \+ rise/.test(html)) {
+if (!/function addVoxelTerrainRiserBacking/.test(html) || !/addVoxelTerrainRiserBacking\(g, terrain, riserSize, riserHeight,/.test(html)) {
   fail('voxel terrain sides must include a solid backing behind detailed panels');
 }
 if (/addVoxelTerrainRiser\(g, terrain, x, z, rise, riserSize, DIRT_H \+ rise/.test(html)) {

--- a/world.schema.json
+++ b/world.schema.json
@@ -252,6 +252,12 @@
           "maximum": 8,
           "description": "Ground height stack for the terrain layer only. Terrain repeat taps raise this value. Object repeat taps raise floors instead."
         },
+        "dig": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 6,
+          "description": "Sandbox excavation depth: how many levels this cell's ground is carved BELOW the board base plane (0 = undug). The cell stays a grid tile; digging lowers its surface and exposes geological strata (soil/clay/rock) on the resulting pit walls. The cell's signed render elevation is terrainFloors - dig."
+        },
         "buildingType": { "$ref": "#/$defs/buildingType" },
         "fenceSide": { "$ref": "#/$defs/fenceSide" },
         "extras": { "$ref": "#/$defs/extras" },

--- a/world.schema.json
+++ b/world.schema.json
@@ -258,6 +258,16 @@
           "maximum": 6,
           "description": "Sandbox excavation depth: how many levels this cell's ground is carved BELOW the board base plane (0 = undug). The cell stays a grid tile; digging lowers its surface and exposes geological strata (soil/clay/rock) on the resulting pit walls. The cell's signed render elevation is terrainFloors - dig."
         },
+        "voxels": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["n", "h"],
+          "description": "Per-tile blocky voxel sculpt heightmap. The tile surface becomes an n×n grid of voxel columns instead of one flat slab. Used by the Sculpt tool; omit for flat tiles.",
+          "properties": {
+            "n": { "type": "integer", "minimum": 2, "maximum": 16, "description": "Sub-grid resolution per tile (matches the Voxel Resolution setting: 4/6/8/10)." },
+            "h": { "type": "array", "description": "Row-major n*n signed sub-cell height offsets in voxel steps.", "items": { "type": "integer", "minimum": -16, "maximum": 16 } }
+          }
+        },
         "buildingType": { "$ref": "#/$defs/buildingType" },
         "fenceSide": { "$ref": "#/$defs/fenceSide" },
         "extras": { "$ref": "#/$defs/extras" },


### PR DESCRIPTION
## What & why

Adapts the [UnrealSandboxTerrain](https://github.com/bw2012/UnrealSandboxTerrain) destructible/sculptable voxel-terrain mechanic to our boards **without changing the fundamentals** — boards stay grids of tiles, they just gain the ability to **dig**. A cell can now be excavated *below* the base plane into a pit/trench that exposes geological strata (soil → clay → rock → bedrock), or raised into a mound. This is UnrealSandboxTerrain's "add/remove material, layers by depth" idea, done additively.

Raising terrain already existed (`terrainFloors`); the missing half — **removing** material / digging with strata — is what this adds, giving full add/remove sculpting.

## How it stays non-breaking

The whole feature pivots on one existing hook, `tileLevelForCell`, now returning a **signed** level `terrainFloors - dig`. Digging just makes a cell read as "lower" for geometry, neighbour side-culling, and every surface‑Y lookup (so objects/hover/crowd ride the dug floor automatically).

- `terrainRiseForLevel` is now signed (negative for dug cells).
- `makeTile` generalises the riser bottom so a **higher neighbour's cliff reaches the pit floor** (no gaps), while for an undug grid every neighbour is equal‑or‑shallower and the geometry resolves to exactly the old `DIRT_H + rise` formula. Verified numerically: flat grass / hills / dirt produce **identical** riser height + bottom to before.
- Excavated walls render as stacked strata bands reusing existing `M.*` materials — **no new textures, no extra render passes**. Banding only turns on for cells that are dug or border a pit, so ordinary cliffs are untouched.

## UX

- New **Sculpt** tool (shortcut `K`, terrain group) with **Lower** (dig, default) / **Raise** variants. Click steps one level; drag carves/builds a run.
- **`R` / `F`** and the command palette now lower to the base then **dig below it**; raising fills a pit before stacking floors — one continuous sculpt control.

## Persistence

`dig` is threaded through the single serialize chokepoint (`serializeCell`) and the `applyState` parser + both apply paths, so **save/reload, export/import and undo/redo all round‑trip**. Optional `dig` (0..6) added to `world.schema.json` and the embedded copy (parity guard updated).

## Tests

- `npm test` green: `check` (schema parity + i18n 213×4) → ok, `smoke` → smoke ok, unit **45 pass / 0 fail**.
- `node --check` clean on every changed module.
- Numeric invariant check confirms undug worlds are byte-identical and pit walls reach the floor.

## Not in this pass (follow-ups)

- The pit **floor** keeps the cell's own surface material; making it read as exposed earth needs a top-face override in `addVoxelTerrainTop` without disturbing path/water adjacency.
- No visual QA was possible in this environment (no browser) — see the checklist in `status.MD`.

See the new `.codex/skills/tinyworld-sandbox-terrain` skill for the full design.

https://claude.ai/code/session_01KGtT34oLw5ja8kTwkF8vdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGtT34oLw5ja8kTwkF8vdn)_