### PR TITLE
builder: material glyphs + context-gate dead buttons (feedback #2,#5)

### DIFF
--- a/engine/i18n/en.js
+++ b/engine/i18n/en.js
@@ -358,6 +358,7 @@
     'props.gate.nothingCopied': 'Nothing copied yet',
     'props.gate.noTemplate': 'No saved template yet',
     'props.gate.voxelOnly': 'Voxel parts only',
+    'props.gate.emptyTemplate': 'Template is empty',
     'props.action.failed': 'Nothing to do here',
   };
 }());

--- a/engine/i18n/en.js
+++ b/engine/i18n/en.js
@@ -352,5 +352,12 @@
     'toast.downloadFailed': 'Download failed.',
     'toast.invalidJson': 'That file is not valid JSON.',
     'toast.readFailed': 'Could not read that file.',
+
+    // ---- builder Properties panel: action gating tooltips + toasts ----
+    'props.gate.needTool': 'Pick a placeable tool first',
+    'props.gate.nothingCopied': 'Nothing copied yet',
+    'props.gate.noTemplate': 'No saved template yet',
+    'props.gate.voxelOnly': 'Voxel parts only',
+    'props.action.failed': 'Nothing to do here',
   };
 }());

--- a/engine/i18n/es.js
+++ b/engine/i18n/es.js
@@ -327,6 +327,7 @@
     'props.gate.nothingCopied': 'Aún no has copiado nada',
     'props.gate.noTemplate': 'Aún no hay plantilla guardada',
     'props.gate.voxelOnly': 'Solo piezas vóxel',
+    'props.gate.emptyTemplate': 'La plantilla está vacía',
     'props.action.failed': 'No hay nada que hacer aquí',
   };
 }());

--- a/engine/i18n/es.js
+++ b/engine/i18n/es.js
@@ -321,5 +321,12 @@
     'toast.downloadFailed': 'Error al descargar.',
     'toast.invalidJson': 'Ese archivo no es un JSON válido.',
     'toast.readFailed': 'No se pudo leer ese archivo.',
+
+    // ---- builder Properties panel: action gating tooltips + toasts ----
+    'props.gate.needTool': 'Elige primero una herramienta para colocar',
+    'props.gate.nothingCopied': 'Aún no has copiado nada',
+    'props.gate.noTemplate': 'Aún no hay plantilla guardada',
+    'props.gate.voxelOnly': 'Solo piezas vóxel',
+    'props.action.failed': 'No hay nada que hacer aquí',
   };
 }());

--- a/engine/i18n/fr.js
+++ b/engine/i18n/fr.js
@@ -327,6 +327,7 @@
     'props.gate.nothingCopied': 'Rien de copié pour l’instant',
     'props.gate.noTemplate': 'Aucun modèle enregistré',
     'props.gate.voxelOnly': 'Pièces voxel uniquement',
+    'props.gate.emptyTemplate': 'Le modèle est vide',
     'props.action.failed': 'Rien à faire ici',
   };
 }());

--- a/engine/i18n/fr.js
+++ b/engine/i18n/fr.js
@@ -321,5 +321,12 @@
     'toast.downloadFailed': 'Échec du téléchargement.',
     'toast.invalidJson': 'Ce fichier n’est pas un JSON valide.',
     'toast.readFailed': 'Impossible de lire ce fichier.',
+
+    // ---- builder Properties panel: action gating tooltips + toasts ----
+    'props.gate.needTool': 'Choisissez d’abord un outil de placement',
+    'props.gate.nothingCopied': 'Rien de copié pour l’instant',
+    'props.gate.noTemplate': 'Aucun modèle enregistré',
+    'props.gate.voxelOnly': 'Pièces voxel uniquement',
+    'props.action.failed': 'Rien à faire ici',
   };
 }());

--- a/engine/i18n/zh.js
+++ b/engine/i18n/zh.js
@@ -327,6 +327,7 @@
     'props.gate.nothingCopied': '尚未复制任何内容',
     'props.gate.noTemplate': '尚未保存模板',
     'props.gate.voxelOnly': '仅限体素部件',
+    'props.gate.emptyTemplate': '模板为空',
     'props.action.failed': '这里没有可执行的操作',
   };
 }());

--- a/engine/i18n/zh.js
+++ b/engine/i18n/zh.js
@@ -321,5 +321,12 @@
     'toast.downloadFailed': '下载失败。',
     'toast.invalidJson': '该文件不是有效的 JSON。',
     'toast.readFailed': '无法读取该文件。',
