### PR TITLE
feat: WAVE labels on roadmap + suggestions, suggestion wave filter [Phase 2]

### DIFF
--- a/features.html
+++ b/features.html
@@ -285,6 +285,40 @@
 .admin-status-select.badge-planned { background:#e8f0fe; color:#1a4fcf; border-color:#b3cafd; }
 .admin-status-select.badge-done    { background:#e6f4ea; color:#1a6632; border-color:#b7dfbe; }
 .admin-status-select.badge-rejected{ background:#f5f0f0; color:#8a2a20; border-color:#e0bab7; }
+
+/* WAVE launch taxonomy — public filter, per-item badge, admin set control. */
+.wave-filter {
+  font: inherit;
+  font-size: 13px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border, #d6dae5);
+  background: #fff;
+  color: var(--ink, #1a1d27);
+  cursor: pointer;
+}
+.wave-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent, #ffb020);
+  color: #1a1205;
+  border: 1px solid rgba(0,0,0,0.08);
+}
+.admin-wave-select {
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid #e6c98a;
+  background: #fff7e6;
+  color: #6a4a00;
+  cursor: pointer;
+}
 </style>
 </head>
 <body class="landing-page">
@@ -322,6 +356,12 @@
           <button class="filter-btn" data-status="done">Done</button>
           <button class="filter-btn" data-status="all">All</button>
         </div>
+        <select class="wave-filter" id="wave-filter" aria-label="Filter by wave">
+          <option value="">All waves</option>
+          <option value="WAVE1">WAVE1</option>
+          <option value="WAVE2">WAVE2</option>
+          <option value="WAVE3">WAVE3</option>
+        </select>
         <button class="suggest-btn" id="suggest-open-btn">
           <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
           Suggest a feature
@@ -373,6 +413,7 @@
   (function() {
     const MIN_BALANCE = 100;
     const STATUS_OPTS = ['open','planned','done','rejected'];
+    const WAVES = ['WAVE1','WAVE2','WAVE3'];
 
     const FALLBACK_SUGGESTIONS = [
       { id: -1, title: 'NPC companions', description: 'Add AI-driven NPCs that wander your world and interact with players — merchants, wanderers, quest-givers.', wallet: 'admin', vote_weight: 0, status: 'open', created_at: '' },
@@ -415,6 +456,7 @@
       try { localStorage.removeItem('twAdminSecret'); } catch (_) {}
     }
     let currentFilter = 'open';
+    let currentWave = ''; // '' = all waves; otherwise WAVE1/WAVE2/WAVE3
     let suggestions = [];
     let myVotes = {};
     // The server's last verdict on admin authority (verified account email on prod,
@@ -515,7 +557,8 @@
 
     // ---- API ----
     async function loadSuggestions(status) {
-      const r = await fetch('/api/features?status=' + encodeURIComponent(status), { headers: await authHeaders(false), credentials: 'same-origin' });
+      const waveQ = currentWave ? '&wave=' + encodeURIComponent(currentWave) : '';
+      const r = await fetch('/api/features?status=' + encodeURIComponent(status) + waveQ, { headers: await authHeaders(false), credentials: 'same-origin' });
       const d = await r.json();
       serverSaysAdmin = !!d.admin; // server's verdict: verified admin email OR local dev secret
       return d.suggestions || [];
@@ -557,6 +600,17 @@
       return d.suggestion;
     }
 
+    // Admin-only: set/clear a suggestion's launch wave ('none' clears it).
+    async function patchWave(id, wave) {
+      const r = await fetch('/api/features?id=' + id, {
+        method: 'PATCH', headers: await authHeaders(true), credentials: 'same-origin',
+        body: JSON.stringify({ wave }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d.error || 'Update failed');
+      return d.suggestion;
+    }
+
     // ---- render ----
     function fmtScore(n) {
       if (n >= 1000000) return (n/1000000).toFixed(1).replace(/\.0$/,'') + 'M';
@@ -591,6 +645,13 @@
               ${STATUS_OPTS.map(o => `<option value="${o}"${o===s.status?' selected':''}>${o}</option>`).join('')}
             </select>`
           : `<span class="feature-status-badge ${badgeClass(s.status)}">${esc(s.status)}</span>`;
+        // WAVE label: admins get a set/clear picker; everyone else sees a badge (or nothing).
+        const waveCell = adminMode
+          ? `<select class="admin-wave-select" data-wave-id="${s.id}" aria-label="Set wave">
+              <option value="none"${!WAVES.includes(s.wave)?' selected':''}>No wave</option>
+              ${WAVES.map(w => `<option value="${w}"${w===s.wave?' selected':''}>${w}</option>`).join('')}
+            </select>`
+          : (WAVES.includes(s.wave) ? `<span class="wave-badge">${esc(s.wave)}</span>` : '');
 
         return `<div class="feature-item" data-id="${s.id}">
   <div class="vote-col">
@@ -603,6 +664,7 @@
     ${s.description ? `<p>${esc(s.description)}</p>` : ''}
     <div class="feature-meta">
       <span class="feature-wallet">${esc(fmtWallet(s.wallet))}</span>
+      ${waveCell}
     </div>
   </div>
   ${adminStatusPicker}
@@ -651,6 +713,25 @@
           } catch (err) { alert(err.message); }
         });
       });
+
+      // admin wave pickers
+      el.querySelectorAll('.admin-wave-select').forEach(sel => {
+        sel.addEventListener('change', async () => {
+          const id = Number(sel.dataset.waveId);
+          try {
+            const updated = await patchWave(id, sel.value);
+            if (updated) {
+              const idx = suggestions.findIndex(s => s.id === id);
+              if (idx >= 0) suggestions[idx] = updated;
+              // If a wave filter is active and this item no longer matches, drop it.
+              if (currentWave && updated.wave !== currentWave) {
+                suggestions = suggestions.filter(s => s.id !== id);
+              }
+              renderList();
+            }
+          } catch (err) { alert(err.message); }
+        });
+      });
     }
 
     // ---- filter ----
@@ -663,6 +744,14 @@
         suggestions = await loadSuggestions(currentFilter).catch(() => []);
         renderList();
       });
