### PR TITLE
GitHub stars: fix 0-render + em dash + README hero/gallery (follow-up to #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/jasonkneen/tiny-world-builder?style=flat&logo=github&label=Stars&color=3a72c8)](https://github.com/jasonkneen/tiny-world-builder/stargazers)
 
-<img width="1324" height="1016" alt="Screenshot 2026-05-11 at 07 09 24" src="https://github.com/user-attachments/assets/1b19a5f7-def5-42bf-b85f-01714f502afa" />
+![Tiny World Builder](assets/landing-hero.png)
+
+A self-contained 3D voxel world editor in the browser: build, sculpt, fly
+through, and share tiny worlds.
+
+| Build | Fly |
+| --- | --- |
+| ![Build worlds](assets/landing-feature-build.png) | ![Fly and explore](assets/landing-feature-fly.png) |
+| Place terrain, props, homes, paths, crops, and animals. | Switch camera modes and explore from every angle. |
+
+| Sculpt | Share |
+| --- | --- |
+| ![Sculpt terrain](assets/landing-feature-sculpt.png) | ![Share your tinyverse](assets/landing-feature-share.png) |
+| Raise, lower, paint, and tune the ground into cliffs and rivers. | Save, remix, export, and open worlds to real players. |
 
 ## Running locally
 

--- a/scripts/github-stars.js
+++ b/scripts/github-stars.js
@@ -6,9 +6,9 @@
  *   number instantly even when the API is rate-limited.
  * - Unauthenticated api.github.com is ~60 req/hr per IP. A rate-limited call
  *   RESOLVES with HTTP 403 (no stargazers_count), so we gate on res.ok and on
- *   Number.isFinite — we only ever render a real integer, never undefined / 0
- *   from a bad body / NaN. On any failure we keep the cached value or the plain
- *   "Star on GitHub" label.
+ *   a positive finite integer - we only ever render a real count, never
+ *   undefined / 0 from a bad body / NaN. On any failure we keep the cached
+ *   value or the plain "Star on GitHub" label.
  */
 (function githubStars() {
   var REPO = 'jasonkneen/tiny-world-builder';
@@ -21,7 +21,7 @@
   if (!countEl || !valueEl) return;
 
   function render(n) {
-    if (!Number.isFinite(n) || n < 0) return;
+    if (!Number.isFinite(n) || n <= 0) return;
     valueEl.textContent = Math.round(n).toLocaleString('en-US');
     countEl.hidden = false;
     pill.classList.add('has-count');
@@ -30,7 +30,7 @@
   // 1) Hydrate immediately from cache (survives API rate limits).
   try {
     var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
-    if (cached && Number.isFinite(cached.count)) render(cached.count);
+    if (cached) render(cached.count);
   } catch (err) { /* ignore malformed cache */ }
 
   // 2) Best-effort live refresh.
@@ -43,7 +43,7 @@
     })
     .then(function (data) {
       var n = data && data.stargazers_count;
-      if (!Number.isFinite(n)) throw new Error('missing stargazers_count');
+      if (!Number.isFinite(n) || n <= 0) throw new Error('missing stargazers_count');
       render(n);
       try {
         localStorage.setItem(CACHE_KEY, JSON.stringify({ count: n, ts: Date.now() }));


### PR DESCRIPTION
Follow-up to #56 (which merged before this review round).

**Fixes (were blocking in #56's review):**
- scripts/github-stars.js: reject 0 stars before render AND before cache (n<=0), so the pill never shows 0; falls back to the plain 'Star on GitHub' label.
- Removed a non-ASCII em dash from a comment (ASCII-clean now).

**README screenshots (requested):**
- Replaced the stale external 2026-05-11 screenshot with repo-relative assets/landing-hero.png.
- Added a Build / Fly / Sculpt / Share gallery using assets/landing-feature-*.png.

Gates green (check, i18n:check, test:unit 135/135). Cross-reviewed (codex): CLEAN. No emoji. Not deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated landing section with new hero layout and refreshed feature grid highlighting core capabilities.

* **Bug Fixes**
  * Enhanced validation for star count display to prevent rendering invalid or zero values, with improved fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->