### PR TITLE
admin: account-based roadmap/features auth (retire shared-secret for prod) [Phase 0]

### DIFF
--- a/features.html
+++ b/features.html
@@ -285,6 +285,40 @@
 .admin-status-select.badge-planned { background:#e8f0fe; color:#1a4fcf; border-color:#b3cafd; }
 .admin-status-select.badge-done    { background:#e6f4ea; color:#1a6632; border-color:#b7dfbe; }
 .admin-status-select.badge-rejected{ background:#f5f0f0; color:#8a2a20; border-color:#e0bab7; }
+
+/* WAVE launch taxonomy — public filter, per-item badge, admin set control. */
+.wave-filter {
+  font: inherit;
+  font-size: 13px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border, #d6dae5);
+  background: #fff;
+  color: var(--ink, #1a1d27);
+  cursor: pointer;
+}
+.wave-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent, #ffb020);
+  color: #1a1205;
+  border: 1px solid rgba(0,0,0,0.08);
+}
+.admin-wave-select {
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid #e6c98a;
+  background: #fff7e6;
+  color: #6a4a00;
+  cursor: pointer;
+}
 </style>
 </head>
 <body class="landing-page">
@@ -322,6 +356,12 @@
           <button class="filter-btn" data-status="done">Done</button>
           <button class="filter-btn" data-status="all">All</button>
         </div>
+        <select class="wave-filter" id="wave-filter" aria-label="Filter by wave">
+          <option value="">All waves</option>
+          <option value="WAVE1">WAVE1</option>
+          <option value="WAVE2">WAVE2</option>
+          <option value="WAVE3">WAVE3</option>
+        </select>
         <button class="suggest-btn" id="suggest-open-btn">
           <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
           Suggest a feature
@@ -373,6 +413,7 @@
   (function() {
     const MIN_BALANCE = 100;
     const STATUS_OPTS = ['open','planned','done','rejected'];
+    const WAVES = ['WAVE1','WAVE2','WAVE3'];
 
     const FALLBACK_SUGGESTIONS = [
       { id: -1, title: 'NPC companions', description: 'Add AI-driven NPCs that wander your world and interact with players — merchants, wanderers, quest-givers.', wallet: 'admin', vote_weight: 0, status: 'open', created_at: '' },
@@ -415,6 +456,7 @@
       try { localStorage.removeItem('twAdminSecret'); } catch (_) {}
     }
     let currentFilter = 'open';
+    let currentWave = ''; // '' = all waves; otherwise WAVE1/WAVE2/WAVE3
     let suggestions = [];
     let myVotes = {};
     // The server's last verdict on admin authority (verified account email on prod,
@@ -515,7 +557,8 @@
 
     // ---- API ----
     async function loadSuggestions(status) {
-      const r = await fetch('/api/features?status=' + encodeURIComponent(status), { headers: await authHeaders(false), credentials: 'same-origin' });
+      const waveQ = currentWave ? '&wave=' + encodeURIComponent(currentWave) : '';
+      const r = await fetch('/api/features?status=' + encodeURIComponent(status) + waveQ, { headers: await authHeaders(false), credentials: 'same-origin' });
       const d = await r.json();
       serverSaysAdmin = !!d.admin; // server's verdict: verified admin email OR local dev secret
       return d.suggestions || [];
@@ -557,6 +600,17 @@
       return d.suggestion;
     }
 
+    // Admin-only: set/clear a suggestion's launch wave ('none' clears it).
+    async function patchWave(id, wave) {
+      const r = await fetch('/api/features?id=' + id, {
+        method: 'PATCH', headers: await authHeaders(true), credentials: 'same-origin',
+        body: JSON.stringify({ wave }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d.error || 'Update failed');
+      return d.suggestion;
+    }
+
     // ---- render ----
     function fmtScore(n) {
       if (n >= 1000000) return (n/1000000).toFixed(1).replace(/\.0$/,'') + 'M';
@@ -591,6 +645,13 @@
               ${STATUS_OPTS.map(o => `<option value="${o}"${o===s.status?' selected':''}>${o}</option>`).join('')}
             </select>`
           : `<span class="feature-status-badge ${badgeClass(s.status)}">${esc(s.status)}</span>`;
+        // WAVE label: admins get a set/clear picker; everyone else sees a badge (or nothing).
+        const waveCell = adminMode
+          ? `<select class="admin-wave-select" data-wave-id="${s.id}" aria-label="Set wave">
+              <option value="none"${!WAVES.includes(s.wave)?' selected':''}>No wave</option>
+              ${WAVES.map(w => `<option value="${w}"${w===s.wave?' selected':''}>${w}</option>`).join('')}
+            </select>`
+          : (WAVES.includes(s.wave) ? `<span class="wave-badge">${esc(s.wave)}</span>` : '');
 
         return `<div class="feature-item" data-id="${s.id}">
   <div class="vote-col">
@@ -603,6 +664,7 @@
     ${s.description ? `<p>${esc(s.description)}</p>` : ''}
     <div class="feature-meta">
       <span class="feature-wallet">${esc(fmtWallet(s.wallet))}</span>
+      ${waveCell}
     </div>
   </div>
   ${adminStatusPicker}
@@ -651,6 +713,25 @@
           } catch (err) { alert(err.message); }
         });
       });
+
+      // admin wave pickers
+      el.querySelectorAll('.admin-wave-select').forEach(sel => {
+        sel.addEventListener('change', async () => {
+          const id = Number(sel.dataset.waveId);
+          try {
+            const updated = await patchWave(id, sel.value);
+            if (updated) {
+              const idx = suggestions.findIndex(s => s.id === id);
+              if (idx >= 0) suggestions[idx] = updated;
+              // If a wave filter is active and this item no longer matches, drop it.
+              if (currentWave && updated.wave !== currentWave) {
+                suggestions = suggestions.filter(s => s.id !== id);
+              }
+              renderList();
+            }
+          } catch (err) { alert(err.message); }
+        });
+      });
     }
 
     // ---- filter ----
@@ -663,6 +744,14 @@
         suggestions = await loadSuggestions(currentFilter).catch(() => []);
         renderList();
       });
