### PR TITLE
builder: add core-loop coach card to first-run tips (feedback #1)

### DIFF
--- a/engine/i18n/en.js
+++ b/engine/i18n/en.js
@@ -209,6 +209,12 @@
     // ---- layers / tips ----
     'tips.show': 'Show controls',
     'tips.hide': 'Hide tips',
+    'tips.todoTitle': 'What to do',
+    'tips.controlsTitle': 'Controls',
+    'tips.step1': 'Pick a tool from the toolbar',
+    'tips.step2': 'Place terrain & objects on the grid',
+    'tips.step3': 'Click anything to edit it',
+    'tips.step4': 'Switch to Play to walk your world',
     'layers.toggle': 'Layers',
     'layers.open': 'Open layers panel',
     'layers.close': 'Close layers',

--- a/engine/i18n/es.js
+++ b/engine/i18n/es.js
@@ -187,6 +187,12 @@
 
     'tips.show': 'Mostrar controles',
     'tips.hide': 'Ocultar consejos',
+    'tips.todoTitle': 'Qué hacer',
+    'tips.controlsTitle': 'Controles',
+    'tips.step1': 'Elige una herramienta de la barra de herramientas',
+    'tips.step2': 'Coloca terreno y objetos en la cuadrícula',
+    'tips.step3': 'Haz clic en cualquier cosa para editarla',
+    'tips.step4': 'Cambia al modo Jugar para recorrer tu mundo',
     'layers.toggle': 'Capas',
     'layers.open': 'Abrir panel de capas',
     'layers.close': 'Cerrar capas',

--- a/engine/i18n/fr.js
+++ b/engine/i18n/fr.js
@@ -187,6 +187,12 @@
 
     'tips.show': 'Afficher les commandes',
     'tips.hide': 'Masquer les astuces',
+    'tips.todoTitle': 'Que faire',
+    'tips.controlsTitle': 'Commandes',
+    'tips.step1': 'Choisissez un outil dans la barre d’outils',
+    'tips.step2': 'Placez le terrain et les objets sur la grille',
+    'tips.step3': 'Cliquez sur un élément pour le modifier',
+    'tips.step4': 'Passez en mode Jeu pour parcourir votre monde',
     'layers.toggle': 'Calques',
     'layers.open': 'Ouvrir le panneau des calques',
     'layers.close': 'Fermer les calques',

--- a/engine/i18n/zh.js
+++ b/engine/i18n/zh.js
@@ -187,6 +187,12 @@
 
     'tips.show': '显示操作说明',
     'tips.hide': '隐藏提示',
+    'tips.todoTitle': '该做什么',
+    'tips.controlsTitle': '操作',
+    'tips.step1': '从工具栏选择一个工具',
+    'tips.step2': '在网格上放置地形和物体',
+    'tips.step3': '点击任意物体即可编辑',
+    'tips.step4': '切换到游玩模式，漫步你的世界',
     'layers.toggle': '图层',
     'layers.open': '打开图层面板',
     'layers.close': '关闭图层',

--- a/engine/world/24-crop-duster-banners.js
+++ b/engine/world/24-crop-duster-banners.js
@@ -264,6 +264,52 @@
       grid.appendChild(val);
     }
 
+    // First-run coach: explain the core loop above the controls. Two labelled
+    // sections — "What to do" (numbered steps) + "Controls" (the existing grid).
+    // Built once at setup; reuses the card's own classes / CSS vars so it stays
+    // visually consistent and dark-theme aware. No new tutorial subsystem.
+    const tx = (k, fb) => (window.tx ? window.tx(k, fb) : fb);
+    function sectionTitle(key, fallback) {
+      const h = document.createElement('div');
+      h.className = 'tips-label';
+      h.style.cssText = 'text-transform:uppercase;letter-spacing:.04em;font-size:9px;opacity:.65;margin-bottom:4px;';
+      h.textContent = tx(key, fallback);
+      return h;
+    }
+
+    const STEPS = [
+      ['tips.step1', 'Pick a tool from the toolbar'],
+      ['tips.step2', 'Place terrain & objects on the grid'],
+      ['tips.step3', 'Click anything to edit it'],
+      ['tips.step4', 'Switch to Play to walk your world'],
+    ];
+    const steps = document.createElement('div');
+    steps.className = 'tips-grid';
+    steps.style.gridTemplateColumns = 'auto 1fr';
+    STEPS.forEach(([key, fallback], i) => {
+      const num = document.createElement('div');
+      num.className = 'tips-label';
+      num.textContent = (i + 1) + '.';
+      const txt = document.createElement('div');
+      txt.className = 'tips-keys';
+      txt.style.whiteSpace = 'normal';
+      txt.textContent = tx(key, fallback);
+      steps.appendChild(num);
+      steps.appendChild(txt);
+    });
+
+    const content = document.createElement('div');
+    content.style.cssText = 'display:flex;flex-direction:column;gap:10px;flex:1;min-width:0;';
+    const todoSection = document.createElement('div');
+    todoSection.appendChild(sectionTitle('tips.todoTitle', 'What to do'));
+    todoSection.appendChild(steps);
+    const ctrlSection = document.createElement('div');
+    ctrlSection.appendChild(sectionTitle('tips.controlsTitle', 'Controls'));
+    ctrlSection.appendChild(grid); // reparent the existing controls grid
+    content.appendChild(todoSection);
+    content.appendChild(ctrlSection);
+    panel.appendChild(content); // close button keeps its CSS `order` on the right
+
     function show() {
       panel.hidden = false;
       if (showBtn) showBtn.hidden = true;


### PR DESCRIPTION
## What & why

New builder-mode users get no explanation of the core game loop — the only first-run help today is a tips card listing **camera/keyboard controls only** (Orbit/Pan/Zoom/Select/Tools/Reset). They're left asking "what am I supposed to do?".

This augments that **same** first-run card with a short, friendly **"What to do"** section communicating the core loop in 4 steps, above a now-labelled **"Controls"** section that keeps the existing camera-controls grid unchanged.

## The card now reads

**What to do**
1. Pick a tool from the toolbar
2. Place terrain & objects on the grid
3. Click anything to edit it
4. Switch to Play to walk your world

**Controls** — (unchanged Orbit / Pan / Zoom / Select area / Tools / Reset view grid)

## How

- Reuses the existing dismiss-once banner mechanism (`tinyworld:tips.dismissed` localStorage, auto-shows on first run, skippable via the close button / appbar toggle). **No new tutorial subsystem.**
- The new section is built once at panel setup and reuses the card's own classes (`tips-grid` / `tips-label` / `tips-keys`) and CSS variables, so it stays visually consistent and dark-theme aware.
- "Play" matches the established term (the build↔play toggle button + welcome modal).

## i18n

All new copy routed through i18n — 6 keys added to `en.js`, `es.js`, `fr.js`, `zh.js` (`tips.todoTitle`, `tips.controlsTitle`, `tips.step1`–`step4`), translated using the existing glossary/terminology. Existing keys untouched and not reordered (minimizes conflict surface with sibling PRs sharing these files).

## Checks

- `npm run i18n:check` — green (305 keys × 4 locales)
- `npm run check` — green
- `node --check` on the edited module — passes

Files touched: `engine/world/24-crop-duster-banners.js` + the four i18n locale files only.

https://claude.ai/code/session_016Np1ABvnrS75avJQuMftWe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tips panel with step-by-step guidance for tool selection, terrain placement, object editing, and play mode activation
  * Tips now available in English, Spanish, French, and Simplified Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->