### PR TITLE
Make WAVE1 countdown pill bigger (builder + hero)

### DIFF
--- a/styles/countdown.css
+++ b/styles/countdown.css
@@ -58,6 +58,21 @@
 .brand-countdown.tw-countdown {
   --countdown-bg: rgba(255, 255, 255, 0.62);
   color: var(--ink, #2a2722);
+  gap: 11px;
+  min-height: 47px;
+  padding: 11px 20px 11px 17px;
+  font-size: 18px;
+  font-weight: 800;
+}
+
+.brand-countdown .tw-countdown-dot {
+  width: 12px;
+  height: 12px;
+  box-shadow: 0 0 0 4px rgba(58, 114, 200, 0.14);
+}
+
+.brand-countdown.tw-countdown[data-countdown-live="true"] .tw-countdown-dot {
+  box-shadow: 0 0 0 4px rgba(35, 178, 109, 0.16);
 }
 
 body.xr-active .brand-countdown {
@@ -77,13 +92,25 @@ body.showcase .brand-countdown {
 .hero-countdown.tw-countdown {
   --countdown-bg: rgba(255, 255, 255, 0.7);
   --countdown-border: rgba(255, 255, 255, 0.72);
-  min-height: 40px;
-  padding: 10px 16px 10px 13px;
+  gap: 11px;
+  min-height: 58px;
+  padding: 15px 24px 15px 20px;
   color: #111b45;
-  font-size: 14px;
+  font-size: 21px;
+  font-weight: 800;
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.9) inset,
     0 16px 40px -22px rgba(10, 35, 90, 0.42);
+}
+
+.hero-countdown .tw-countdown-dot {
+  width: 12px;
+  height: 12px;
+  box-shadow: 0 0 0 4px rgba(58, 114, 200, 0.14);
+}
+
+.hero-countdown.tw-countdown[data-countdown-live="true"] .tw-countdown-dot {
+  box-shadow: 0 0 0 4px rgba(35, 178, 109, 0.16);
 }
 
 @media (max-width: 620px) {
@@ -93,7 +120,30 @@ body.showcase .brand-countdown {
     max-width: calc(100vw - 32px);
   }
 
+  .brand-countdown.tw-countdown {
+    gap: 9px;
+    min-height: 42px;
+    padding: 9px 16px 9px 13px;
+    font-size: 16px;
+  }
+
+  .brand-countdown .tw-countdown-dot {
+    width: 10px;
+    height: 10px;
+    box-shadow: 0 0 0 3px rgba(58, 114, 200, 0.14);
+  }
+
   .hero-countdown.tw-countdown {
     max-width: 100%;
+    gap: 9px;
+    min-height: 50px;
+    padding: 12px 18px 12px 15px;
+    font-size: 18px;
+  }
+
+  .hero-countdown .tw-countdown-dot {
+    width: 10px;
+    height: 10px;
+    box-shadow: 0 0 0 3px rgba(58, 114, 200, 0.14);
   }
 }


### PR DESCRIPTION
## What

Makes the WAVE1 countdown pill noticeably bigger and more prominent, per feedback that "it could be bigger". CSS-only.

Two skins resized ~1.5x:
- **`.brand-countdown`** (builder, under the logo) — previously inherited the base 12px with no size overrides. Now **18px / weight 800**, padding `11px 20px 11px 17px`, min-height 47px, status dot 12px.
- **`.hero-countdown`** (home page hero) — **14px → 21px / weight 800**, padding `10/16` → `15px 24px 15px 20px`, min-height 40 → 58px, status dot 12px.

Responsive `@media (max-width: 620px)` caps scaled down so neither overflows at ~360px (brand 16px, hero 18px, smaller padding/dot) — still clearly larger than the original.

## Scope

- Only `styles/countdown.css` (53 insertions, 3 deletions).
- Changes scoped to the two skin selectors + their scoped `.tw-countdown-dot`. Base `.tw-countdown` is untouched (shared by all instances).
- Did NOT touch `index.html` footer/nav (sibling PR p7-news-blog owns that).

## Before / after (computed, desktop)

| Pill | font-size | weight | padding | min-height | dot |
|---|---|---|---|---|---|
| brand before | 12px | 760 | 7/13/7/11 | 32px | 8px |
| brand after | **18px** | **800** | **11/20/11/17** | **47px** | **12px** |
| hero before | 14px | 760 | 10/16/10/13 | 40px | 8px |
| hero after | **21px** | **800** | **15/24/15/20** | **58px** | **12px** |

## Verification (Chrome, against edited source via dev server)

- Confirmed the on-screen pill is the DOM `<span class="tw-countdown-label">`, not the canvas `fillText` path — so font-size moves it.
- **Desktop (1440w):** brand `18px/800`, hero `21px/800` (274px wide, under the 320px cap). Both render bigger, one line, no overflow; brand sits below the logo with a clear gap, hero sits cleanly between the subhead and CTA buttons.
- **Narrow (`@media` active):** brand `16px` (width 207px, within `calc(100vw-32px)` cap), hero `18px` (width 230px). Both one line, no viewport overflow. Content width (nowrap) is well under 360px, so no overflow at 360px.

## Gates

- `npm run check` — green
- `npm run i18n:check` — green (320 keys × 5 locales)
- `npm run test:unit` — green (135 pass / 0 fail)

## Note

View-facing CSS: the served site is built `dist/` (not source), so `./publish.sh` is needed for this to appear on the served/prod site. **Not run here** — no prod deploy performed.

Do not merge — human review.

https://claude.ai/code/session_0114APN63DCt42WLUw7e9RxP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved countdown timer styling with enhanced spacing, typography, and visual hierarchy.
  * Updated visual indicators with refined dot styling and shadow effects for better visual feedback.
  * Optimized mobile layout with adjusted sizing and spacing for improved responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->