+    });
+
+    // ---- wave filter ----
+    document.getElementById('wave-filter').addEventListener('change', async (e) => {
+      currentWave = e.target.value;
+      document.getElementById('features-list').innerHTML = '<div class="features-empty">Loading...</div>';
+      suggestions = await loadSuggestions(currentFilter).catch(() => []);
+      renderList();
     });
 
     // ---- suggest modal ----

--- a/features.html
+++ b/features.html
@@ -10,6 +10,25 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300..700&display=swap" />
 <link rel="stylesheet" href="styles/landing.css" />
+<script>
+  // Resolve once the Netlify Identity auth module has loaded (or time out), so the
+  // admin-by-account check can read window.TinyWorldAuth before booting.
+  (function featuresAuthBootstrap() {
+    window.__tinyworldAuthReady = new Promise(function (resolve) {
+      window.__resolveTinyWorldAuthReady = resolve;
+      setTimeout(function () { resolve(false); }, 2500);
+    });
+  })();
+</script>
+<script id="tinyworld-auth-importmap" type="importmap">
+{
+  "imports": {
+    "@netlify/identity": "./vendor/netlify/identity.js",
+    "gotrue-js": "./vendor/netlify/gotrue.js"
+  }
+}
+</script>
+<script type="module" src="vendor/tinyworld-auth.js"></script>
 <style>
 /* ---- features page ---- */
 .features-list-section { width: min(1200px, calc(100% - 48px)); margin: 0 auto; padding: 8px 0 64px; }
@@ -398,6 +417,9 @@
     let currentFilter = 'open';
     let suggestions = [];
     let myVotes = {};
