### PR TITLE
builder: make object shrink discoverable in radial menu (feedback #4)

### DIFF
--- a/engine/i18n/en.js
+++ b/engine/i18n/en.js
@@ -326,6 +326,8 @@
     'radial.color': 'Color',
     'radial.style': 'Style',
     'radial.size': 'Size',
+    'radial.size.shrink': 'Shrink',
+    'radial.size.grow': 'Grow',
     'radial.rotate': 'Rotate',
     'radial.more': 'More',
     'radial.move': 'Move',

--- a/engine/i18n/es.js
+++ b/engine/i18n/es.js
@@ -296,6 +296,8 @@
     'radial.color': 'Color',
     'radial.style': 'Estilo',
     'radial.size': 'Tamaño',
+    'radial.size.shrink': 'Reducir',
+    'radial.size.grow': 'Agrandar',
     'radial.rotate': 'Rotar',
     'radial.more': 'Más',
     'radial.move': 'Mover',

--- a/engine/i18n/fr.js
+++ b/engine/i18n/fr.js
@@ -296,6 +296,8 @@
     'radial.color': 'Couleur',
     'radial.style': 'Style',
     'radial.size': 'Taille',
+    'radial.size.shrink': 'Réduire',
+    'radial.size.grow': 'Agrandir',
     'radial.rotate': 'Pivoter',
     'radial.more': 'Plus',
     'radial.move': 'Déplacer',

--- a/engine/i18n/zh.js
+++ b/engine/i18n/zh.js
@@ -296,6 +296,8 @@
     'radial.color': '颜色',
     'radial.style': '样式',
     'radial.size': '大小',
+    'radial.size.shrink': '缩小',
+    'radial.size.grow': '放大',
     'radial.rotate': '旋转',
     'radial.more': '更多',
     'radial.move': '移动',

--- a/engine/world/33-radial-menu.js
+++ b/engine/world/33-radial-menu.js
@@ -17,6 +17,8 @@
       back: '<path d="m15 18-6-6 6-6"/>',
       edit: '<path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/>',
       explode: '<path d="M12 2v5"/><path d="M12 17v5"/><path d="M2 12h5"/><path d="M17 12h5"/><path d="m4.9 4.9 3.5 3.5"/><path d="m15.6 15.6 3.5 3.5"/><path d="m19.1 4.9-3.5 3.5"/><path d="m8.4 15.6-3.5 3.5"/>',
+      minus: '<path d="M5 12h14"/>',
+      plus: '<path d="M5 12h14"/><path d="M12 5v14"/>',
     };
 
     // Root ring — angles in screen degrees (0=right, 90=down, 270=up). The top
@@ -24,7 +26,7 @@
     const ROOT = [
       { id: 'color',     label: window.t('radial.color'),     icon: 'palette',  angle: 225, submenu: 'color', posType: 'primary' },
       { id: 'style',     label: window.t('radial.style'),     icon: 'sparkles', angle: 315, action: 'style', posType: 'primary' },
-      { id: 'size',      label: window.t('radial.size'),      icon: 'size',     angle: 0,   action: 'size', posType: 'primary' },
+      { id: 'size',      label: window.t('radial.size'),      icon: 'size',     angle: 0,   submenu: 'size', posType: 'primary' },
       { id: 'rotate',    label: window.t('radial.rotate'),    icon: 'rotate',   angle: 45,  action: 'rotate', posType: 'primary' },
       { id: 'more',      label: window.t('radial.more'),      icon: 'more',     angle: 90,  action: 'more', posType: 'primary' },
       { id: 'move',      label: window.t('radial.move'),      icon: 'move',     angle: 135, action: 'move', posType: 'primary' },
@@ -248,6 +250,26 @@
           btn.addEventListener('click', e => { e.stopPropagation(); flash(btn); if (se && se.recolorPart) se.recolorPart(c.hex); });
           root.appendChild(btn);
         });
