### PR TITLE
Limit non-admin feature votes to 1; admin unlimited

### DIFF
--- a/features.html
+++ b/features.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="description" content="Suggest and vote on features for Tiny World Builder. Your coin balance determines your vote weight." />
+<meta name="description" content="Suggest and vote on features for Tiny World Builder. One vote per idea." />
 <title>Feature Suggestions - Tiny World Builder</title>
 <link rel="icon" href="assets/twlogo.png" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -345,7 +345,7 @@
     <section class="page-hero-section" style="padding-bottom:24px" aria-labelledby="page-title">
       <div class="page-hero-copy">
         <h1 id="page-title">Feature Suggestions</h1>
-        <p>Got an idea? Connect your Phantom wallet and submit. Your coin balance sets your vote weight.</p>
+        <p>Got an idea? Connect your Phantom wallet and submit. Each wallet gets one vote per idea.</p>
       </div>
     </section>
 
@@ -390,7 +390,7 @@
   <div class="suggest-modal-back" id="suggest-modal-back" role="dialog" aria-modal="true" aria-labelledby="suggest-title">
     <div class="suggest-modal">
       <h2 id="suggest-title">Suggest a feature</h2>
-      <p>Requires a Phantom wallet holding at least 100 coins. Your coin balance becomes your initial vote weight.</p>
+      <p>Requires a Phantom wallet holding at least 100 coins. Each wallet gets one vote per idea.</p>
       <div class="modal-wallet-status wallet-none" id="wallet-status">
         Connect your Phantom wallet to submit.
       </div>