+
+    // ---- builder Properties panel: action gating tooltips + toasts ----
+    'props.gate.needTool': '请先选择放置工具',
+    'props.gate.nothingCopied': '尚未复制任何内容',
+    'props.gate.noTemplate': '尚未保存模板',
+    'props.gate.voxelOnly': '仅限体素部件',
+    'props.action.failed': '这里没有可执行的操作',
   };
 }());

--- a/engine/world/20-input-place-erase.js
+++ b/engine/world/20-input-place-erase.js
@@ -161,21 +161,22 @@
     return true;
   }
 
-  // Read-only mirror of applySelectedToolToSelection's gating (above) so the
+  // Read-only mirror of applySelectedToolToSelection's STATIC gating so the
   // Properties panel can disable the "Apply tool" chip when the action would
-  // no-op (feedback #5). Mirrors the handler's false-returning guards exactly —
-  // no more, no less — so keep this beside applySelectedToolToSelection.
+  // no-op (feedback #5). This runs on the panel-refresh path, so it MUST be
+  // strictly side-effect-free: it gates only on cheap, statically-knowable
+  // conditions and never calls sel.materialize() — materializeSelectedCells()
+  // mutates the world (setCell, ghost-mesh removal, key rewrite, userEdited),
+  // which must not happen just by rendering the panel. A non-empty selection is
+  // enough here; the genuinely-runtime "no cell accepted placement" outcome is
+  // covered by the dispatcher's failure toast, not pre-computed.
   function canApplySelectedToolToSelection() {
     if (window.__tinyworldIsPlayMode && window.__tinyworldIsPlayMode()) return false;
     const sel = window.__tinyworldSelection;
     if (!sel || !sel.cells || !sel.cells.size) return false;
     if (!selectedTool || selectedTool.select || selectedTool.auto || selectedTool.island || selectedTool.mooring) return false;
-    const selectedCoords = sel.materialize ? sel.materialize() : (sel.worldCoords ? sel.worldCoords() : []);
-    if (!selectedCoords.length) return false;
     // Asset-template tools no-op when their template clipboard is missing/invalid
-    // (handler's static false path). This lookup is read-only — no mutation. The
-    // runtime "no placement succeeded" outcome is NOT statically knowable and is
-    // covered by the dispatcher's failure toast, so it is deliberately not here.
+    // (handler's static false path). This lookup is read-only — no mutation.
     if (selectedTool.kind === 'asset-template') {
       const template = selectedTool.assetTemplate || assetTemplateById(selectedTool.assetTemplateId || selectedAssetTemplateId);
       if (!normalizeClipboardPayload(template && template.clipboard)) return false;

--- a/engine/world/20-input-place-erase.js
+++ b/engine/world/20-input-place-erase.js
@@ -163,26 +163,33 @@
 
   // Read-only mirror of applySelectedToolToSelection's gating (above) so the
   // Properties panel can disable the "Apply tool" chip when the action would
-  // no-op (feedback #5). Keep this beside applySelectedToolToSelection so the
-  // two stay in sync if the guards change.
+  // no-op (feedback #5). Mirrors the handler's false-returning guards exactly —
+  // no more, no less — so keep this beside applySelectedToolToSelection.
   function canApplySelectedToolToSelection() {
     if (window.__tinyworldIsPlayMode && window.__tinyworldIsPlayMode()) return false;
     const sel = window.__tinyworldSelection;
     if (!sel || !sel.cells || !sel.cells.size) return false;
     if (!selectedTool || selectedTool.select || selectedTool.auto || selectedTool.island || selectedTool.mooring) return false;
+    const selectedCoords = sel.materialize ? sel.materialize() : (sel.worldCoords ? sel.worldCoords() : []);
+    if (!selectedCoords.length) return false;
     return true;
   }
 
-  // True when there is a clipboard payload (copy/cut, or a single hovered cell
-  // captured for copy) that paste could place. Mirrors pasteClipboardAtTarget's
-  // content check so the panel can disable a "Paste" chip that would no-op.
+  // True when "Paste" would actually place something. Mirrors the full false
+  // path of pasteClipboardAtActiveTarget → pasteClipboardPayloadAtTarget: it
+  // needs edit permission (mpEditAllowed — read-only/play roles return false)
+  // AND a clipboard payload (copy/cut, or a single copied hover cell).
   function clipboardHasContent() {
+    if (!mpEditAllowed()) return false;
     if (assetClipboard && assetClipboard.cells && assetClipboard.cells.length) return true;
     return !!copiedHoverCell;
   }
 
-  // True when a saved asset template exists for "Paste latest".
+  // True when "Paste latest" would succeed: edit permission allowed AND a saved
+  // asset template exists. Mirrors pasteLatestTemplateAtActiveTarget's false path
+  // (the paste it calls also gates on mpEditAllowed).
   function latestTemplateAvailable() {
+    if (!mpEditAllowed()) return false;
     return !!latestTemplateClipboardPayload();
   }
 

--- a/engine/world/20-input-place-erase.js
+++ b/engine/world/20-input-place-erase.js
@@ -172,6 +172,14 @@
     if (!selectedTool || selectedTool.select || selectedTool.auto || selectedTool.island || selectedTool.mooring) return false;
     const selectedCoords = sel.materialize ? sel.materialize() : (sel.worldCoords ? sel.worldCoords() : []);
     if (!selectedCoords.length) return false;
+    // Asset-template tools no-op when their template clipboard is missing/invalid
+    // (handler's static false path). This lookup is read-only — no mutation. The
+    // runtime "no placement succeeded" outcome is NOT statically knowable and is
+    // covered by the dispatcher's failure toast, so it is deliberately not here.
+    if (selectedTool.kind === 'asset-template') {
+      const template = selectedTool.assetTemplate || assetTemplateById(selectedTool.assetTemplateId || selectedAssetTemplateId);
+      if (!normalizeClipboardPayload(template && template.clipboard)) return false;
+    }
     return true;
   }
 

--- a/engine/world/20-input-place-erase.js
+++ b/engine/world/20-input-place-erase.js
@@ -161,6 +161,31 @@
     return true;
   }
 