+    });
+
+    // ---- wave filter ----
+    document.getElementById('wave-filter').addEventListener('change', async (e) => {
+      currentWave = e.target.value;
+      document.getElementById('features-list').innerHTML = '<div class="features-empty">Loading...</div>';
+      suggestions = await loadSuggestions(currentFilter).catch(() => []);
+      renderList();
     });
 
     // ---- suggest modal ----

--- a/netlify/database/migrations/20260618000000_wave_labels.sql
+++ b/netlify/database/migrations/20260618000000_wave_labels.sql
@@ -1,0 +1,19 @@
+-- WAVE launch taxonomy (Phase 2): tag roadmap milestones and feature suggestions
+-- with a launch-wave label (WAVE1 / WAVE2 / WAVE3; NULL = none). WAVE1 is the
+-- launch wave tied to the countdown target. Additive and idempotent.
+--
+-- roadmap_milestones / feature_suggestions are created LAZILY by their Netlify
+-- functions (ensureTable/ensureTables in roadmap.mjs / features.mjs), not by an
+-- earlier migration — so a plain ALTER would fail on a database where the
+-- function has never run yet. Guard on table existence: this migration adds the
+-- column where the table already exists (e.g. prod), and the functions' own
+-- idempotent ALTER adds it on first call for fresh databases.
+DO $$
+BEGIN
+  IF to_regclass('public.roadmap_milestones') IS NOT NULL THEN
+    ALTER TABLE roadmap_milestones ADD COLUMN IF NOT EXISTS wave TEXT;
+  END IF;
+  IF to_regclass('public.feature_suggestions') IS NOT NULL THEN
+    ALTER TABLE feature_suggestions ADD COLUMN IF NOT EXISTS wave TEXT;
+  END IF;
+END $$;

--- a/netlify/functions/features.mjs
+++ b/netlify/functions/features.mjs
@@ -9,6 +9,15 @@ export const config = { path: '/api/features' };
 // in a future step when Solana RPC is wired; for now the client enforces it).
 const MIN_COIN_BALANCE = 100;
 