+      } else if (level === 'size') {
+        // Two-way scale for the whole selected object — explicit, labelled, no
+        // hidden Shift modifier. Reuses scaleSelectedBoardObject() (universal:
+        // basic kinds, buildings, voxel/asset-templates). 0.87 ≈ 1/1.15, so a
+        // Shrink undoes a Grow tap-for-tap.
+        const its = [
+          { id: 'shrink', label: window.t('radial.size.shrink'), icon: 'minus', factor: 0.87 },
+          { id: 'grow',   label: window.t('radial.size.grow'),   icon: 'plus',  factor: 1.15 },
+        ];
+        const angles = arcAngles(its.length);
+        its.forEach((it, i) => {
+          const btn = makeBtn('', iconHtml(it.icon) + '<span class="radial-label">' + it.label + '</span>', angles[i], i + 1, 'primary');
+          btn.title = it.label;
+          btn.addEventListener('click', e => {
+            e.stopPropagation();
+            flash(btn);
+            if (typeof scaleSelectedBoardObject === 'function') scaleSelectedBoardObject(it.factor);
+          });
+          root.appendChild(btn);
+        });
       } else if (level === 'color') {
         const angles = arcAngles(COLORS.length);
         COLORS.forEach((c, i) => {
@@ -309,10 +331,6 @@
             const sel = window.__tinyworldSelection;
             if (sel && typeof sel.rotate === 'function') sel.rotate(Math.PI / 2);
             else if (typeof rotateSelectedCells === 'function') rotateSelectedCells(Math.PI / 2);
-          }
-        } else if (id === 'size') {
-          if (typeof scaleSelectedBoardObject === 'function') {
-            scaleSelectedBoardObject((window.event && window.event.shiftKey) ? 0.87 : 1.15);
           }
         } else if (id === 'more' || id === 'style') {
           openSelectionPanel();


### PR DESCRIPTION
## Feedback #4 — "Size only grows, no way to shrink"

In-app investigation showed this is a **discoverability** problem, not a missing feature. A working shrink exists for every object type, but:

- The prominent radial **Size** button **grew** on a plain click (`x1.15`) and only **shrank** via a **hidden, unlabelled Shift+click** (`x0.87`) — `scaleSelectedBoardObject` in `engine/world/33-radial-menu.js`.
- The real bidirectional Scale control is buried under radial → **Edit** → **Transform** tab, which most users never find.

So users perceived "only grows."

## Before / After

- **Before:** tap Size → grow. Shrink required a secret `Shift`+click with no on-screen hint.
- **After:** tap **Size** → a clearly-labelled two-way sub-ring appears with **Grow (+)** and **Shrink (−)**, both always visible. **No modifier key required.** Back returns to the root ring.

## Approach

Chose option (b) from the brief: keep a single root **Size** entry, but make it a submenu that reveals an explicit `−`/`+` sub-ring — this fits the radial menu's existing interaction model and directly mirrors the existing `edit-scale` sub-ring (`−`/`+`). It reuses the universal `scaleSelectedBoardObject(factor)` logic (clamped 0.25–24, works for basic kinds, buildings, and voxel/asset-templates alike); `0.87 ≈ 1/1.15` so a Shrink undoes a Grow tap-for-tap. The now-dead hidden-Shift branch in `runAction('size')` was removed.

All new user-facing text added via i18n across **all 4 locales** (en/es/fr/zh): `radial.size.shrink`, `radial.size.grow`. No existing keys reordered.

## Verification (real browser, on-screen radial buttons only — no Shift)

Selected an object, opened **Size**, and clicked the actual rendered **Grow**/**Shrink** buttons. Measured both `objectScale` and the live mesh bounding-box size:

| Object type | start | Grow | Shrink | bbox start → shrunk |
|---|---|---|---|---|
| house (building) | 1.00 | 1.32 | **0.76** | 2.10 → **1.59** |
| voxel-build (asset-template) | 0.83 | 0.95 | **0.63** | 0.466 → **0.353** |
| rock (basic kind) | 1.00 | 1.15 | **0.76** | 2.884 → **2.183** |

Shrink is visibly smaller in the 3D view (bbox shrinks below the starting size) for all three types. No console errors. Test mutations were reset; the in-browser world state was not persisted.

`npm run check` and `npm run i18n:check` both green (301 keys × 4 locales).

https://claude.ai/code/session_01EpNuxefYr8C2G3xj9fYpxG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The radial menu now features a dedicated Size submenu with explicit Shrink and Grow controls, providing users with a more intuitive way to adjust object dimensions. This replaces the previous single size action. Supported languages include English, Spanish, French, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->