### PR TITLE
[codex] fix profile avatar URL normalization

### DIFF
--- a/.codex/skills/tinyworld-integrations/SKILL.md
+++ b/.codex/skills/tinyworld-integrations/SKILL.md
@@ -56,6 +56,11 @@ backend:
   `vendor/tinyworld-auth.js` with an import map to vendored
   `@netlify/identity` / `gotrue-js`; do not reintroduce a remote identity
   widget script.
+- Profile image fields stored through `/api/profile`, `/api/admin-users`, or
+  community preset-avatar saves must be absolute `http(s)` URLs. Preset avatar
+  paths under `assets/avatars/*.png` are normalized with the trusted site origin
+  from `TINYWORLD_SITE_URL` / Netlify `URL` / deploy URL envs before validation
+  and persistence; already-absolute URLs are left unchanged.
 - Account API fetches must send `Authorization: Bearer <nf_jwt>` when possible
   and `credentials: 'same-origin'` so Netlify Functions can resolve the current
   Identity user. Wallet login uses the same bearer path with signed

--- a/netlify/functions/admin-users.mjs
+++ b/netlify/functions/admin-users.mjs
@@ -1,7 +1,7 @@
 import { requireAuthUser } from './lib/auth.mjs';
 import { getSql, isDatabaseUnavailable } from './lib/db.mjs';
 import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
-import { ensureProfile, normalizeProfileHandle, normalizeUsername, profileDto } from './lib/profiles.mjs';
+import { ensureProfile, normalizeProfileHandle, normalizeProfileImageUrl, normalizeUsername, profileDto } from './lib/profiles.mjs';
 import { isWorldAdminEmail, worldAdminEmails } from './lib/worlds.mjs';
 
 export const config = { path: '/api/admin-users' };