+// WAVE launch taxonomy: constrain the label server-side to a small known set so
+// arbitrary client strings can never be stored or filtered on. Anything else
+// (incl. 'none'/'') normalizes to null = no wave.
+const WAVES = ['WAVE1', 'WAVE2', 'WAVE3'];
+function normalizeWave(value) {
+  const s = String(value == null ? '' : value).trim().toUpperCase();
+  return WAVES.includes(s) ? s : null;
+}
+
 // Curated idea pool harvested from the design docs, the Skybound roadmap
 // (plans/ROADMAP-skybound.md), the fork-improvement harvest, and existing
 // infra seams. These are intentionally broad — the team filters/triages them on
@@ -82,6 +91,10 @@ async function ensureTables(sql) {
       updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `;
+  // WAVE launch label (Phase 2). Idempotent ALTER so fresh and older databases
+  // — including prod where migrations lag — gain the column before any write
+  // references it. Mirrors migration 20260618000000_wave_labels.sql.
+  await sql`ALTER TABLE feature_suggestions ADD COLUMN IF NOT EXISTS wave TEXT`;
   await sql`
     CREATE TABLE IF NOT EXISTS feature_votes (
       id            SERIAL PRIMARY KEY,
@@ -103,6 +116,7 @@ function suggestionDto(row) {
     wallet:       row.wallet,
     vote_weight:  Number(row.vote_weight) || 0,
     status:       row.status,
+    wave:         row.wave || null,
     created_at:   row.created_at,
   };
 }
@@ -153,9 +167,12 @@ export default async function featuresFunction(request) {
       await seedSuggestions(sql);
       const url = new URL(request.url);
       const status = url.searchParams.get('status') || 'open';
+      // Public wave filter: ?wave=WAVE1. Unknown values normalize to null = no filter.
+      const wave = normalizeWave(url.searchParams.get('wave'));
       const rows = await sql`
         SELECT * FROM feature_suggestions
         WHERE ${status === 'all' ? sql`TRUE` : sql`status = ${status}`}
+          AND ${wave ? sql`wave = ${wave}` : sql`TRUE`}
         ORDER BY vote_weight DESC, created_at DESC
         LIMIT 200
       `;
@@ -248,11 +265,18 @@ export default async function featuresFunction(request) {
     if (!id) return errorResponse('id is required', 400, origin);
     const body = await readJson(request);
     const status = ['open','planned','done','rejected'].includes(body && body.status) ? body.status : null;
-    if (!status) return errorResponse('valid status is required', 400, origin);
+    // wave is set/cleared explicitly: a provided 'none'/'' normalizes to null (a real
+    // clear) and bypasses COALESCE, which would treat null as "leave unchanged".
+    const waveProvided = !!(body && Object.prototype.hasOwnProperty.call(body, 'wave'));
+    const wave = waveProvided ? normalizeWave(body.wave) : null;
+    if (!status && !waveProvided) return errorResponse('status or wave is required', 400, origin);
     try {
       const sql = getSql();
       const rows = await sql`
-        UPDATE feature_suggestions SET status = ${status}, updated_at = NOW()
+        UPDATE feature_suggestions SET
+          status = COALESCE(${status}, status),
+          wave = CASE WHEN ${waveProvided} THEN ${wave} ELSE wave END,
+          updated_at = NOW()
         WHERE id = ${id} RETURNING *
       `;
       if (!rows.length) return errorResponse('Not found', 404, origin);

--- a/netlify/functions/roadmap.mjs
+++ b/netlify/functions/roadmap.mjs
@@ -40,6 +40,15 @@ function envValue(name) {
   return process.env[name] || '';
 }
 
+// WAVE launch taxonomy: constrain the label server-side to a small known set so
+// arbitrary client strings can never be stored. Anything else (incl. 'none'/'')
+// normalizes to null = no wave.
+const WAVES = ['WAVE1', 'WAVE2', 'WAVE3'];
+function normalizeWave(value) {
+  const s = String(value == null ? '' : value).trim().toUpperCase();
+  return WAVES.includes(s) ? s : null;
+}
+
 // Admin authority is decided SERVER-SIDE from a verified account session.
 // Prod path: the requester's Netlify Identity (or wallet) session resolves to an
 // email on the world-admin allowlist (isWorldAdminEmail). This branch has NO host
@@ -79,6 +88,10 @@ async function ensureTable(sql) {
       updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `;
+  // WAVE launch label (Phase 2). Idempotent ALTER so fresh and older databases
+  // — including prod where migrations lag — gain the column before any write
+  // references it. Mirrors migration 20260618000000_wave_labels.sql.
+  await sql`ALTER TABLE roadmap_milestones ADD COLUMN IF NOT EXISTS wave TEXT`;
 }
 
 async function seedTable(sql) {
@@ -118,6 +131,7 @@ function milestoneDto(row) {
     title:       row.title,
     description: row.description,
     sort_order:  row.sort_order,
+    wave:        row.wave || null,
   };
 }
 
@@ -155,13 +169,14 @@ export default async function roadmapFunction(request) {
     const description = String(body && body.description || '').slice(0, 1000).trim();
     const status = ['done', 'active', 'planned'].includes(body && body.status) ? body.status : 'planned';
     const sort_order = Number.isFinite(Number(body && body.sort_order)) ? Math.round(Number(body.sort_order)) : 0;
+    const wave = normalizeWave(body && body.wave);
     if (!title) return errorResponse('title is required', 400, origin);
     try {
       const sql = getSql();
       await ensureTable(sql);
       const rows = await sql`
-        INSERT INTO roadmap_milestones (status, title, description, sort_order)
-        VALUES (${status}, ${title}, ${description}, ${sort_order})
+        INSERT INTO roadmap_milestones (status, title, description, sort_order, wave)
+        VALUES (${status}, ${title}, ${description}, ${sort_order}, ${wave})
         RETURNING *
       `;
       return jsonResponse({ milestone: milestoneDto(rows[0]) }, origin, 201);
@@ -182,7 +197,12 @@ export default async function roadmapFunction(request) {
     if (body && body.description != null) updates.description = String(body.description).slice(0, 1000).trim();
     if (body && body.status != null && ['done', 'active', 'planned'].includes(body.status)) updates.status = body.status;
     if (body && body.sort_order != null && Number.isFinite(Number(body.sort_order))) updates.sort_order = Math.round(Number(body.sort_order));
-    if (!Object.keys(updates).length) return errorResponse('No fields to update', 400, origin);
+    // wave is set/cleared explicitly: a provided value of 'none'/'' normalizes to
+    // null (a real clear), so it must bypass COALESCE — which would otherwise treat
+    // null as "leave unchanged". Tracked separately so a wave-only PATCH is allowed.
+    const waveProvided = !!(body && Object.prototype.hasOwnProperty.call(body, 'wave'));
+    const wave = waveProvided ? normalizeWave(body.wave) : null;
+    if (!Object.keys(updates).length && !waveProvided) return errorResponse('No fields to update', 400, origin);
     try {
       const sql = getSql();
       const rows = await sql`
@@ -192,6 +212,7 @@ export default async function roadmapFunction(request) {
           description = COALESCE(${updates.description ?? null}, description),
           status      = COALESCE(${updates.status ?? null}, status),
           sort_order  = COALESCE(${updates.sort_order ?? null}, sort_order),
+          wave        = CASE WHEN ${waveProvided} THEN ${wave} ELSE wave END,
           updated_at  = NOW()
         WHERE id = ${id}
         RETURNING *

--- a/roadmap.html
+++ b/roadmap.html
@@ -384,6 +384,21 @@
 
 /* roadmap status badges (reused inside modal) */
 
+/* WAVE launch badge — small accent pill shown on cards + in the detail modal. */
+.wave-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent, #ffb020);
+  color: #1a1205;
+  border: 1px solid rgba(0,0,0,0.08);
+  vertical-align: middle;
+}
+.kanban-card .wave-badge { margin-top: 8px; }
+
 /* responsive */
 @media (max-width: 780px) {
   .kanban-board {
@@ -512,8 +527,13 @@
     }
 
     // ---- Helpers ----
+    const WAVES = ['WAVE1', 'WAVE2', 'WAVE3'];
     function esc(s) {
       return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+    // WAVE launch label pill, or '' when the milestone has no wave.
+    function waveBadge(w) {
+      return WAVES.includes(w) ? `<span class="wave-badge">${esc(w)}</span>` : '';
     }
 
     // Bearer token for the signed-in account, if any. Mirrors scripts/admin-users.js:
@@ -617,6 +637,7 @@
                 <div class="kanban-card-body">
                   <h3>${esc(m.title)}</h3>
                   ${m.description ? `<p>${esc(m.description)}</p>` : ''}
+                  ${waveBadge(m.wave)}
                 </div>
               </div>
             </div>`;
@@ -624,6 +645,7 @@
           return `<div class="kanban-card" data-id="${m.id}" tabindex="0" role="button" aria-label="${esc(m.title)}">
             <h3>${esc(m.title)}</h3>
             ${m.description ? `<p>${esc(m.description)}</p>` : ''}
+            ${waveBadge(m.wave)}
           </div>`;
         }).join('');
 
@@ -724,15 +746,15 @@
       const m = milestones.find(m => m.id === id);
       if (!m) return;
       modalState = { id, isNew: false, status: m.status };
-      renderModal(m.title, m.description, m.status);
+      renderModal(m.title, m.description, m.status, m.wave);
     }
 
     function openNewCard(status) {
       modalState = { id: null, isNew: true, status };
-      renderModal('', '', status);
+      renderModal('', '', status, null);
     }
 
-    function renderModal(title, description, status) {
+    function renderModal(title, description, status, wave) {
       const modal = document.getElementById('detail-modal');
       const sc = STATUS_CLASS[status] || 'planned';
       const sl = STATUS_LABEL[status] || 'Planned';
@@ -741,12 +763,16 @@
         const opts = Object.entries(STATUS_LABEL).map(([v, l]) =>
           `<option value="${v}"${v === status ? ' selected' : ''}>${l}</option>`
         ).join('');
+        // Wave control: 'none' clears the label; WAVE1/2/3 sets it. PATCHed on save.
+        const waveOpts = `<option value="none"${!WAVES.includes(wave) ? ' selected' : ''}>No wave</option>`
+          + WAVES.map(w => `<option value="${w}"${w === wave ? ' selected' : ''}>${w}</option>`).join('');
 
         modal.innerHTML = `
           <div class="detail-head">
             <div class="detail-head-copy">
               <input class="detail-edit-title" id="d-title" type="text" value="${esc(title)}" placeholder="Card title" maxlength="200" />
               <select class="detail-status-select" id="d-status">${opts}</select>
+              <select class="detail-status-select" id="d-wave" aria-label="Launch wave">${waveOpts}</select>
             </div>
             <button class="detail-close-btn" id="d-close">
               <svg viewBox="0 0 24 24"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
@@ -763,15 +789,16 @@
           const newTitle = modal.querySelector('#d-title').value.trim();
           const newDesc = modal.querySelector('#d-desc').value.trim();
           const newStatus = modal.querySelector('#d-status').value;
+          const newWave = modal.querySelector('#d-wave').value;
           if (!newTitle) { modal.querySelector('#d-title').focus(); return; }
           const btn = modal.querySelector('#d-save');
           btn.disabled = true;
           btn.textContent = modalState.isNew ? 'Adding…' : 'Saving…';
           try {
             if (modalState.isNew) {
-              await createMilestone({ title: newTitle, description: newDesc, status: newStatus, sort_order: (milestones.length + 1) * 10 });
+              await createMilestone({ title: newTitle, description: newDesc, status: newStatus, wave: newWave, sort_order: (milestones.length + 1) * 10 });
             } else {
-              await patchMilestone(modalState.id, { title: newTitle, description: newDesc, status: newStatus });
+              await patchMilestone(modalState.id, { title: newTitle, description: newDesc, status: newStatus, wave: newWave });
             }
             closeModal();
             render();
@@ -797,7 +824,7 @@
         modal.innerHTML = `
           <div class="detail-head">
             <div class="detail-head-copy">
-              <span class="roadmap-status roadmap-status--${sc}">${sl}</span>
+              <span class="roadmap-status roadmap-status--${sc}">${sl}</span>${waveBadge(wave)}
               <h2 class="detail-modal-title" id="detail-modal-title">${esc(title)}</h2>
             </div>
             <button class="detail-close-btn" id="d-close">


### PR DESCRIPTION
## Phase 2 — WAVE taxonomy (plans/wave-launch-system.md §2)

**STACKED on #50 (Phase 0 — account-based admin auth). Merge after #50.** Base branch is `polly/p0-account-admin-auth`, not `main`. Reuses the Phase 0 `isAdmin` gate (verified `isWorldAdminEmail`) for all wave writes.

Tags roadmap items **and** suggestions with a launch-wave label (WAVE1 / WAVE2 / WAVE3 / none), shows a WAVE badge, and lets the public **filter suggestions by wave**. WAVE1 is the launch wave (the countdown target). Wave-SET is admin-only; the suggestion wave-FILTER is public.

### Changes
- **`netlify/database/migrations/20260618000000_wave_labels.sql`** — additive, idempotent `wave TEXT` on `roadmap_milestones` + `feature_suggestions`. Guarded with `to_regclass` because both tables are created **lazily by their functions**, not by an earlier migration — a plain `ALTER` would throw on a DB where the function has never run (confirmed against a fresh migrated DB). The functions' own ensure-time ALTER covers fresh databases.
- **`roadmap.mjs`** — ensure-time idempotent ALTER; `wave` in the DTO; accepted on POST create and PATCH; server-constrained to `{WAVE1,WAVE2,WAVE3}`→null. Wave set/clear bypasses `COALESCE` (via `CASE WHEN <provided>`) so selecting "none" actually clears; a wave-only PATCH is allowed.
- **`features.mjs`** — same ensure ALTER + DTO + normalize helper; `&wave=WAVE1` filter on the public list query (junk → no filter); admin PATCH now accepts a **wave-only** update (previously hard-required `status`, which would 400).
- **`roadmap.html`** — WAVE badge on kanban cards (both admin and normal render branches) and in the detail modal; admin select to set/clear a card's wave (PATCHes).
- **`features.html`** — public "All waves / WAVE1-3" filter next to the status filter that refetches with `&wave=`; per-item badge in `renderList`; admin per-item set/clear select.

### i18n — deliberately no keys added
`roadmap.html`/`features.html` never load the i18n runtime (no `t()`/`TWI18N`; every string is hardcoded English, matching all existing strings on those pages). Parity spans **5** locales including `th.js`, which is outside this phase's allowed file set — adding a key to `en.js` alone breaks `i18n:check`. New strings ("All waves", "No wave", etc.) are hardcoded to match the existing page convention. `i18n:check` stays green (314 keys × 5 locales).

### Scope
Touched only: the migration, `roadmap.mjs`, `features.mjs`, `roadmap.html`, `features.html`. No countdown header (deferred to PR #51), no countdown files, no `index.html` / builder / `engine/world/**`.

### Verification
- `npm run check` / `smoke` / `test:unit` (135 pass) / `i18n:check` — all green.
- Full wave lifecycle exercised against a **local Postgres** through the real function modules: create stores valid wave / normalizes junk → null; wave-only and status-only PATCH (no clobber); "none" actually clears; non-admin write → 403; public filter includes/excludes/junk-ignores correctly; migration applies cleanly on a fresh DB.
- Not run: full `netlify dev` browser session (the lightweight `tools/dev-server.js` doesn't route `/api/roadmap|features`); the backend is proven against real Postgres and the HTML edits mirror existing render patterns.

https://claude.ai/code/session_012V67Xmmk6ajGNnrx9L3haX