--- a/netlify/functions/features.mjs
+++ b/netlify/functions/features.mjs
@@ -208,16 +208,39 @@ export default async function featuresFunction(request) {
       const suggestionId = Number(body && body.suggestionId);
       const vote = Number(body && body.vote) === -1 ? -1 : 1;
       if (!suggestionId) return errorResponse('suggestionId is required', 400, origin);
+      // Eligibility gate (pre-existing, client-trusted): a non-admin needs a minimum
+      // claimed coin balance to vote at all. This gates WHETHER you may vote; it no
+      // longer determines vote WEIGHT (see below). Tightening this gate to a verified
+      // on-chain balance is out of scope here.
       if (!isAdminReq && coinBalance < MIN_COIN_BALANCE) return errorResponse('Insufficient coin balance to vote', 403, origin);
       try {
         const sql = getSql();
         await ensureTables(sql);
-        await sql`
-          INSERT INTO feature_votes (suggestion_id, wallet, coin_balance, vote)
-          VALUES (${suggestionId}, ${wallet}, ${coinBalance}, ${vote})
-          ON CONFLICT (suggestion_id, wallet) DO UPDATE
-            SET vote = ${vote}, coin_balance = ${coinBalance}, created_at = NOW()
-        `;
+        // One vote per user per item, enforced server-side. A non-admin's contribution
+        // to vote_weight is pinned to exactly 1, regardless of the client-supplied
+        // coinBalance. This closes the old exploit where a single vote counted for the
+        // (unverified, client-claimed) coin balance - up to MIN_COIN_BALANCE and
+        // beyond. UNIQUE(suggestion_id, wallet) already keeps it to one row per wallet.
+        //
+        // Admins are exempt from the cap: each admin click ACCUMULATES weight (+1,
+        // unbounded) on their single row, so an admin can repeatedly boost or sink an
+        // item with no per-user limit. Authority is the server's isAdminReq (verified
+        // admin email or local-dev secret) - never a client-supplied flag.
+        if (isAdminReq) {
+          await sql`
+            INSERT INTO feature_votes (suggestion_id, wallet, coin_balance, vote)
+            VALUES (${suggestionId}, ${wallet}, 1, ${vote})
+            ON CONFLICT (suggestion_id, wallet) DO UPDATE
+              SET vote = ${vote}, coin_balance = feature_votes.coin_balance + 1, created_at = NOW()
+          `;
+        } else {
+          await sql`
+            INSERT INTO feature_votes (suggestion_id, wallet, coin_balance, vote)
+            VALUES (${suggestionId}, ${wallet}, 1, ${vote})
+            ON CONFLICT (suggestion_id, wallet) DO UPDATE
+              SET vote = ${vote}, coin_balance = 1, created_at = NOW()
+          `;
+        }
         // Recompute vote_weight as sum of coin_balance * vote.
         await sql`
           UPDATE feature_suggestions


### PR DESCRIPTION
## What & why

On the feature-suggestions / voting page, a non-admin's single vote counted for far more than one. Fixes that: **non-admins get exactly one vote per item; the world-admin is exempt and can keep voting with no cap.**

### 1. Where the cap lives & current storage model
- **Page:** `features.html` (client) + `netlify/functions/features.mjs` `action=vote` (server, authoritative). This is the only suggestions/voting system; `community.mjs` is chat moderation (report/downvote), unrelated.
- **Storage model:** coin-weighted, NOT a stackable count. `feature_votes` has `UNIQUE(suggestion_id, wallet)` + `ON CONFLICT DO UPDATE`, so there is already **one row per wallet per item** (a toggle: re-clicking switches direction; there is no un-vote/removal). `vote_weight = SUM(coin_balance * vote)`.
- **The real bug (not "100 clicks"):** the per-row `coin_balance` was taken from the **client-supplied, unverified** `body.coinBalance` (clamped only to `>= 0`). So one non-admin vote was worth their *claimed* balance — `MIN_COIN_BALANCE` (100) at minimum and unbounded above. The "100" is `MIN_COIN_BALANCE`.

### 2. How admin is detected (not spoofable)
Server computes `isAdminReq = await isAdmin(request)` from `getAuthUser(request)` + `isWorldAdminEmail(user.email)` (the account allowlist from PR #50 in `lib/worlds.mjs`), with a localhost-only secret fallback. It is derived from the verified session on the request — **never** from a request-body flag — so a client cannot claim admin.

### 3. Enforcement (server-authoritative)
- **Non-admin:** vote contribution pinned to exactly `1` on both INSERT and `ON CONFLICT` (client `coinBalance` ignored for weight). One vote per user per item.
- **Admin:** `ON CONFLICT DO UPDATE SET coin_balance = feature_votes.coin_balance + 1` — each click accumulates unbounded, so admins can repeatedly boost/sink an item.
- **Client copy** updated (meta description, hero, suggest modal) from "coin balance determines your vote weight" to "one vote per idea". The vote control itself is unchanged: it already reflects a single vote via the `voted-up`/`voted-down` toggle highlight, and the admin-only UI is gated on the existing `adminMode`/`serverSaysAdmin` signal.

### 4. Existing >1 tallies
Old `feature_votes` rows keep their stored `coin_balance` (up to 100) until that wallet next votes; because `vote_weight` is recomputed from stored balances on every vote, each item's score stays a **mix of old (<=100) and new (1)** contributions until re-voted. Not silently corrupted. A one-shot normalization (NOT performed here, deliberately left to the operator) would be:
```sql
UPDATE feature_votes SET coin_balance = 1 WHERE wallet <> 'admin' AND coin_balance <> 1;
UPDATE feature_suggestions s SET vote_weight =
  (SELECT COALESCE(SUM(coin_balance*vote),0) FROM feature_votes WHERE suggestion_id = s.id);
```
This was intentionally not placed in `ensureTables` (which runs every request).

### 5. Rate-limit note
`features.mjs` has **no** vote rate-limiter, so there is nothing for admin to bypass. The `UNIQUE(suggestion_id, wallet)` constraint is the per-user limit. No limiter added.

### 6. Gates
- `npm test` — 135/135 pass
- `npm run i18n:check` — pass (320 keys x 5 locales; `features.html` copy is not i18n-managed)
- `npm run build` — pass

**dist:** `features.html` is copied into `dist/` by `publish.sh`, so a rebuild is needed for the client copy to ship. `dist/` is gitignored — not committed.

https://claude.ai/code/session_016YaEVb3PwA5Mbu64MTYCk3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Feature voting simplified: Each wallet now receives one vote per idea, replacing coin-balance-weighted voting
  * Updated feature page messaging to reflect new voting model
  * Minimum coin requirement (100 coins) retained for voting eligibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->