@@ -45,7 +45,7 @@ function validateAdminEdit(body) {
   const username = normalizeUsername(body && body.username);
   const displayName = cleanText(body && body.displayName, 80);
   const about = cleanText(body && body.about, 1000);
-  const image = cleanText(body && body.image, 2048);
+  const image = normalizeProfileImageUrl(body && body.image);
   const email = cleanEmail(body && body.email);
   const twitter = normalizeProfileHandle(body && body.twitter);
   const github = normalizeProfileHandle(body && body.github);

--- a/netlify/functions/community.mjs
+++ b/netlify/functions/community.mjs
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { requireAuthUser } from './lib/auth.mjs';
 import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
 import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
-import { ensureProfile, profileDto } from './lib/profiles.mjs';
+import { ensureProfile, normalizeProfileImageUrl, profileDto } from './lib/profiles.mjs';
 import { emitCommunityEvent, screenMessage, suspendMember, activeSuspension, ensureSuspensionTable, unsuspendMember, deleteMessage, hideMessage, unhideMessage, SUSPENSION_HOURS, POLICY_NOTICE } from './lib/community-moderation.mjs';
 import { issueChallenge, verifySubmission, HONEYPOT_FIELD } from './lib/human-verification.mjs';
 
@@ -127,13 +127,13 @@ export function isValidTwitter(handle) { return TWITTER_RE.test(String(handle ||
 export function isValidGithub(handle) { return GITHUB_RE.test(String(handle || '')); }
 
 // -------- preset avatars (allowlist; no user uploads => no NSFW image risk) --------
-// Keys map to same-origin PNGs under assets/avatars/. Editing the profile can
-// only ever select one of these — arbitrary image URLs are rejected.
+// Keys map to canonical site PNGs under assets/avatars/. Editing the profile can
+// only ever select one of these; arbitrary image URLs are rejected.
 export const AVATAR_KEYS = ['knight', 'wizard', 'builder', 'explorer', 'knave', 'robot', 'fox', 'cat'];
 const AVATAR_BASE = '/assets/avatars/';
 export function avatarUrlForKey(key) {
   const k = String(key || '').trim().toLowerCase();
-  return AVATAR_KEYS.includes(k) ? AVATAR_BASE + k + '.png' : '';
+  return AVATAR_KEYS.includes(k) ? normalizeProfileImageUrl(AVATAR_BASE + k + '.png') : '';
 }
 // Reverse-map a stored image URL back to a preset key (for pre-selecting in UI).
 export function avatarKeyForUrl(url) {

--- a/netlify/functions/community.mjs
+++ b/netlify/functions/community.mjs
@@ -1,8 +1,8 @@
 import { randomBytes } from 'node:crypto';
 import { requireAuthUser } from './lib/auth.mjs';
 import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
-import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
-import { ensureProfile, normalizeProfileImageUrl, profileDto } from './lib/profiles.mjs';
+import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard, siteOrigin } from './lib/http.mjs';
+import { ensureProfile, normalizeProfileImageUrl, PROFILE_AVATAR_KEYS, profileDto } from './lib/profiles.mjs';
 import { emitCommunityEvent, screenMessage, suspendMember, activeSuspension, ensureSuspensionTable, unsuspendMember, deleteMessage, hideMessage, unhideMessage, SUSPENSION_HOURS, POLICY_NOTICE } from './lib/community-moderation.mjs';
 import { issueChallenge, verifySubmission, HONEYPOT_FIELD } from './lib/human-verification.mjs';
 
@@ -129,7 +129,7 @@ export function isValidGithub(handle) { return GITHUB_RE.test(String(handle || '
 // -------- preset avatars (allowlist; no user uploads => no NSFW image risk) --------
 // Keys map to canonical site PNGs under assets/avatars/. Editing the profile can
 // only ever select one of these; arbitrary image URLs are rejected.
-export const AVATAR_KEYS = ['knight', 'wizard', 'builder', 'explorer', 'knave', 'robot', 'fox', 'cat'];
+export const AVATAR_KEYS = PROFILE_AVATAR_KEYS;
 const AVATAR_BASE = '/assets/avatars/';
 export function avatarUrlForKey(key) {
   const k = String(key || '').trim().toLowerCase();
@@ -137,7 +137,20 @@ export function avatarUrlForKey(key) {
 }
 // Reverse-map a stored image URL back to a preset key (for pre-selecting in UI).
 export function avatarKeyForUrl(url) {
-  const m = String(url || '').match(/\/assets\/avatars\/([a-z]+)\.png$/i);
+  let raw = String(url || '').trim();
+  if (!raw) return '';
+  if (/^https?:\/\//i.test(raw)) {
+    let parsed;
+    try {
+      parsed = new URL(raw);
+    } catch (_) {
+      return '';
+    }
+    if (parsed.origin !== siteOrigin()) return '';
+    raw = parsed.pathname;
+  }
+  const path = '/' + raw.split(/[?#]/)[0].replace(/^\/+/, '');
+  const m = path.match(/^\/assets\/avatars\/([a-z]+)\.png$/i);
   return m && AVATAR_KEYS.includes(m[1].toLowerCase()) ? m[1].toLowerCase() : '';
 }
 

--- a/netlify/functions/lib/http.mjs
+++ b/netlify/functions/lib/http.mjs
@@ -1,11 +1,37 @@
 // -------- cors allowlist --------
+const DEFAULT_SITE_ORIGIN = 'https://tinyworld.build';
+
+export function siteOrigin() {
+  const raw = process.env.TINYWORLD_SITE_URL || process.env.URL || process.env.DEPLOY_PRIME_URL || process.env.DEPLOY_URL || DEFAULT_SITE_ORIGIN;
+  try {
+    return new URL(raw).origin;
+  } catch (_) {
+    return DEFAULT_SITE_ORIGIN;
+  }
+}
+
+export function absoluteSiteUrl(path) {
+  const value = String(path == null ? '' : path).trim();
+  if (!value || /^https?:\/\//i.test(value)) return value;
+  return new URL(value.replace(/^\/+/, ''), siteOrigin() + '/').href;
+}
+
+function envOrigin(value) {
+  if (!value) return '';
+  try {
+    return new URL(value).origin;
+  } catch (_) {
+    return '';
+  }
+}
+
 // Reflect the caller Origin only when it matches the deployed site URL (prod +
 // branch/deploy previews) or localhost for dev; otherwise omit the header. We
 // never emit Access-Control-Allow-Credentials, so a missing ACAO simply blocks
 // the cross-origin read rather than leaking it.
 function isAllowedOrigin(origin) {
   if (!origin) return false;
-  const siteOrigins = [process.env.URL, process.env.DEPLOY_PRIME_URL, process.env.DEPLOY_URL].filter(Boolean);
+  const siteOrigins = [process.env.TINYWORLD_SITE_URL, process.env.URL, process.env.DEPLOY_PRIME_URL, process.env.DEPLOY_URL].map(envOrigin).filter(Boolean);
   if (siteOrigins.includes(origin)) return true;
   return /^http:\/\/localhost(:\d+)?$/.test(origin);
 }

--- a/netlify/functions/lib/profiles.mjs
+++ b/netlify/functions/lib/profiles.mjs
@@ -1,4 +1,5 @@
 import { getSql } from './db.mjs';
+import { absoluteSiteUrl } from './http.mjs';
 
 function cleanText(value, limit) {
   return String(value || '').trim().slice(0, limit);
@@ -27,6 +28,13 @@ export function normalizeProfileHandle(value) {
   return s.replace(/[^a-zA-Z0-9_-]+/g, '').slice(0, 39);
 }
 
+export function normalizeProfileImageUrl(value, limit = 2048) {
+  const image = cleanText(value, limit);
+  if (!image || /^https?:\/\//i.test(image)) return image;
+  if (/^\/?assets\/avatars\/[a-z]+\.png$/i.test(image)) return absoluteSiteUrl(image);
+  return image;
+}
+
 function defaultUsernameForUser(user) {
   const metadata = user.userMetadata || {};
   const raw = normalizeUsername(metadata.username || metadata.display_name || metadata.full_name || metadata.name || user.email);
@@ -45,7 +53,7 @@ function defaultDisplayNameForUser(user) {
 
 function defaultImageForUser(user) {
   const metadata = user.userMetadata || {};
-  return cleanText(user.pictureUrl || metadata.avatar_url || metadata.picture || metadata.image, 2048);
+  return normalizeProfileImageUrl(user.pictureUrl || metadata.avatar_url || metadata.picture || metadata.image);
 }
 
 export function profileDto(row) {
@@ -57,7 +65,7 @@ export function profileDto(row) {
     username: row.username,
     displayName: row.display_name,
     about: row.about || '',
-    image: row.image || '',
+    image: normalizeProfileImageUrl(row.image),
     twitter: row.twitter || '',
     github: row.github || '',
     lobbyAccess: !!row.lobby_access,

--- a/netlify/functions/lib/profiles.mjs
+++ b/netlify/functions/lib/profiles.mjs
@@ -1,6 +1,8 @@
 import { getSql } from './db.mjs';
 import { absoluteSiteUrl } from './http.mjs';
 
+export const PROFILE_AVATAR_KEYS = ['knight', 'wizard', 'builder', 'explorer', 'knave', 'robot', 'fox', 'cat'];
+
 function cleanText(value, limit) {
   return String(value || '').trim().slice(0, limit);
 }
@@ -30,8 +32,11 @@ export function normalizeProfileHandle(value) {
 
 export function normalizeProfileImageUrl(value, limit = 2048) {
   const image = cleanText(value, limit);
-  if (!image || /^https?:\/\//i.test(image)) return image;
-  if (/^\/?assets\/avatars\/[a-z]+\.png$/i.test(image)) return absoluteSiteUrl(image);
+  if (!image) return '';
+  if (/^https?:\/\//i.test(image)) return image;
+  const m = image.match(/^\/?assets\/avatars\/([a-z]+)\.png$/i);
+  const key = m ? m[1].toLowerCase() : '';
+  if (key && PROFILE_AVATAR_KEYS.includes(key)) return absoluteSiteUrl(image);
   return image;
 }
 

--- a/netlify/functions/profile.mjs
+++ b/netlify/functions/profile.mjs
@@ -1,7 +1,7 @@
 import { requireAuthUser } from './lib/auth.mjs';
 import { getSql, isDatabaseUnavailable } from './lib/db.mjs';
 import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
-import { ensureProfile, normalizeProfileHandle, normalizeUsername, profileDto } from './lib/profiles.mjs';
+import { ensureProfile, normalizeProfileHandle, normalizeProfileImageUrl, normalizeUsername, profileDto } from './lib/profiles.mjs';
 
 export const config = { path: '/api/profile' };
 
@@ -9,7 +9,7 @@ function validateProfile(body) {
   const username = normalizeUsername(body && body.username);
   const displayName = String((body && body.displayName) || '').trim().slice(0, 80);
   const about = String((body && body.about) || '').trim().slice(0, 1000);
-  const image = String((body && body.image) || '').trim().slice(0, 2048);
+  const image = normalizeProfileImageUrl(body && body.image);
   const twitter = normalizeProfileHandle(body && body.twitter);
   const github = normalizeProfileHandle(body && body.github);
   if (!/^[a-z0-9_]{3,24}$/.test(username)) return { error: 'Username must be 3-24 lowercase letters, numbers, underscores' };

--- a/tests/community-profile.test.mjs
+++ b/tests/community-profile.test.mjs
@@ -38,15 +38,29 @@ test('github validity allows single non-edge hyphens', () => {
   assert.ok(!isValidGithub('a--b'));
 });
 
-// -------- preset avatars (allowlist) --------
-test('avatar keys map to same-origin preset PNGs only', () => {
-  for (const k of AVATAR_KEYS) {
-    assert.equal(avatarUrlForKey(k), '/assets/avatars/' + k + '.png');
+function withTinyworldSiteUrl(fn) {
+  const old = process.env.TINYWORLD_SITE_URL;
+  process.env.TINYWORLD_SITE_URL = 'https://tinyworld.build';
+  try {
+    fn();
+  } finally {
+    if (old === undefined) delete process.env.TINYWORLD_SITE_URL;
+    else process.env.TINYWORLD_SITE_URL = old;
   }
-  assert.equal(avatarUrlForKey('evil'), '');
-  assert.equal(avatarUrlForKey('http://x/y.png'), '');
-  assert.equal(avatarKeyForUrl('/assets/avatars/fox.png'), 'fox');
-  assert.equal(avatarKeyForUrl('https://evil.example/x.png'), '');
+}
+
+// -------- preset avatars (allowlist) --------
+test('avatar keys map to absolute preset PNGs only', () => {
+  withTinyworldSiteUrl(() => {
+    for (const k of AVATAR_KEYS) {
+      assert.equal(avatarUrlForKey(k), 'https://tinyworld.build/assets/avatars/' + k + '.png');
+    }
+    assert.equal(avatarUrlForKey('evil'), '');
+    assert.equal(avatarUrlForKey('http://x/y.png'), '');
+    assert.equal(avatarKeyForUrl('/assets/avatars/fox.png'), 'fox');
+    assert.equal(avatarKeyForUrl('https://tinyworld.build/assets/avatars/fox.png'), 'fox');
+    assert.equal(avatarKeyForUrl('https://evil.example/x.png'), '');
+  });
 });
 
 // -------- content safety --------

--- a/tests/community-profile.test.mjs
+++ b/tests/community-profile.test.mjs
@@ -59,7 +59,10 @@ test('avatar keys map to absolute preset PNGs only', () => {
     assert.equal(avatarUrlForKey('http://x/y.png'), '');
     assert.equal(avatarKeyForUrl('/assets/avatars/fox.png'), 'fox');
     assert.equal(avatarKeyForUrl('https://tinyworld.build/assets/avatars/fox.png'), 'fox');
+    assert.equal(avatarKeyForUrl('https://tinyworld.build/assets/avatars/wizard.png'), 'wizard');
+    assert.equal(avatarKeyForUrl('https://evil.example/assets/avatars/wizard.png'), '');
     assert.equal(avatarKeyForUrl('https://evil.example/x.png'), '');
+    assert.equal(avatarKeyForUrl('https://tinyworld.build/assets/avatars/notakey.png'), '');
   });
 });
 

--- a/tests/profile-image-url.test.mjs
+++ b/tests/profile-image-url.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeProfileImageUrl } from '../netlify/functions/lib/profiles.mjs';
+
+const SITE_ENV_KEYS = ['TINYWORLD_SITE_URL', 'URL', 'DEPLOY_PRIME_URL', 'DEPLOY_URL'];
+
+function withSiteEnv(env, fn) {
+  const old = {};
+  for (const key of SITE_ENV_KEYS) {
+    old[key] = process.env[key];
+    delete process.env[key];
+  }
+  Object.assign(process.env, env);
+  try {
+    fn();
+  } finally {
+    for (const key of SITE_ENV_KEYS) {
+      if (old[key] === undefined) delete process.env[key];
+      else process.env[key] = old[key];
+    }
+  }
+}
+
+test('normalizes preset avatar paths against the configured site origin', () => {
+  withSiteEnv({ TINYWORLD_SITE_URL: 'https://tinyworld.build' }, () => {
+    assert.equal(
+      normalizeProfileImageUrl('/assets/avatars/wizard.png'),
+      'https://tinyworld.build/assets/avatars/wizard.png',
+    );
+    assert.equal(
+      normalizeProfileImageUrl('assets/avatars/wizard.png'),
+      'https://tinyworld.build/assets/avatars/wizard.png',
+    );
+  });
+});
+
+test('keeps already absolute profile image URLs unchanged', () => {
+  withSiteEnv({ TINYWORLD_SITE_URL: 'https://tinyworld.build' }, () => {
+    assert.equal(
+      normalizeProfileImageUrl('https://cdn.example.test/avatars/wizard.png'),
+      'https://cdn.example.test/avatars/wizard.png',
+    );
+    assert.equal(
+      normalizeProfileImageUrl('http://localhost:8888/assets/avatars/wizard.png'),
+      'http://localhost:8888/assets/avatars/wizard.png',
+    );
+  });
+});
+
+test('does not bless arbitrary relative profile image paths', () => {
+  withSiteEnv({ TINYWORLD_SITE_URL: 'https://tinyworld.build' }, () => {
+    assert.equal(normalizeProfileImageUrl('/uploads/custom.png'), '/uploads/custom.png');
+    assert.equal(normalizeProfileImageUrl('javascript:alert(1)'), 'javascript:alert(1)');
+  });
+});

--- a/tests/profile-image-url.test.mjs
+++ b/tests/profile-image-url.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizeProfileImageUrl } from '../netlify/functions/lib/profiles.mjs';
+import { normalizeProfileImageUrl, profileDto } from '../netlify/functions/lib/profiles.mjs';
 
 const SITE_ENV_KEYS = ['TINYWORLD_SITE_URL', 'URL', 'DEPLOY_PRIME_URL', 'DEPLOY_URL'];
 
@@ -31,6 +31,7 @@ test('normalizes preset avatar paths against the configured site origin', () => 
       normalizeProfileImageUrl('assets/avatars/wizard.png'),
       'https://tinyworld.build/assets/avatars/wizard.png',
     );
+    assert.equal(normalizeProfileImageUrl('/assets/avatars/notakey.png'), '/assets/avatars/notakey.png');
   });
 });
 
@@ -52,4 +53,11 @@ test('does not bless arbitrary relative profile image paths', () => {
     assert.equal(normalizeProfileImageUrl('/uploads/custom.png'), '/uploads/custom.png');
     assert.equal(normalizeProfileImageUrl('javascript:alert(1)'), 'javascript:alert(1)');
   });
+});
+
+test('keeps empty profile image values as strings', () => {
+  assert.equal(normalizeProfileImageUrl(null), '');
+  assert.equal(normalizeProfileImageUrl(undefined), '');
+  assert.equal(profileDto({ image: null }).image, '');
+  assert.equal(profileDto({ image: undefined }).image, '');
 });


### PR DESCRIPTION
## Summary
- Normalize preset avatar image paths to absolute site URLs before profile/admin persistence.
- Store community preset avatar selections as absolute URLs going forward and normalize profile DTOs so existing relative avatar rows do not round-trip back into the save validator.
- Add focused unit coverage for leading-slash/no-slash avatar joins, already-absolute URL idempotence, and non-avatar relative rejection behavior.

## Root Cause
Community profile saves produced preset avatar URLs with `AVATAR_BASE = '/assets/avatars/'`, so `profiles.image` could contain values like `/assets/avatars/wizard.png`. The builder account modal loads `/api/profile`, copies `p.image` into the profile image input, and sends it back on `PUT /api/profile`.

`netlify/functions/profile.mjs` rejects non-absolute profile images in `validateProfile` with `Image must be an https URL` unless the URL is `http://localhost/...`. That server-side URL validator is why the same relative path renders in the browser but fails on profile save.

The canonical base origin now comes from the trusted site env chain (`TINYWORLD_SITE_URL`, Netlify `URL`, `DEPLOY_PRIME_URL`, `DEPLOY_URL`) with a centralized fallback of `https://tinyworld.build`. I also checked `https://tinyworld.build/assets/avatars/wizard.png` and it returns HTTP 200 from Netlify.

## Validation
- `npm test`
- `npm run build`
- `curl -I --max-time 15 https://tinyworld.build/assets/avatars/wizard.png`

`dist/` is generated by `publish.sh`; the build was run, but no `dist/` files are tracked in this repo, so no generated output is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar images are now normalized to absolute `https` URLs, ensuring consistent display across deployments.
  * Preset avatar paths are resolved using the configured site origin (including for profile edits).
  * Profile image validation now accepts only proper absolute `http(s)` URLs, with safer handling of unsafe/relative inputs.
  * Improved origin checking for cross-origin access based on deployed site URL.
* **Documentation**
  * Updated avatar image requirements in the skill instructions to require absolute `http(s)` URLs.
* **Tests**
  * Expanded automated tests for avatar URL normalization and profile image handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->