+  // Read-only mirror of applySelectedToolToSelection's gating (above) so the
+  // Properties panel can disable the "Apply tool" chip when the action would
+  // no-op (feedback #5). Keep this beside applySelectedToolToSelection so the
+  // two stay in sync if the guards change.
+  function canApplySelectedToolToSelection() {
+    if (window.__tinyworldIsPlayMode && window.__tinyworldIsPlayMode()) return false;
+    const sel = window.__tinyworldSelection;
+    if (!sel || !sel.cells || !sel.cells.size) return false;
+    if (!selectedTool || selectedTool.select || selectedTool.auto || selectedTool.island || selectedTool.mooring) return false;
+    return true;
+  }
+
+  // True when there is a clipboard payload (copy/cut, or a single hovered cell
+  // captured for copy) that paste could place. Mirrors pasteClipboardAtTarget's
+  // content check so the panel can disable a "Paste" chip that would no-op.
+  function clipboardHasContent() {
+    if (assetClipboard && assetClipboard.cells && assetClipboard.cells.length) return true;
+    return !!copiedHoverCell;
+  }
+
+  // True when a saved asset template exists for "Paste latest".
+  function latestTemplateAvailable() {
+    return !!latestTemplateClipboardPayload();
+  }
+
   // True unless a shared-room role forbids editing entirely (viewer/player).
   // Gates the non-per-cell edit paths (clipboard, keyboard shortcuts).
   function mpEditAllowed() {

--- a/engine/world/28-generate-panel-agent.js
+++ b/engine/world/28-generate-panel-agent.js
@@ -1764,7 +1764,8 @@
         // nothing, so tell the user why (feedback #5). Chips are also gated off in
         // the panel, but a keyboard/route can still reach a failing action.
         if (ok === false && typeof twToast === 'function') {
-          const reason = value === 'apply-tool' ? window.t('props.gate.needTool')
+          const reason = value === 'apply-tool'
+              ? ((typeof selectedTool !== 'undefined' && selectedTool && selectedTool.kind === 'asset-template') ? window.t('props.gate.emptyTemplate') : window.t('props.gate.needTool'))
             : value === 'paste' ? window.t('props.gate.nothingCopied')
             : value === 'paste-template' ? window.t('props.gate.noTemplate')
             : window.t('props.action.failed');
@@ -2130,9 +2131,15 @@
       const applyToolDisabled = typeof canApplySelectedToolToSelection === 'function' && !canApplySelectedToolToSelection();
       const pasteDisabled = typeof clipboardHasContent === 'function' && !clipboardHasContent();
       const pasteTemplateDisabled = typeof latestTemplateAvailable === 'function' && !latestTemplateAvailable();
+      // An asset-template tool with no/invalid template is disabled for a
+      // different reason than "no placeable tool selected" — show the matching
+      // precondition. (read-only check of the active tool kind)
+      const applyToolReason = (typeof selectedTool !== 'undefined' && selectedTool && selectedTool.kind === 'asset-template')
+        ? window.t('props.gate.emptyTemplate')
+        : window.t('props.gate.needTool');
       addRows('Edit', [
         { key: 'selectionAction', label: 'Tool', control: 'actions', options: [
-          { label: 'Apply tool', value: 'apply-tool', disabled: applyToolDisabled, disabledReason: window.t('props.gate.needTool') },
+          { label: 'Apply tool', value: 'apply-tool', disabled: applyToolDisabled, disabledReason: applyToolReason },
           { label: 'Delete', value: 'delete' },
         ] },
         { key: 'selectionAction', label: 'Clipboard', control: 'actions', options: [

--- a/engine/world/28-generate-panel-agent.js
+++ b/engine/world/28-generate-panel-agent.js
@@ -1891,20 +1891,27 @@
       }
       if (rowKey === 'voxelSculpt') {
         const se = window.__tinyworldSubEdit;
-        if (se) { if (value === 'remove' && se.removeVoxel) se.removeVoxel(); else if (value === 'smooth' && se.smoothVoxel) se.smoothVoxel(); }
+        let ok;
+        if (se) { if (value === 'remove' && se.removeVoxel) ok = se.removeVoxel(); else if (value === 'smooth' && se.smoothVoxel) ok = se.smoothVoxel(); }
+        // Same failure-feedback contract as the selectionAction dispatcher: a
+        // voxel sculpt that no-ops (e.g. non-voxel part) surfaces a toast rather
+        // than silently swallowing the false (feedback #5).
+        if (ok === false && typeof twToast === 'function') twToast(window.t('props.action.failed'), 'warn');
         renderSelection();
         return;
       }
       if (rowKey === 'voxelAdd') {
         const se = window.__tinyworldSubEdit;
+        let ok;
         if (se && se.addVoxel) {
-          if (value === 'x-') se.addVoxel(-1, 0, 0);
-          else if (value === 'x+') se.addVoxel(1, 0, 0);
-          else if (value === 'y-') se.addVoxel(0, -1, 0);
-          else if (value === 'y+') se.addVoxel(0, 1, 0);
-          else if (value === 'z-') se.addVoxel(0, 0, -1);
-          else if (value === 'z+') se.addVoxel(0, 0, 1);
+          if (value === 'x-') ok = se.addVoxel(-1, 0, 0);
+          else if (value === 'x+') ok = se.addVoxel(1, 0, 0);
+          else if (value === 'y-') ok = se.addVoxel(0, -1, 0);
+          else if (value === 'y+') ok = se.addVoxel(0, 1, 0);
+          else if (value === 'z-') ok = se.addVoxel(0, 0, -1);
+          else if (value === 'z+') ok = se.addVoxel(0, 0, 1);
         }
+        if (ok === false && typeof twToast === 'function') twToast(window.t('props.action.failed'), 'warn');
         renderSelection();
         return;
       }

--- a/engine/world/28-generate-panel-agent.js
+++ b/engine/world/28-generate-panel-agent.js
@@ -1308,16 +1308,21 @@
     function selectionColorOptions(options) {
       return [{ label: 'Default', value: 'default' }].concat(options || []);
     }
+    // Each material chip carries a small visual marker so the row is readable at
+    // a glance (feedback #2 — chips were text-only). `swatch` is a representative
+    // material colour and `glyph` is a tiny inline SVG (tinted via currentColor),
+    // following the SVG-glyph pattern in 19-tools-toolbar.js (TOOL_GLYPH_SVG).
+    // PROJECT RULE: SVG glyphs only — never PNG/baked icons.
     const SELECTION_MATERIAL_OPTIONS = [
-      { label: 'Default', value: 'default' },
-      { label: 'Brick', value: 'brick' },
-      { label: 'Stone', value: 'cottage-stone' },
-      { label: 'Rock', value: 'rock-face' },
-      { label: 'Slate', value: 'shingles' },
-      { label: 'Wood', value: 'cottage-wood' },
-      { label: 'Grass', value: 'cottage-grass' },
-      { label: 'Dirt', value: 'cottage-dirt' },
-      { label: 'Sand', value: 'sand' },
+      { label: 'Default', value: 'default', swatch: '#aab0b8', glyph: '<svg viewBox="0 0 16 16"><rect x="2.5" y="2.5" width="11" height="11" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.4" stroke-dasharray="2 2"/></svg>' },
+      { label: 'Brick', value: 'brick', swatch: '#b0563a', glyph: '<svg viewBox="0 0 16 16"><path d="M2 5h12M2 8h12M2 11h12M7 5v3M11 8v3M7 11v3M4 8v3" fill="none" stroke="currentColor" stroke-width="1.3"/></svg>' },
+      { label: 'Stone', value: 'cottage-stone', swatch: '#9a948a', glyph: '<svg viewBox="0 0 16 16"><path d="M2.5 4.5h5v3h-5zM8.5 4.5h5v3h-5zM2.5 8.5h5v3h-5zM8.5 8.5h5v3h-5z" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>' },
+      { label: 'Rock', value: 'rock-face', swatch: '#6f6a64', glyph: '<svg viewBox="0 0 16 16"><path d="M8 2.5 13.5 8 8 13.5 2.5 8Z M8 2.5 8 13.5 M2.5 8 13.5 8" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>' },
+      { label: 'Slate', value: 'shingles', swatch: '#5a6b7d', glyph: '<svg viewBox="0 0 16 16"><path d="M3 5.5h10M3 9.5h10M3 13.5h10" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>' },
+      { label: 'Wood', value: 'cottage-wood', swatch: '#9c6b3b', glyph: '<svg viewBox="0 0 16 16"><path d="M4 2.5v11M8 2.5v11M12 2.5v11" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>' },
+      { label: 'Grass', value: 'cottage-grass', swatch: '#4f9a43', glyph: '<svg viewBox="0 0 16 16"><path d="M5 13.5C4 9.5 3.5 7 3.5 4.5M8 13.5V4M11 13.5c1-4 1.5-6.5 1.5-9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>' },
+      { label: 'Dirt', value: 'cottage-dirt', swatch: '#6f4a2c', glyph: '<svg viewBox="0 0 16 16"><g fill="currentColor"><circle cx="4.5" cy="5" r="1.2"/><circle cx="9" cy="7" r="1.2"/><circle cx="12" cy="4.5" r="1.2"/><circle cx="6" cy="11" r="1.2"/><circle cx="11" cy="11.5" r="1.2"/></g></svg>' },
+      { label: 'Sand', value: 'sand', swatch: '#cdb267', glyph: '<svg viewBox="0 0 16 16"><path d="M2.5 6c1.5-2 3.5-2 5 0s3.5 2 6 0M2.5 11c1.5-2 3.5-2 5 0s3.5 2 6 0" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>' },
     ];
     const SELECTION_COLOR_EDITABLE_KINDS = new Set([
       'house', 'voxel-build', 'tree', 'rock', 'bridge', 'fence', 'crop',
@@ -1746,14 +1751,25 @@
         return;
       }
       if (rowKey === 'selectionAction') {
-        if (value === 'copy') copyActiveCellIntent();
-        else if (value === 'cut') cutActiveCellIntent();
-        else if (value === 'delete') deleteActiveCellIntent();
-        else if (value === 'apply-tool') applySelectedToolToSelection();
-        else if (value === 'paste') pasteClipboardAtActiveTarget();
-        else if (value === 'duplicate') duplicateActiveCellIntent();
-        else if (value === 'save-template') saveActiveSelectionTemplate();
-        else if (value === 'paste-template') pasteLatestTemplateAtActiveTarget();
+        let ok = true;
+        if (value === 'copy') ok = copyActiveCellIntent();
+        else if (value === 'cut') ok = cutActiveCellIntent();
+        else if (value === 'delete') ok = deleteActiveCellIntent();
+        else if (value === 'apply-tool') ok = applySelectedToolToSelection();
+        else if (value === 'paste') ok = pasteClipboardAtActiveTarget();
+        else if (value === 'duplicate') ok = duplicateActiveCellIntent();
+        else if (value === 'save-template') ok = saveActiveSelectionTemplate();
+        else if (value === 'paste-template') ok = pasteLatestTemplateAtActiveTarget();
+        // Surface a no-op instead of swallowing it: a chip that returns false did
+        // nothing, so tell the user why (feedback #5). Chips are also gated off in
+        // the panel, but a keyboard/route can still reach a failing action.
+        if (ok === false && typeof twToast === 'function') {
+          const reason = value === 'apply-tool' ? window.t('props.gate.needTool')
+            : value === 'paste' ? window.t('props.gate.nothingCopied')
+            : value === 'paste-template' ? window.t('props.gate.noTemplate')
+            : window.t('props.action.failed');
+          twToast(reason, 'warn');
+        }
         renderSelection();
         return;
       }
@@ -2101,20 +2117,26 @@
         { label: 'Undo', value: 'undo', disabled: !worldUndoStack.length },
         { label: 'Redo', value: 'redo', disabled: !worldRedoStack.length },
       ] });
+      // Context-gate the actions that silently no-op when their precondition is
+      // not met (feedback #5): disable the chip + show the precondition as its
+      // tooltip rather than leaving a dead button that does nothing on click.
+      const applyToolDisabled = typeof canApplySelectedToolToSelection === 'function' && !canApplySelectedToolToSelection();
+      const pasteDisabled = typeof clipboardHasContent === 'function' && !clipboardHasContent();
+      const pasteTemplateDisabled = typeof latestTemplateAvailable === 'function' && !latestTemplateAvailable();
       addRows('Edit', [
         { key: 'selectionAction', label: 'Tool', control: 'actions', options: [
-          { label: 'Apply tool', value: 'apply-tool' },
+          { label: 'Apply tool', value: 'apply-tool', disabled: applyToolDisabled, disabledReason: window.t('props.gate.needTool') },
           { label: 'Delete', value: 'delete' },
         ] },
         { key: 'selectionAction', label: 'Clipboard', control: 'actions', options: [
           { label: 'Copy', value: 'copy' },
           { label: 'Cut', value: 'cut' },
-          { label: 'Paste', value: 'paste' },
+          { label: 'Paste', value: 'paste', disabled: pasteDisabled, disabledReason: window.t('props.gate.nothingCopied') },
           { label: 'Duplicate', value: 'duplicate' },
         ] },
         { key: 'selectionAction', label: 'Templates', control: 'actions', options: [
           { label: 'Save template', value: 'save-template' },
-          { label: 'Paste latest', value: 'paste-template' },
+          { label: 'Paste latest', value: 'paste-template', disabled: pasteTemplateDisabled, disabledReason: window.t('props.gate.noTemplate') },
         ] },
       ]);
       addRow('Transform', { key: 'rotate', label: 'Rotate', control: 'rotate', options: [
@@ -2169,7 +2191,7 @@
         );
         addRows('Transform', transformRows);
         const appearanceRows = [
-          { key: 'objectMaterial', label: 'All material', currentValue: currentObjectMaterial, options: SELECTION_MATERIAL_OPTIONS },
+          { key: 'objectMaterial', label: 'All material', material: true, currentValue: currentObjectMaterial, options: SELECTION_MATERIAL_OPTIONS },
           { key: 'objectMaterialScale', label: 'All mat scale', control: 'stepper', currentValue: scaleResetValue(objectCells, 'materialTextureScale'), options: [
             { label: 'Smaller', value: 'down' },
             { label: 'Larger', value: 'up' },
@@ -2178,13 +2200,13 @@
         ];
         if (partMaterialCells.length) {
           appearanceRows.push(
-            { key: 'bodyMaterial', label: 'Body material', currentValue: currentBodyMaterial, options: SELECTION_MATERIAL_OPTIONS },
+            { key: 'bodyMaterial', label: 'Body material', material: true, currentValue: currentBodyMaterial, options: SELECTION_MATERIAL_OPTIONS },
             { key: 'bodyMaterialScale', label: 'Body mat scale', control: 'stepper', currentValue: scaleResetValue(partMaterialCells, 'bodyTextureScale'), options: [
               { label: 'Smaller', value: 'down' },
               { label: 'Larger', value: 'up' },
               { label: 'Reset', value: 'reset' },
             ] },
-            { key: 'topMaterial', label: 'Top material', currentValue: currentTopMaterial, options: SELECTION_MATERIAL_OPTIONS },
+            { key: 'topMaterial', label: 'Top material', material: true, currentValue: currentTopMaterial, options: SELECTION_MATERIAL_OPTIONS },
             { key: 'topMaterialScale', label: 'Top mat scale', control: 'stepper', currentValue: scaleResetValue(partMaterialCells, 'topTextureScale'), options: [
               { label: 'Smaller', value: 'down' },
               { label: 'Larger', value: 'up' },
@@ -2238,13 +2260,19 @@
                 { label: 'Yaw-', value: 'y-' }, { label: 'Yaw+', value: 'y+' },
                 { label: 'Roll-', value: 'z-' }, { label: 'Roll+', value: 'z+' },
               ] });
+              // Voxel sculpt/add only apply to voxel parts (key `v:x,y,z`); on a
+              // named part they silently no-op, so disable them with a tooltip
+              // when the selected part is not a voxel (feedback #5).
+              const voxelReady = !!(se.isVoxelPartSelected && se.isVoxelPartSelected());
+              const voxelReason = window.t('props.gate.voxelOnly');
               addRow('Edit', { key: 'voxelSculpt', label: 'Voxel', control: 'actions', options: [
-                { label: 'Remove', value: 'remove' }, { label: 'Smooth', value: 'smooth' },
+                { label: 'Remove', value: 'remove', disabled: !voxelReady, disabledReason: voxelReason },
+                { label: 'Smooth', value: 'smooth', disabled: !voxelReady, disabledReason: voxelReason },
               ] });
               addRow('Edit', { key: 'voxelAdd', label: 'Add voxel', control: 'move', options: [
-                { label: 'X-', value: 'x-' }, { label: 'X+', value: 'x+' },
-                { label: 'Y-', value: 'y-' }, { label: 'Y+', value: 'y+' },
-                { label: 'Z-', value: 'z-' }, { label: 'Z+', value: 'z+' },
+                { label: 'X-', value: 'x-', disabled: !voxelReady, disabledReason: voxelReason }, { label: 'X+', value: 'x+', disabled: !voxelReady, disabledReason: voxelReason },
+                { label: 'Y-', value: 'y-', disabled: !voxelReady, disabledReason: voxelReason }, { label: 'Y+', value: 'y+', disabled: !voxelReady, disabledReason: voxelReason },
+                { label: 'Z-', value: 'z-', disabled: !voxelReady, disabledReason: voxelReason }, { label: 'Z+', value: 'z+', disabled: !voxelReady, disabledReason: voxelReason },
               ] });
             }
           }
@@ -2401,7 +2429,7 @@
       };
       const chipClassForOption = (row, opt) => {
         const classes = ['selection-prop-chip'];
-        if (row.color) classes.push('color-chip');
+        if (row.color || row.material) classes.push('color-chip');
         if (row.control === 'stepper' || row.control === 'rotate' || row.control === 'move' || row.control === 'axis' || row.control === 'history') {
           classes.push('icon-chip');
         }
@@ -2490,11 +2518,33 @@
             if (opt.disabled) chip.disabled = true;
             chip.setAttribute('aria-label', row.label + ': ' + opt.label);
             chip.title = row.label + ': ' + opt.label;
+            // When a chip is gated off, surface the precondition as its tooltip
+            // (and aria-label) so the disabled state is explained, not mysterious.
+            if (opt.disabled && opt.disabledReason) {
+              chip.title = opt.disabledReason;
+              chip.setAttribute('aria-label', row.label + ': ' + opt.label + ' — ' + opt.disabledReason);
+            }
             if (row.color && opt.color) {
               const swatch = document.createElement('span');
               swatch.className = 'selection-prop-swatch';
               swatch.style.background = opt.color;
               chip.appendChild(swatch);
+            } else if (row.material && (opt.glyph || opt.swatch)) {
+              // Material marker: a small SVG glyph tinted with the material's
+              // representative colour so each chip is distinguishable at a glance.
+              const marker = document.createElement('span');
+              marker.setAttribute('aria-hidden', 'true');
+              marker.style.cssText = 'display:inline-flex;align-items:center;justify-content:center;width:14px;height:14px;flex:0 0 auto;color:' + (opt.swatch || 'currentColor') + ';';
+              if (opt.glyph) {
+                marker.innerHTML = opt.glyph;
+                const svgEl = marker.firstChild;
+                if (svgEl && svgEl.style) { svgEl.style.width = '100%'; svgEl.style.height = '100%'; }
+              } else {
+                marker.style.background = opt.swatch;
+                marker.style.borderRadius = '4px';
+                marker.style.boxShadow = 'inset 0 0 0 1px rgba(0,0,0,0.12)';
+              }
+              chip.appendChild(marker);
             }
             chip.appendChild(document.createTextNode(optionGlyph(row, opt)));
             chip.addEventListener('click', e => {

--- a/engine/world/44-sub-object-edit.js
+++ b/engine/world/44-sub-object-edit.js
@@ -323,6 +323,12 @@
     const m = /^v:(-?\d+),(-?\d+),(-?\d+)$/.exec(key || '');
     return m ? { x: +m[1], y: +m[2], z: +m[3] } : null;
   }
+  // True when the locked-in selected part is a sculptable voxel (key `v:x,y,z`).
+  // The voxel remove/smooth/add actions no-op on named (non-voxel) parts, so the
+  // panel uses this to disable those chips when they would silently fail.
+  function isVoxelPartSelected() {
+    return !!parseVoxelKey(selectedPartKey);
+  }
   function sculptMutate(fn) {
     if (subEditCellX === null) return false;
     if (typeof getWorldCell !== 'function' || typeof setCell !== 'function') return false;
@@ -530,6 +536,7 @@
     removeVoxel: removeSelectedVoxel,
     addVoxel: addVoxelFromSelected,
     smoothVoxel: smoothSelectedVoxel,
+    isVoxelPartSelected,
     setExplode,
     isExploded,
     _tickExplode: tickSubEditExplode,


### PR DESCRIPTION
Builder-mode Properties panel fixes for two pieces of feedback. Scope is limited to the panel renderer (`engine/world/28-generate-panel-agent.js`), the action handlers it calls (`20-input-place-erase.js`, `44-sub-object-edit.js`), and the i18n locale files.

## Change A — material chips show a visual marker (feedback #2)
Material option chips rendered as **text only**. Each of the 9 materials in `SELECTION_MATERIAL_OPTIONS` now carries:
- `swatch` — a representative material colour
- `glyph` — a tiny inline SVG (brick courses, stone blocks, rock facets, slate lines, wood grain, grass blades, dirt dots, sand dunes, dashed "default"), tinted via `currentColor`, following the existing `TOOL_GLYPH_SVG` pattern in `19-tools-toolbar.js`.

The chip renderer draws the marker for the three material rows (`objectMaterial` / `bodyMaterial` / `topMaterial`). **SVG glyphs only — no PNG/baked icons.** Selection behaviour is unchanged (markers are purely presentational; `value`/active state untouched).

Anchors: material opts `28-generate-panel-agent.js:1311`, material rows `:2191`, `chipClassForOption` `:2429`, chip renderer `:2518`.

## Change B — context-gate the dead buttons (feedback #5)
**Apply tool**, **Paste**, **Paste latest**, and the **voxel sculpt/add** buttons were shown unconditionally but silently no-op'd. They are now **disabled** (reusing the existing disabled-chip styling) with a tooltip stating the precondition when their underlying action would return `false`:
- Apply tool → "Pick a placeable tool first" (`canApplySelectedToolToSelection`)
- Paste → "Nothing copied yet" (`clipboardHasContent`)
- Paste latest → "No saved template yet" (`latestTemplateAvailable`)
- Voxel Remove/Smooth/Add → "Voxel parts only" (`__tinyworldSubEdit.isVoxelPartSelected`)

The three clipboard/tool predicates are read-only mirrors added beside their action handlers in `20-input-place-erase.js:163`; `isVoxelPartSelected` is added to the sub-edit export in `44-sub-object-edit.js`. The `selectionAction` dispatcher (`28-generate-panel-agent.js:1751`) now captures each handler's return and fires a `twToast` warning when an action no-ops, instead of swallowing the `false` (backstop for keyboard/other routes; chips are also gated).

**Undo/Redo are left disabled as before** — deliberately a separate feature, untouched.

Note: voxel **Add** (`:2263`) shares the exact `parseVoxelKey` precondition as voxel sculpt and was equally dead on non-voxel parts, so it is gated alongside sculpt.

## i18n
New keys `props.gate.needTool`, `props.gate.nothingCopied`, `props.gate.noTemplate`, `props.gate.voxelOnly`, `props.action.failed` added as one contiguous block at the end of `en/es/fr/zh` (no existing keys reordered, to minimise conflict with sibling PRs). `npm run i18n:check` green (304 keys × 4 locales).

## Verification
- `npm run check` / `npm run smoke` / `npm run test:unit` (129 tests) all green.
- Driven in a real browser (dev server + builder): selected an object and confirmed **27 material chips** render distinct SVG glyphs + distinct colours; **apply-tool / paste / paste-latest** disable with the correct tooltips, **Paste re-enables after a copy**, and the dispatcher **failure toast** fires ("No saved template yet").

https://claude.ai/code/session_01D7nX82maJ8BfzugxGLnBmJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Properties panel now provides localized tool/action guidance (tool needed, nothing copied, no template, voxel-only restriction, empty template, and generic “nothing to do” failures).
* **Enhancements**
  * Selection action chips (Apply tool, Paste, Paste latest) are pre-disabled with clear “why” messaging; paste availability is more accurately reflected.
  * Material options in the selection panel now show improved swatches/glyphs for clearer identification.
  * Warning feedback is shown when selection actions can’t complete.
* **Localization**
  * Added new builder-properties i18n strings for English, Spanish, French, and Simplified Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->