+    // The server's last verdict on admin authority (verified account email on prod,
+    // or the localhost-only dev secret). Set as a side effect of loadSuggestions().
+    let serverSaysAdmin = false;
 
     // ---- admin toggle — Ctrl+Shift+A (local dev only) ----
     document.addEventListener('keydown', async e => {
@@ -437,8 +459,39 @@
       const _ab = document.getElementById('features-admin-bar'); if (_ab) _ab.hidden = !adminMode;
     }
 
-    function adminHeaders() {
-      return { 'Content-Type': 'application/json', 'x-admin-secret': adminSecret };
+    // Bearer token for the signed-in account, if any. Mirrors scripts/admin-users.js:
+    // Identity JWT first, then wallet-session / nf_jwt cookie fallbacks. The server
+    // decides admin authority from the verified email this token resolves to.
+    function walletToken() {
+      try { return localStorage.getItem('tinyworld:auth:wallet-session.v1') || ''; } catch (_) { return ''; }
+    }
+    function cookieToken() {
+      try { const m = document.cookie.match(/(?:^|; )nf_jwt=([^;]*)/); return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
+    }
+    async function accessToken() {
+      try {
+        const A = window.TinyWorldAuth;
+        if (A && typeof A.getUser === 'function') {
+          const u = await A.getUser();
+          if (u && typeof u.jwt === 'function') {
+            const jwt = await Promise.resolve(u.jwt()).catch(() => '');
+            return jwt || (u.token && u.token.access_token) || walletToken() || cookieToken() || '';
+          }
+          return (u && u.token && u.token.access_token) || walletToken() || cookieToken() || '';
+        }
+      } catch (_) {}
+      return walletToken() || cookieToken() || '';
+    }
+
+    // Headers for authenticated reads/writes: the account bearer token (prod path)
+    // plus the localhost-only dev secret when present. Same-origin fetch sets Origin
+    // automatically, satisfying the server's CSRF guard.
+    async function authHeaders(withJson) {
+      const headers = withJson ? { 'Content-Type': 'application/json' } : {};
+      const token = await accessToken();
+      if (token) headers['Authorization'] = 'Bearer ' + token;
+      if (adminSecret) headers['x-admin-secret'] = adminSecret;
+      return headers;
     }
 
     // ---- phantom wallet ----
@@ -462,17 +515,18 @@
 
     // ---- API ----
     async function loadSuggestions(status) {
-      const r = await fetch('/api/features?status=' + encodeURIComponent(status));
+      const r = await fetch('/api/features?status=' + encodeURIComponent(status), { headers: await authHeaders(false), credentials: 'same-origin' });
       const d = await r.json();
+      serverSaysAdmin = !!d.admin; // server's verdict: verified admin email OR local dev secret
       return d.suggestions || [];
     }
 
     async function submitSuggestion(title, description) {
-      const headers = adminMode ? adminHeaders() : { 'Content-Type': 'application/json' };
+      const headers = await authHeaders(true);
       const effectiveWallet = adminMode ? 'admin' : wallet;
       const effectiveBalance = adminMode ? MIN_BALANCE : coinBalance;
       const r = await fetch('/api/features', {
-        method: 'POST', headers,
+        method: 'POST', headers, credentials: 'same-origin',
         body: JSON.stringify({ wallet: effectiveWallet, coinBalance: effectiveBalance, title, description }),
       });
       const d = await r.json();
@@ -481,11 +535,11 @@
     }
 
     async function castVote(suggestionId, vote) {
-      const headers = adminMode ? adminHeaders() : { 'Content-Type': 'application/json' };
+      const headers = await authHeaders(true);
       const effectiveWallet = adminMode ? 'admin' : wallet;
       const effectiveBalance = adminMode ? MIN_BALANCE : coinBalance;
       const r = await fetch('/api/features?action=vote', {
-        method: 'POST', headers,
+        method: 'POST', headers, credentials: 'same-origin',
         body: JSON.stringify({ wallet: effectiveWallet, coinBalance: effectiveBalance, suggestionId, vote }),
       });
       const d = await r.json();
@@ -495,7 +549,7 @@
 
     async function patchStatus(id, status) {
       const r = await fetch('/api/features?id=' + id, {
-        method: 'PATCH', headers: adminHeaders(),
+        method: 'PATCH', headers: await authHeaders(true), credentials: 'same-origin',
         body: JSON.stringify({ status }),
       });
       const d = await r.json();
@@ -679,23 +733,25 @@
 
     // ---- boot ----
     (async () => {
-      // A stored secret only grants admin if the server actually accepts it.
-      if (adminSecret) {
-        const ok = await validateSecret(adminSecret);
-        if (!ok) {
-          adminSecret = '';
-          try { sessionStorage.removeItem('twAdminSecret'); } catch (_) {}
-          try { localStorage.removeItem('twAdminSecret'); } catch (_) {}
-          adminMode = false;
-        }
-      }
-      renderAdminBar();
+      // Wait for the Identity auth module so accessToken() can read a live session
+      // on the first load (prod account-based admin), then ask the server.
+      try { await window.__tinyworldAuthReady; } catch (_) {}
       try {
-        const s = await loadSuggestions('open');
+        const s = await loadSuggestions('open'); // sets serverSaysAdmin
         suggestions = s.length ? s : FALLBACK_SUGGESTIONS;
       } catch (_) {
         suggestions = FALLBACK_SUGGESTIONS;
       }
+      // Clear a stale local dev secret the server rejected.
+      if (adminSecret && !serverSaysAdmin) {
+        adminSecret = '';
+        try { sessionStorage.removeItem('twAdminSecret'); } catch (_) {}
+        try { localStorage.removeItem('twAdminSecret'); } catch (_) {}
+      }
+      // Authority is the server's verdict — verified admin email (works on prod) OR
+      // the localhost-only dev secret. No client-side host gate.
+      adminMode = serverSaysAdmin;
+      renderAdminBar();
       renderList();
     })();
   })();

--- a/netlify/database/migrations/20260618000000_wave_labels.sql
+++ b/netlify/database/migrations/20260618000000_wave_labels.sql
@@ -1,0 +1,19 @@
+-- WAVE launch taxonomy (Phase 2): tag roadmap milestones and feature suggestions
+-- with a launch-wave label (WAVE1 / WAVE2 / WAVE3; NULL = none). WAVE1 is the
+-- launch wave tied to the countdown target. Additive and idempotent.
+--
+-- roadmap_milestones / feature_suggestions are created LAZILY by their Netlify
+-- functions (ensureTable/ensureTables in roadmap.mjs / features.mjs), not by an
+-- earlier migration — so a plain ALTER would fail on a database where the
+-- function has never run yet. Guard on table existence: this migration adds the
+-- column where the table already exists (e.g. prod), and the functions' own
+-- idempotent ALTER adds it on first call for fresh databases.
+DO $$
+BEGIN
+  IF to_regclass('public.roadmap_milestones') IS NOT NULL THEN
+    ALTER TABLE roadmap_milestones ADD COLUMN IF NOT EXISTS wave TEXT;
+  END IF;
+  IF to_regclass('public.feature_suggestions') IS NOT NULL THEN
+    ALTER TABLE feature_suggestions ADD COLUMN IF NOT EXISTS wave TEXT;
+  END IF;
+END $$;

--- a/netlify/functions/features.mjs
+++ b/netlify/functions/features.mjs
@@ -9,6 +9,15 @@ export const config = { path: '/api/features' };
 // in a future step when Solana RPC is wired; for now the client enforces it).
 const MIN_COIN_BALANCE = 100;
 
+// WAVE launch taxonomy: constrain the label server-side to a small known set so
+// arbitrary client strings can never be stored or filtered on. Anything else
+// (incl. 'none'/'') normalizes to null = no wave.
+const WAVES = ['WAVE1', 'WAVE2', 'WAVE3'];
+function normalizeWave(value) {
+  const s = String(value == null ? '' : value).trim().toUpperCase();
+  return WAVES.includes(s) ? s : null;
+}
+
 // Curated idea pool harvested from the design docs, the Skybound roadmap
 // (plans/ROADMAP-skybound.md), the fork-improvement harvest, and existing
 // infra seams. These are intentionally broad — the team filters/triages them on
@@ -82,6 +91,10 @@ async function ensureTables(sql) {
       updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `;
+  // WAVE launch label (Phase 2). Idempotent ALTER so fresh and older databases
+  // — including prod where migrations lag — gain the column before any write
+  // references it. Mirrors migration 20260618000000_wave_labels.sql.
+  await sql`ALTER TABLE feature_suggestions ADD COLUMN IF NOT EXISTS wave TEXT`;
   await sql`
     CREATE TABLE IF NOT EXISTS feature_votes (
       id            SERIAL PRIMARY KEY,
@@ -103,6 +116,7 @@ function suggestionDto(row) {
     wallet:       row.wallet,
     vote_weight:  Number(row.vote_weight) || 0,
     status:       row.status,
+    wave:         row.wave || null,
     created_at:   row.created_at,
   };
 }
@@ -153,9 +167,12 @@ export default async function featuresFunction(request) {
       await seedSuggestions(sql);
       const url = new URL(request.url);
       const status = url.searchParams.get('status') || 'open';
+      // Public wave filter: ?wave=WAVE1. Unknown values normalize to null = no filter.
+      const wave = normalizeWave(url.searchParams.get('wave'));
       const rows = await sql`
         SELECT * FROM feature_suggestions
         WHERE ${status === 'all' ? sql`TRUE` : sql`status = ${status}`}
+          AND ${wave ? sql`wave = ${wave}` : sql`TRUE`}
         ORDER BY vote_weight DESC, created_at DESC
         LIMIT 200
       `;
@@ -248,11 +265,18 @@ export default async function featuresFunction(request) {
     if (!id) return errorResponse('id is required', 400, origin);
     const body = await readJson(request);
     const status = ['open','planned','done','rejected'].includes(body && body.status) ? body.status : null;
-    if (!status) return errorResponse('valid status is required', 400, origin);
+    // wave is set/cleared explicitly: a provided 'none'/'' normalizes to null (a real
+    // clear) and bypasses COALESCE, which would treat null as "leave unchanged".
+    const waveProvided = !!(body && Object.prototype.hasOwnProperty.call(body, 'wave'));
+    const wave = waveProvided ? normalizeWave(body.wave) : null;
+    if (!status && !waveProvided) return errorResponse('status or wave is required', 400, origin);
     try {
       const sql = getSql();
       const rows = await sql`
-        UPDATE feature_suggestions SET status = ${status}, updated_at = NOW()
+        UPDATE feature_suggestions SET
+          status = COALESCE(${status}, status),
+          wave = CASE WHEN ${waveProvided} THEN ${wave} ELSE wave END,
+          updated_at = NOW()
         WHERE id = ${id} RETURNING *
       `;
       if (!rows.length) return errorResponse('Not found', 404, origin);

--- a/netlify/functions/features.mjs
+++ b/netlify/functions/features.mjs
@@ -1,6 +1,7 @@
 import { getSql, isDatabaseUnavailable } from './lib/db.mjs';
-import { corsResponse, errorResponse, jsonResponse, readJson } from './lib/http.mjs';
-import { requireAuthUser } from './lib/auth.mjs';
+import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
+import { getAuthUser, requireAuthUser } from './lib/auth.mjs';
+import { isWorldAdminEmail } from './lib/worlds.mjs';
 
 export const config = { path: '/api/features' };
 
@@ -116,8 +117,21 @@ function envValue(name) {
   return process.env[name] || '';
 }
 
-function isAdmin(request) {
-  // Admin actions are LOCAL-DEV ONLY. Never grant admin on a non-local host.
+// Admin authority is decided SERVER-SIDE from a verified account session.
+// Prod path: the requester's Netlify Identity (or wallet) session resolves to an
+// email on the world-admin allowlist (isWorldAdminEmail). No host check, so it
+// works on production. Authority is the verified email only — never a client flag.
+async function isAdmin(request) {
+  try {
+    const user = await getAuthUser(request);
+    if (user && isWorldAdminEmail(user.email)) return true;
+  } catch (_) {}
+  return isLocalSecretAdmin(request);
+}
+
+// LOCALHOST-ONLY DEV FALLBACK: the legacy shared secret. Never grants admin off
+// localhost — the host check fails closed on every non-local request.
+function isLocalSecretAdmin(request) {
   try {
     const host = (request.headers.get('host') || '').toLowerCase();
     if (!/^(localhost|127\.0\.0\.1)(:\d+)?$/.test(host)) return false;
@@ -145,7 +159,7 @@ export default async function featuresFunction(request) {
         ORDER BY vote_weight DESC, created_at DESC
         LIMIT 200
       `;
-      return jsonResponse({ suggestions: rows.map(suggestionDto), admin: isAdmin(request) }, origin);
+      return jsonResponse({ suggestions: rows.map(suggestionDto), admin: await isAdmin(request) }, origin);
     } catch (err) {
       if (isDatabaseUnavailable(err)) return jsonResponse({ suggestions: [], source: 'unavailable' }, origin);
       console.error('[features] GET error:', err);
@@ -155,7 +169,12 @@ export default async function featuresFunction(request) {
 
   // ---- POST — submit a suggestion (requires wallet auth or admin) ----
   if (request.method === 'POST') {
-    const isAdminReq = isAdmin(request);
+    const isAdminReq = await isAdmin(request);
+    // CSRF / same-origin guard, scoped to the admin-authenticated path only: admin
+    // sessions are cookie-ambient, so a cross-site POST riding the admin cookie must
+    // be rejected. The public wallet vote/suggest path is left untouched (Phase 3
+    // tightens that separately).
+    if (isAdminReq && !sameOriginWriteGuard(request)) return errorResponse('Forbidden', 403, origin);
     const url = new URL(request.url);
     const action = url.searchParams.get('action') || 'suggest';
 
@@ -222,7 +241,8 @@ export default async function featuresFunction(request) {
 
   // ---- PATCH — admin status update ----
   if (request.method === 'PATCH') {
-    if (!isAdmin(request)) return errorResponse('Forbidden', 403, origin);
+    if (!(await isAdmin(request))) return errorResponse('Forbidden', 403, origin);
+    if (!sameOriginWriteGuard(request)) return errorResponse('Forbidden', 403, origin);
     const url = new URL(request.url);
     const id = Number(url.searchParams.get('id'));
     if (!id) return errorResponse('id is required', 400, origin);

--- a/netlify/functions/roadmap.mjs
+++ b/netlify/functions/roadmap.mjs
@@ -40,6 +40,15 @@ function envValue(name) {
   return process.env[name] || '';
 }
 
+// WAVE launch taxonomy: constrain the label server-side to a small known set so
+// arbitrary client strings can never be stored. Anything else (incl. 'none'/'')
+// normalizes to null = no wave.
+const WAVES = ['WAVE1', 'WAVE2', 'WAVE3'];
+function normalizeWave(value) {
+  const s = String(value == null ? '' : value).trim().toUpperCase();
+  return WAVES.includes(s) ? s : null;
+}
+
 // Admin authority is decided SERVER-SIDE from a verified account session.
 // Prod path: the requester's Netlify Identity (or wallet) session resolves to an
 // email on the world-admin allowlist (isWorldAdminEmail). This branch has NO host
@@ -79,6 +88,10 @@ async function ensureTable(sql) {
       updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `;
+  // WAVE launch label (Phase 2). Idempotent ALTER so fresh and older databases
+  // — including prod where migrations lag — gain the column before any write
+  // references it. Mirrors migration 20260618000000_wave_labels.sql.
+  await sql`ALTER TABLE roadmap_milestones ADD COLUMN IF NOT EXISTS wave TEXT`;
 }
 
 async function seedTable(sql) {
@@ -118,6 +131,7 @@ function milestoneDto(row) {
     title:       row.title,
     description: row.description,
     sort_order:  row.sort_order,
+    wave:        row.wave || null,
   };
 }
 
@@ -155,13 +169,14 @@ export default async function roadmapFunction(request) {
     const description = String(body && body.description || '').slice(0, 1000).trim();
     const status = ['done', 'active', 'planned'].includes(body && body.status) ? body.status : 'planned';
     const sort_order = Number.isFinite(Number(body && body.sort_order)) ? Math.round(Number(body.sort_order)) : 0;
+    const wave = normalizeWave(body && body.wave);
     if (!title) return errorResponse('title is required', 400, origin);
     try {
       const sql = getSql();
       await ensureTable(sql);
       const rows = await sql`
-        INSERT INTO roadmap_milestones (status, title, description, sort_order)
-        VALUES (${status}, ${title}, ${description}, ${sort_order})
+        INSERT INTO roadmap_milestones (status, title, description, sort_order, wave)
+        VALUES (${status}, ${title}, ${description}, ${sort_order}, ${wave})
         RETURNING *
       `;
       return jsonResponse({ milestone: milestoneDto(rows[0]) }, origin, 201);
@@ -182,7 +197,12 @@ export default async function roadmapFunction(request) {
     if (body && body.description != null) updates.description = String(body.description).slice(0, 1000).trim();
     if (body && body.status != null && ['done', 'active', 'planned'].includes(body.status)) updates.status = body.status;
     if (body && body.sort_order != null && Number.isFinite(Number(body.sort_order))) updates.sort_order = Math.round(Number(body.sort_order));
-    if (!Object.keys(updates).length) return errorResponse('No fields to update', 400, origin);
+    // wave is set/cleared explicitly: a provided value of 'none'/'' normalizes to
+    // null (a real clear), so it must bypass COALESCE — which would otherwise treat
+    // null as "leave unchanged". Tracked separately so a wave-only PATCH is allowed.
+    const waveProvided = !!(body && Object.prototype.hasOwnProperty.call(body, 'wave'));
+    const wave = waveProvided ? normalizeWave(body.wave) : null;
+    if (!Object.keys(updates).length && !waveProvided) return errorResponse('No fields to update', 400, origin);
     try {
       const sql = getSql();
       const rows = await sql`
@@ -192,6 +212,7 @@ export default async function roadmapFunction(request) {
           description = COALESCE(${updates.description ?? null}, description),
           status      = COALESCE(${updates.status ?? null}, status),
           sort_order  = COALESCE(${updates.sort_order ?? null}, sort_order),
+          wave        = CASE WHEN ${waveProvided} THEN ${wave} ELSE wave END,
           updated_at  = NOW()
         WHERE id = ${id}
         RETURNING *

--- a/netlify/functions/roadmap.mjs
+++ b/netlify/functions/roadmap.mjs
@@ -1,5 +1,7 @@
 import { getSql, isDatabaseUnavailable, isMissingRelation } from './lib/db.mjs';
-import { corsResponse, errorResponse, jsonResponse, readJson } from './lib/http.mjs';
+import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
+import { getAuthUser } from './lib/auth.mjs';
+import { isWorldAdminEmail } from './lib/worlds.mjs';
 
 export const config = { path: '/api/roadmap' };
 
@@ -38,10 +40,23 @@ function envValue(name) {
   return process.env[name] || '';
 }
 
-function isAdmin(request) {
-  // Admin actions are LOCAL-DEV ONLY. Never grant admin on a non-local host —
-  // this keeps the admin toolbar off production for every client, including
-  // cached browsers that still hold a stored secret.
+// Admin authority is decided SERVER-SIDE from a verified account session.
+// Prod path: the requester's Netlify Identity (or wallet) session resolves to an
+// email on the world-admin allowlist (isWorldAdminEmail). This branch has NO host
+// check, so it works on production. Authority is the verified email only — never a
+// client-supplied email or admin flag.
+async function isAdmin(request) {
+  try {
+    const user = await getAuthUser(request);
+    if (user && isWorldAdminEmail(user.email)) return true;
+  } catch (_) {}
+  return isLocalSecretAdmin(request);
+}
+
+// LOCALHOST-ONLY DEV FALLBACK: the legacy shared secret. Kept so local roadmap
+// editing keeps working without an Identity session, but it can NEVER grant admin
+// off localhost — the host check fails closed on every non-local request.
+function isLocalSecretAdmin(request) {
   try {
     const host = (request.headers.get('host') || '').toLowerCase();
     if (!/^(localhost|127\.0\.0\.1)(:\d+)?$/.test(host)) return false;
@@ -117,7 +132,7 @@ export default async function roadmapFunction(request) {
       await ensureTable(sql);
       await seedTable(sql);
       const rows = await sql`SELECT * FROM roadmap_milestones ORDER BY sort_order ASC, id ASC LIMIT 500`;
-      return jsonResponse({ milestones: rows.map(milestoneDto), source: 'db', admin: isAdmin(request) }, origin);
+      return jsonResponse({ milestones: rows.map(milestoneDto), source: 'db', admin: await isAdmin(request) }, origin);
     } catch (err) {
       if (isDatabaseUnavailable(err) || isMissingRelation(err, 'roadmap_milestones')) {
         return jsonResponse({ milestones: FALLBACK_MILESTONES, source: 'fallback' }, origin);
@@ -128,7 +143,10 @@ export default async function roadmapFunction(request) {
   }
 
   // ---- writes require admin ----
-  if (!isAdmin(request)) return errorResponse('Forbidden', 403, origin);
+  if (!(await isAdmin(request))) return errorResponse('Forbidden', 403, origin);
+  // CSRF / same-origin guard: account sessions are cookie-ambient, so a verified
+  // admin's browser could be driven cross-site. Reject writes that aren't same-origin.
+  if (!sameOriginWriteGuard(request)) return errorResponse('Forbidden', 403, origin);
 
   // ---- POST — create ----
   if (request.method === 'POST') {

--- a/roadmap.html
+++ b/roadmap.html
@@ -384,6 +384,21 @@
 
 /* roadmap status badges (reused inside modal) */
 
+/* WAVE launch badge — small accent pill shown on cards + in the detail modal. */
+.wave-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent, #ffb020);
+  color: #1a1205;
+  border: 1px solid rgba(0,0,0,0.08);
+  vertical-align: middle;
+}
+.kanban-card .wave-badge { margin-top: 8px; }
+
 /* responsive */
 @media (max-width: 780px) {
   .kanban-board {
@@ -512,8 +527,13 @@
     }
 
     // ---- Helpers ----
+    const WAVES = ['WAVE1', 'WAVE2', 'WAVE3'];
     function esc(s) {
       return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+    // WAVE launch label pill, or '' when the milestone has no wave.
+    function waveBadge(w) {
+      return WAVES.includes(w) ? `<span class="wave-badge">${esc(w)}</span>` : '';
     }
 
     // Bearer token for the signed-in account, if any. Mirrors scripts/admin-users.js:
@@ -617,6 +637,7 @@
                 <div class="kanban-card-body">
                   <h3>${esc(m.title)}</h3>
                   ${m.description ? `<p>${esc(m.description)}</p>` : ''}
+                  ${waveBadge(m.wave)}
                 </div>
               </div>
             </div>`;
@@ -624,6 +645,7 @@
           return `<div class="kanban-card" data-id="${m.id}" tabindex="0" role="button" aria-label="${esc(m.title)}">
             <h3>${esc(m.title)}</h3>
             ${m.description ? `<p>${esc(m.description)}</p>` : ''}
+            ${waveBadge(m.wave)}
           </div>`;
         }).join('');
 
@@ -724,15 +746,15 @@
       const m = milestones.find(m => m.id === id);
       if (!m) return;
       modalState = { id, isNew: false, status: m.status };
-      renderModal(m.title, m.description, m.status);
+      renderModal(m.title, m.description, m.status, m.wave);
     }
 
     function openNewCard(status) {
       modalState = { id: null, isNew: true, status };
-      renderModal('', '', status);
+      renderModal('', '', status, null);
     }
 
-    function renderModal(title, description, status) {
+    function renderModal(title, description, status, wave) {
       const modal = document.getElementById('detail-modal');
       const sc = STATUS_CLASS[status] || 'planned';
       const sl = STATUS_LABEL[status] || 'Planned';
@@ -741,12 +763,16 @@
         const opts = Object.entries(STATUS_LABEL).map(([v, l]) =>
           `<option value="${v}"${v === status ? ' selected' : ''}>${l}</option>`
         ).join('');
+        // Wave control: 'none' clears the label; WAVE1/2/3 sets it. PATCHed on save.
+        const waveOpts = `<option value="none"${!WAVES.includes(wave) ? ' selected' : ''}>No wave</option>`
+          + WAVES.map(w => `<option value="${w}"${w === wave ? ' selected' : ''}>${w}</option>`).join('');
 
         modal.innerHTML = `
           <div class="detail-head">
             <div class="detail-head-copy">
               <input class="detail-edit-title" id="d-title" type="text" value="${esc(title)}" placeholder="Card title" maxlength="200" />
               <select class="detail-status-select" id="d-status">${opts}</select>
+              <select class="detail-status-select" id="d-wave" aria-label="Launch wave">${waveOpts}</select>
             </div>
             <button class="detail-close-btn" id="d-close">
               <svg viewBox="0 0 24 24"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
@@ -763,15 +789,16 @@
           const newTitle = modal.querySelector('#d-title').value.trim();
           const newDesc = modal.querySelector('#d-desc').value.trim();
           const newStatus = modal.querySelector('#d-status').value;
+          const newWave = modal.querySelector('#d-wave').value;
           if (!newTitle) { modal.querySelector('#d-title').focus(); return; }
           const btn = modal.querySelector('#d-save');
           btn.disabled = true;
           btn.textContent = modalState.isNew ? 'Adding…' : 'Saving…';
           try {
             if (modalState.isNew) {
-              await createMilestone({ title: newTitle, description: newDesc, status: newStatus, sort_order: (milestones.length + 1) * 10 });
+              await createMilestone({ title: newTitle, description: newDesc, status: newStatus, wave: newWave, sort_order: (milestones.length + 1) * 10 });
             } else {
-              await patchMilestone(modalState.id, { title: newTitle, description: newDesc, status: newStatus });
+              await patchMilestone(modalState.id, { title: newTitle, description: newDesc, status: newStatus, wave: newWave });
             }
             closeModal();
             render();
@@ -797,7 +824,7 @@
         modal.innerHTML = `
           <div class="detail-head">
             <div class="detail-head-copy">
-              <span class="roadmap-status roadmap-status--${sc}">${sl}</span>
+              <span class="roadmap-status roadmap-status--${sc}">${sl}</span>${waveBadge(wave)}
               <h2 class="detail-modal-title" id="detail-modal-title">${esc(title)}</h2>
             </div>
             <button class="detail-close-btn" id="d-close">

--- a/roadmap.html
+++ b/roadmap.html
@@ -10,6 +10,25 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300..700&display=swap" />
 <link rel="stylesheet" href="styles/landing.css" />
+<script>
+  // Resolve once the Netlify Identity auth module has loaded (or time out), so the
+  // admin-by-account check can read window.TinyWorldAuth before booting.
+  (function roadmapAuthBootstrap() {
+    window.__tinyworldAuthReady = new Promise(function (resolve) {
+      window.__resolveTinyWorldAuthReady = resolve;
+      setTimeout(function () { resolve(false); }, 2500);
+    });
+  })();
+</script>
+<script id="tinyworld-auth-importmap" type="importmap">
+{
+  "imports": {
+    "@netlify/identity": "./vendor/netlify/identity.js",
+    "gotrue-js": "./vendor/netlify/gotrue.js"
+  }
+}
+</script>
+<script type="module" src="vendor/tinyworld-auth.js"></script>
 <script src="engine/world/00-custom-confirm.js"></script>
 <style>
 /* ---- kanban board ---- */
@@ -497,22 +516,52 @@
       return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     }
 
-    function adminHeaders() {
-      return { 'Content-Type': 'application/json', 'x-admin-secret': adminSecret };
+    // Bearer token for the signed-in account, if any. Mirrors scripts/admin-users.js:
+    // Identity JWT first, then wallet-session / nf_jwt cookie fallbacks. The server
+    // decides admin authority from the verified email this token resolves to.
+    function walletToken() {
+      try { return localStorage.getItem('tinyworld:auth:wallet-session.v1') || ''; } catch (_) { return ''; }
+    }
+    function cookieToken() {
+      try { const m = document.cookie.match(/(?:^|; )nf_jwt=([^;]*)/); return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
+    }
+    async function accessToken() {
+      try {
+        const A = window.TinyWorldAuth;
+        if (A && typeof A.getUser === 'function') {
+          const u = await A.getUser();
+          if (u && typeof u.jwt === 'function') {
+            const jwt = await Promise.resolve(u.jwt()).catch(() => '');
+            return jwt || (u.token && u.token.access_token) || walletToken() || cookieToken() || '';
+          }
+          return (u && u.token && u.token.access_token) || walletToken() || cookieToken() || '';
+        }
+      } catch (_) {}
+      return walletToken() || cookieToken() || '';
+    }
+
+    // Headers for authenticated reads/writes: the account bearer token (prod path)
+    // plus the localhost-only dev secret when present. Same-origin fetch sets Origin
+    // automatically, satisfying the server's CSRF guard.
+    async function authHeaders(withJson) {
+      const headers = withJson ? { 'Content-Type': 'application/json' } : {};
+      const token = await accessToken();
+      if (token) headers['Authorization'] = 'Bearer ' + token;
+      if (adminSecret) headers['x-admin-secret'] = adminSecret;
+      return headers;
     }
 
     // ---- API ----
     async function loadMilestones() {
-      const headers = adminSecret ? { 'x-admin-secret': adminSecret } : {};
-      const r = await fetch('/api/roadmap', { headers });
+      const r = await fetch('/api/roadmap', { headers: await authHeaders(false), credentials: 'same-origin' });
       const d = await r.json();
       milestones = d.milestones || [];
-      return !!d.admin; // server's verdict on the supplied secret
+      return !!d.admin; // server's verdict: verified admin email OR local dev secret
     }
 
     async function patchMilestone(id, updates) {
       const r = await fetch('/api/roadmap?id=' + id, {
-        method: 'PATCH', headers: adminHeaders(), body: JSON.stringify(updates),
+        method: 'PATCH', headers: await authHeaders(true), credentials: 'same-origin', body: JSON.stringify(updates),
       });
       const d = await r.json();
       if (!r.ok) throw new Error(d.error || 'Update failed');
@@ -522,7 +571,7 @@
 
     async function createMilestone(data) {
       const r = await fetch('/api/roadmap', {
-        method: 'POST', headers: adminHeaders(), body: JSON.stringify(data),
+        method: 'POST', headers: await authHeaders(true), credentials: 'same-origin', body: JSON.stringify(data),
       });
       const d = await r.json();
       if (!r.ok) throw new Error(d.error || 'Create failed');
@@ -531,7 +580,7 @@
 
     async function deleteMilestone(id) {
       const r = await fetch('/api/roadmap?id=' + id, {
-        method: 'DELETE', headers: adminHeaders(),
+        method: 'DELETE', headers: await authHeaders(false), credentials: 'same-origin',
       });
       if (!r.ok) { const d = await r.json(); throw new Error(d.error || 'Delete failed'); }
       milestones = milestones.filter(m => m.id !== id);
@@ -781,6 +830,9 @@
 
     // ---- Boot ----
     (async () => {
+      // Wait for the Identity auth module so accessToken() can read a live session
+      // on the first load (prod account-based admin), then ask the server.
+      try { await window.__tinyworldAuthReady; } catch (_) {}
       let serverSaysAdmin = false;
       try {
         serverSaysAdmin = await loadMilestones();
@@ -789,14 +841,16 @@
           '<p style="grid-column:1/-1;text-align:center;padding:64px;color:var(--muted)">Could not load roadmap.</p>';
         return;
       }
-      // A stored secret only grants admin if the server actually accepts it.
-      // Clears a stale/wrong secret so you never see the banner without real access.
+      // A stored local dev secret only grants admin if the server accepts it; clear
+      // a stale/wrong secret so the banner never shows without real access.
       if (adminSecret && !serverSaysAdmin) {
         adminSecret = '';
         try { sessionStorage.removeItem('twAdminSecret'); } catch (_) {}
         try { localStorage.removeItem('twAdminSecret'); } catch (_) {}
       }
-      adminMode = IS_LOCAL && serverSaysAdmin;
+      // Authority is the server's verdict — verified admin email (works on prod) OR
+      // the localhost-only dev secret. No client-side host gate.
+      adminMode = serverSaysAdmin;
       render();
     })();
   })();


### PR DESCRIPTION
## Phase 0 — Auth foundation (WAVE launch system)

Authorize roadmap/features admin by the owner's **verified account email** instead of the shared secret. This is the keystone every later WAVE phase (live roadmap edit, vote override, admin-only specs) depends on.

### New auth flow (server)
`isAdmin()` in `roadmap.mjs` and `features.mjs` is now **async + account-aware**:

```
await getAuthUser(request) → user.email → isWorldAdminEmail(email) ? admin : fallback
```

- **Prod path (the unlock):** `getAuthUser(request)` resolves the server-verified Netlify Identity session (or wallet session); if its email is on the world-admin allowlist (`isWorldAdminEmail` — the 2 owner emails + `TINYWORLD_WORLD_ADMIN_EMAILS`), the request is admin. This branch has **no host check**, so it works on production. Authority is the **server-verified email only** — never a client-supplied email or `admin:true` flag.
- **Retained localhost dev fallback:** the legacy `x-admin-secret` path lives on in `isLocalSecretAdmin()`. It **fails closed on every non-local host**, so it can never grant admin on prod. Local roadmap/features editing keeps working without an Identity session.
- Every `isAdmin()` call site converted to `await` (no missed-await gate bypass — verified by grep).

### CSRF / same-origin guard
Identity sessions are cookie-ambient, so a verified admin's browser could be driven cross-site. Added `sameOriginWriteGuard` (reused verbatim from `admin-users.mjs`) to the admin write paths:
- roadmap `POST`/`PATCH`/`DELETE` — unconditional (all admin).
- features `PATCH` — unconditional (admin-only).
- features `POST` — **only when the request is admin** (`isAdminReq && !guard → 403`). The public wallet vote/suggest contract is deliberately left untouched; Phase 3 tightens normal-vote auth separately.

### Client (`roadmap.html`, `features.html`)
- Load the Netlify Identity auth module (`vendor/tinyworld-auth.js` + importmap + ready-promise), mirroring `admin-users.html`.
- `accessToken()` lifted from `scripts/admin-users.js` (Identity JWT → wallet-session → `nf_jwt` cookie fallbacks); sends `Authorization: Bearer <jwt>` on reads and writes with `credentials: 'same-origin'`.
- Admin mode is driven by the **server's `d.admin` verdict** — the client-side prod host gate is gone, so account-based admin engages on production. The localhost secret entry (Ctrl+Shift+A) still works for local dev.

### Security scoping
Authority is decided **server-side from the verified session email only**, scoped strictly to `isWorldAdminEmail` (never "any logged-in user"). A client cannot assert admin by sending an email or a flag.

## Testing

**Deny side — exercised directly against the exported functions** (gate runs before any DB access):

| Request | Result |
|---|---|
| `PATCH` prod host, no session | `403 Forbidden` |
| `PATCH` prod host, stale `x-admin-secret` | `403` (secret never works off-localhost) |
| `PATCH` localhost + correct secret | passes gate → `400 id is required` (proves localhost fallback) |
| `PATCH` localhost + wrong secret | `403` |
| features `PATCH` prod, no session | `403` |

**Accept side — logic walkthrough** (a live Identity session can't be staged headlessly; this is the same composition already shipped and working in `admin-users.mjs`, from which the client token pattern was lifted):
- Admin-email session: `getAuthUser(request)` → verified email → `isWorldAdminEmail(email) === true` → **admin granted**. Backed by passing unit tests `isWorldAdminEmail allows the default god-admin account` and the live-function precedent `a non-admin world.refresh is ignored` (same email-gate in another function).
- **Logged-in non-admin** session: `isWorldAdminEmail(email) === false` → falls to `isLocalSecretAdmin` → prod host → `false` → **403** (the "over a non-admin session is 403" case). Backed by `isWorldAdminEmail rejects non-admin and empty emails`.

**Suite:** `npm run check`, `npm run smoke`, `npm run test:unit` (135 pass), `npm run i18n:check` — all green. No new i18n keys.

**Post-merge:** the accept-path can't run headlessly — confirm live after deploy that the owner's Identity login engages admin on prod (the green suite proves the lockdown, not the unlock).

https://claude.ai/code/session_01BmyJsvuhVnYVvdnj95Ln4e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added “wave” support for features and roadmap items, including wave badges, filtering, and admin controls to set/clear wave labels.
  * Updated auth bootstrapping so admin mode is determined after Identity auth is ready.

* **Security**
  * Strengthened admin authorization to be fully server-side via verified email, with a safe localhost fallback.
  * Enforced same-origin/CSRF-style protection for admin write actions (rejecting invalid requests with `403`).

* **Improvements**
  * Unified authenticated API requests and token/header handling for consistent reads and writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->