### PR TITLE
Auto-enable Tinyverse access for verified accounts

### DIFF
--- a/netlify/functions/admin-users.mjs
+++ b/netlify/functions/admin-users.mjs
@@ -1,4 +1,4 @@
-import { requireAuthUser } from './lib/auth.mjs';
+import { accountMeetsCriteria, requireAuthUser } from './lib/auth.mjs';
 import { getSql, isDatabaseUnavailable } from './lib/db.mjs';
 import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
 import { ensureProfile, normalizeProfileHandle, normalizeUsername, profileDto } from './lib/profiles.mjs';
@@ -28,7 +28,16 @@ function isBuiltInTinyverseEmail(email) {
 }
 
 function canAccessTinyverse(user, profile) {
-  return isWorldAdminEmail(user && user.email) || isBuiltInTinyverseEmail(profile && profile.email) || !!(profile && profile.lobby_access);
+  // accountMeetsCriteria(user) makes Tinyverse access default ON for registered,
+  // email-verified accounts (no admin toggle needed). Consequence: lobby_access
+  // is no longer required for, and can no longer deny, a verified account here -
+  // it remains the explicit admin grant for accounts that do NOT auto-qualify
+  // (e.g. wallet-only). Bans are enforced separately via suspensions in
+  // worlds.mjs (activeSuspension), not via this flag.
+  return isWorldAdminEmail(user && user.email)
+    || isBuiltInTinyverseEmail(profile && profile.email)
+    || accountMeetsCriteria(user)
+    || !!(profile && profile.lobby_access);
 }
 
 function adminUserDto(row) {

--- a/netlify/functions/lib/auth.mjs
+++ b/netlify/functions/lib/auth.mjs
@@ -94,6 +94,10 @@ function userFromIdentityPayload(payload) {
   return {
     id: payload.id,
     email: payload.email,
+    // GoTrue returns confirmed_at (snake_case); normalize to confirmedAt so this
+    // bearer-fallback path matches the @netlify/identity getUser() shape that
+    // accountMeetsCriteria() reads.
+    confirmedAt: payload.confirmed_at || payload.confirmedAt || null,
     name: userMetadata.full_name || userMetadata.name || payload.email,
     pictureUrl: userMetadata.avatar_url || userMetadata.picture,
     userMetadata,
@@ -205,4 +209,28 @@ export async function requireAuthUser(request, origin) {
   const user = await getAuthUser(request);
   if (!user || !user.id) return { response: errorResponse('Unauthorized', 401, origin) };
   return { user };
+}
+
+// Centralized access-criteria predicate. This is the SINGLE place that decides
+// whether an account qualifies for auto-enabled Tinyverse/lobby/multiplayer
+// access, so the rule can change in one spot (a wallet-policy decision is still
+// pending upstream).
+//
+// Initial criterion: a registered, email-verified Netlify Identity account
+// (confirmedAt set). Wallet-only sessions (id prefixed `wallet:`), unverified
+// Identity accounts, and anonymous/logged-out callers do NOT qualify for now.
+//
+// Fails closed: getAuthUser()/getUser() may fall back to raw JWT claims if the
+// Identity API is unreachable, in which case confirmedAt is undefined and this
+// returns false (a verified user briefly loses auto-access). There is no path
+// that spuriously sets confirmedAt, so it never grants access to an
+// unverified/wallet account.
+export function accountMeetsCriteria(account) {
+  if (!account || !account.id) return false;
+  // Wallet sessions carry no Identity email confirmation; revisit when the
+  // wallet-access policy is decided.
+  if (String(account.id).startsWith('wallet:')) return false;
+  // getUser() exposes confirmedAt; the bearer-fallback path normalizes the
+  // GoTrue confirmed_at into confirmedAt (see userFromIdentityPayload).
+  return !!(account.confirmedAt || account.confirmed_at);
 }

--- a/tests/account-criteria.test.mjs
+++ b/tests/account-criteria.test.mjs
@@ -1,0 +1,43 @@
+// Unit tests for accountMeetsCriteria() - the single centralized predicate that
+// decides whether an account auto-qualifies for Tinyverse/lobby/multiplayer
+// access. Run with: npm run test:unit
+//
+// The rule is intentionally narrow for now (registered, email-verified Identity
+// account) because a wallet-access policy decision is still pending upstream.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  accountMeetsCriteria,
+  walletUserFromPublicKey,
+} from '../netlify/functions/lib/auth.mjs';
+
+test('verified Identity account (confirmedAt set) meets criteria', () => {
+  const user = { id: 'abc-123', email: 'a@b.com', confirmedAt: '2026-01-02T03:04:05Z' };
+  assert.equal(accountMeetsCriteria(user), true);
+});
+
+test('snake_case confirmed_at (bearer-fallback payload shape) meets criteria', () => {
+  const user = { id: 'abc-123', email: 'a@b.com', confirmed_at: '2026-01-02T03:04:05Z' };
+  assert.equal(accountMeetsCriteria(user), true);
+});
+
+test('unverified Identity account (no confirmation) does NOT meet criteria', () => {
+  const user = { id: 'abc-123', email: 'a@b.com', confirmedAt: undefined };
+  assert.equal(accountMeetsCriteria(user), false);
+  assert.equal(accountMeetsCriteria({ id: 'abc-123', email: 'a@b.com', confirmedAt: '' }), false);
+  assert.equal(accountMeetsCriteria({ id: 'abc-123', email: 'a@b.com', confirmedAt: null }), false);
+});
+
+test('wallet-only session does NOT meet criteria (even if a stray confirmedAt is present)', () => {
+  const wallet = walletUserFromPublicKey('11111111111111111111111111111111');
+  assert.equal(accountMeetsCriteria(wallet), false);
+  assert.equal(accountMeetsCriteria({ id: 'wallet:xyz', confirmedAt: '2026-01-02T03:04:05Z' }), false);
+});
+
+test('anonymous / malformed accounts do NOT meet criteria', () => {
+  assert.equal(accountMeetsCriteria(null), false);
+  assert.equal(accountMeetsCriteria(undefined), false);
+  assert.equal(accountMeetsCriteria({}), false);
+  assert.equal(accountMeetsCriteria({ confirmedAt: '2026-01-02T03:04:05Z' }), false); // no id
+});


### PR DESCRIPTION
## Goal
Make Tinyverse / multiplayer access turn ON **automatically** for an account once it meets access criteria, instead of requiring a manual admin toggle. Accounts that do not qualify keep the current default (no access / observer).

## 1. Where the setting + criteria live (investigation)
- **The "setting" is a server-side gate, not a client toggle.** `canAccessTinyverse(user, profile)` in `netlify/functions/admin-users.mjs` is the authoritative source. The client (`engine/world/30-ui-boot-wiring.js`) reads it via `GET /api/admin-users?action=tinyverse-access` and uses the result only to enable/disable the welcome "Tinyverse" button. There is **no** user-facing or client-persisted multiplayer toggle (grep of all HTML modals + `engine/` confirms: only `admin-users.html` has a checkbox, and it is admin-only).
- **Prior model:** access was invite-only via `profiles.lobby_access` (BOOLEAN, default FALSE), set by an admin on `/admin-users`. `canAccessTinyverse` granted access to god-admin emails, built-in Tinyverse emails, or accounts with `lobby_access = true`.
- **Account / verified model:** Netlify Identity + Phantom wallet. `@netlify/identity` `getUser()` returns the full server-side user including `confirmedAt` (ISO timestamp of email verification, `undefined` if unverified). Wallet sessions use an `id` prefixed `wallet:` and carry no email/confirmation.
- **Play-peer vs. UI gate:** `roleFor()` in `worlds.mjs` grants role `play` to **any logged-in profile** in a published world and mints a signed join token whenever `WORLDS_JOIN_SECRET`/`WORLDS_SERVICE_TOKEN` is set. This is independent of `lobby_access` — the access gate is a soft client-UI gate, not the play-token boundary.

## 2. Centralized predicate
`accountMeetsCriteria(account)` in `netlify/functions/lib/auth.mjs` — the single place the rule lives (a wallet-policy decision is still pending upstream). Initial criterion: a registered, email-verified Identity account (`confirmedAt` set). Wallet-only (`wallet:` id), unverified, and anonymous accounts return `false`.

## 3. Auto-on wiring
`accountMeetsCriteria(user)` is OR'd into `canAccessTinyverse`. Verified accounts now get access by default with no admin toggle.
- **No stored opt-out preference exists** in the model (`lobby_access` is opt-IN only), so auto-on simply defaults on — it does not override any user opt-out because there is none to override.
- **Behavior change surfaced:** `lobby_access` is no longer required for, and can no longer deny, a verified account. Bans are enforced separately via suspensions (`activeSuspension` in `worlds.mjs`), which `lobby_access` was never used for. The admin DTO's `lobbyAccess` badge still reflects the raw column, so it may show "Off" for a verified user who now has effective access (left as-is for scope).

## 4. Server-side gap for true play-peer join
**None.** `roleFor()` already mints a signed `play` token for any logged-in profile in a published world when `WORLDS_JOIN_SECRET`/`WORLDS_SERVICE_TOKEN` is configured (the case in prod). So a qualifying account becomes a real play peer with **no server change and no secret weakened**. `accountMeetsCriteria` was deliberately wired only into the soft client-UI access gate; `roleFor`/token minting is untouched.

### Fail-closed note
If the Identity API is unreachable, `getUser()` falls back to raw JWT claims and `confirmedAt` is `undefined` → predicate returns `false` (a verified user briefly loses *auto*-access). There is no path that spuriously sets `confirmedAt`, so an unverified/wallet account can never auto-qualify.

## 5. Gates (green)
- `npm test` (check + smoke + 140 unit tests incl. 5 new predicate tests): pass
- `npm run i18n:check`: pass (320 keys x 5 locales, untouched)

## Dist / rebuild
Diff touches only `netlify/functions/` + tests. Netlify functions run from source — **no `dist/` rebuild needed** for this change to take effect.

https://claude.ai/code/session_01NXsnQL6nsq3UzLwvwh22tE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced access control for Tinyverse with centralized account verification criteria checks.

* **Bug Fixes**
  * Standardized account confirmation field handling across different authentication payload formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->