### PR TITLE
Add GitHub stars social proof: README star chart + live hero pill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tiny World Builder
 
+[![GitHub stars](https://img.shields.io/github/stars/jasonkneen/tiny-world-builder?style=flat&logo=github&label=Stars&color=3a72c8)](https://github.com/jasonkneen/tiny-world-builder/stargazers)
+
 <img width="1324" height="1016" alt="Screenshot 2026-05-11 at 07 09 24" src="https://github.com/user-attachments/assets/1b19a5f7-def5-42bf-b85f-01714f502afa" />
 
 ## Running locally
@@ -174,6 +176,12 @@ errors; place/erase works; `C`, `P`/`I`, `R`/`F`, and tool shortcuts respond;
 fence neighbors update; cloud shadow at 0% still leaves visible clouds.
 
 See [AGENTS.md](./AGENTS.md) for guidance on extending the codebase.
+
+## Star History
+
+If Tiny World Builder is useful to you, a star helps other builders find it.
+
+[![Star History Chart](https://api.star-history.com/svg?repos=jasonkneen/tiny-world-builder&type=Date)](https://star-history.com/#jasonkneen/tiny-world-builder&Date)
 
 ## Files
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300..700&display=swap" />
 <link rel="stylesheet" href="styles/landing.css" />
 <link rel="stylesheet" href="styles/countdown.css" />
+<link rel="stylesheet" href="styles/github-stars.css" />
 <link rel="preload" as="image" href="assets/landing-hero.png" />
 <script>
   (function landingAuthBootstrap() {
@@ -69,6 +70,14 @@
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
           </a>
         </div>
+        <a class="gh-stars-pill" id="gh-stars-pill" href="https://github.com/jasonkneen/tiny-world-builder" rel="noopener noreferrer" aria-label="Star Tiny World Builder on GitHub">
+          <svg class="gh-stars-mark" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .5a12 12 0 0 0-3.79 23.4c.6.11.82-.26.82-.58v-2.02c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.12-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 12 .5z"/></svg>
+          <span class="gh-stars-text">Star on GitHub</span>
+          <span class="gh-stars-count" data-gh-stars-count hidden>
+            <svg class="gh-stars-star" viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2 2.9 6.26 6.84.55-5.2 4.48 1.58 6.7L12 16.9l-6.12 3.59 1.58-6.7-5.2-4.48 6.84-.55z"/></svg>
+            <span data-gh-stars-value></span>
+          </span>
+        </a>
       </div>
       <aside class="hero-feed" id="hero-feed" aria-label="Live worlds" hidden>
         <div class="hero-feed-head">
@@ -221,6 +230,7 @@
     </section>
   </main>
   <script src="scripts/countdown.js" defer></script>
+  <script src="scripts/github-stars.js" defer></script>
   <script src="scripts/landing-auth-chip.js" defer></script>
   <script src="scripts/landing-feed.js" defer></script>
 </body>

--- a/scripts/github-stars.js
+++ b/scripts/github-stars.js
@@ -1,0 +1,53 @@
+/* Live GitHub stars count for the landing hero pill.
+ *
+ * Robustness contract:
+ * - The pill is a plain anchor to the repo, so it works with zero JS.
+ * - We hydrate the count from localStorage first, so repeat visitors see a
+ *   number instantly even when the API is rate-limited.
+ * - Unauthenticated api.github.com is ~60 req/hr per IP. A rate-limited call
+ *   RESOLVES with HTTP 403 (no stargazers_count), so we gate on res.ok and on
+ *   Number.isFinite — we only ever render a real integer, never undefined / 0
+ *   from a bad body / NaN. On any failure we keep the cached value or the plain
+ *   "Star on GitHub" label.
+ */
+(function githubStars() {
+  var REPO = 'jasonkneen/tiny-world-builder';
+  var CACHE_KEY = 'tw:gh-stars';
+
+  var pill = document.getElementById('gh-stars-pill');
+  if (!pill) return;
+  var countEl = pill.querySelector('[data-gh-stars-count]');
+  var valueEl = pill.querySelector('[data-gh-stars-value]');
+  if (!countEl || !valueEl) return;
+
+  function render(n) {
+    if (!Number.isFinite(n) || n < 0) return;
+    valueEl.textContent = Math.round(n).toLocaleString('en-US');
+    countEl.hidden = false;
+    pill.classList.add('has-count');
+  }
+
+  // 1) Hydrate immediately from cache (survives API rate limits).
+  try {
+    var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+    if (cached && Number.isFinite(cached.count)) render(cached.count);
+  } catch (err) { /* ignore malformed cache */ }
+
+  // 2) Best-effort live refresh.
+  fetch('https://api.github.com/repos/' + REPO, {
+    headers: { Accept: 'application/vnd.github+json' },
+  })
+    .then(function (res) {
+      if (!res.ok) throw new Error('github status ' + res.status);
+      return res.json();
+    })
+    .then(function (data) {
+      var n = data && data.stargazers_count;
+      if (!Number.isFinite(n)) throw new Error('missing stargazers_count');
+      render(n);
+      try {
+        localStorage.setItem(CACHE_KEY, JSON.stringify({ count: n, ts: Date.now() }));
+      } catch (err) { /* storage may be unavailable */ }
+    })
+    .catch(function () { /* keep cached value or the plain anchor label */ });
+})();

--- a/styles/github-stars.css
+++ b/styles/github-stars.css
@@ -1,0 +1,83 @@
+/* GitHub stars social-proof pill (landing hero). Glass-pill aesthetic shared
+   with the countdown chip so it reads as part of the same design language. */
+.gh-stars-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: max-content;
+  max-width: 100%;
+  min-height: 36px;
+  margin-top: 16px;
+  padding: 7px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.9) inset,
+    0 1px 2px rgba(20, 30, 50, 0.06),
+    0 16px 40px -22px rgba(10, 35, 90, 0.42);
+  color: #111b45;
+  font-family: var(--body-font, 'Space Grotesk', system-ui, sans-serif);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+  -webkit-backdrop-filter: blur(22px) saturate(180%);
+  backdrop-filter: blur(22px) saturate(180%);
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+.gh-stars-pill:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.9) inset,
+    0 1px 2px rgba(20, 30, 50, 0.08),
+    0 22px 48px -22px rgba(10, 35, 90, 0.5);
+}
+
+.gh-stars-pill:focus-visible {
+  outline: 2px solid var(--accent, #3a72c8);
+  outline-offset: 3px;
+}
+
+.gh-stars-mark {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 auto;
+  fill: currentColor;
+}
+
+.gh-stars-text {
+  display: block;
+}
+
+.gh-stars-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(58, 114, 200, 0.12);
+  color: var(--accent, #3a72c8);
+  font-variant-numeric: tabular-nums;
+  font-weight: 760;
+}
+
+.gh-stars-count[hidden] {
+  display: none;
+}
+
+.gh-stars-star {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  fill: #f5a623;
+}
+
+@media (max-width: 620px) {
+  .gh-stars-pill {
+    font-size: 12px;
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
Adds GitHub-stars social proof in two places. Repo: jasonkneen/tiny-world-builder.

## README.md
- shields.io stars badge near the title (`img.shields.io/github/stars/...`) — live, cached server-side.
- New **Star History** section embedding the star-history.com growth chart (the classic star chart), image linking to the interactive page.

## index.html landing hero — live stars pill
A glass-pill "Star on GitHub" widget placed right after the hero actions (a small, localized region; deliberately NOT in the nav, hero-countdown block, or footer to avoid collisions with the sibling countdown/news PRs).

**Approach: custom pill + client fetch + localStorage cache + anchor fallback.** Chosen over a bare shields image or a ghbtns iframe because it matches the site's existing glass-pill design language exactly while staying robust:
- The pill is a plain anchor to the repo, so it works with **zero JS**.
- Hydrates the count from `localStorage` first, so repeat visitors see a number instantly even when the API is rate-limited.
- Refreshes from `api.github.com`. Unauthenticated GitHub is ~60/hr per IP and a rate-limited call resolves with **HTTP 403** (no `stargazers_count`), so the code gates on `res.ok` + `Number.isFinite` and only ever renders a real integer — it degrades to the plain "Star on GitHub" label and **never shows undefined / 0 / NaN**. Cache is written only on success.

New files `styles/github-stars.css` + `scripts/github-stars.js` land in `dist/` via `publish.sh`'s recursive `styles/` and `scripts/` copy. **A `./publish.sh` build is needed for the change to appear on the served (dist) site — not run here; no prod deploy.**

No emoji. Mobile-responsive (verified at 360px). No console errors.

## Gates
- `npm run check` — pass
- `npm run i18n:check` — pass (320 keys x 5 locales)
- `npm run smoke` — pass
- `npm run test:unit` — pass (135/135)

## Browser verification (Playwright, dev server)
- **Desktop (1280px):** pill renders "Star on GitHub 1,023" (live count from api.github.com, cached), within viewport, 0 console errors.
- **360px:** pill within viewport (right edge 228 <= 360); the only horizontal overflow is the pre-existing `.cta-copy` / X tweet embed, not this widget.
- **Fallback (forced 403, no cache):** pill shows only "Star on GitHub" — count hidden, no number, no cache written.

https://claude.ai/code/session_01AnYtc8fDxaDuo1SAWjhCCn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub stars widget to the landing page that displays the repository's current star count with real-time updates from GitHub's API.
  * Added a Star History section to the README with a visual chart reference.
  * Integrated an interactive button on the hero section linking to GitHub starring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->