### PR TITLE
Roadmap: inline admin control for wave assignment

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -399,6 +399,23 @@
 }
 .kanban-card .wave-badge { margin-top: 8px; }
 
+/* Admin inline wave control - a <select> styled as the wave badge so an admin can
+   reassign (or clear) a card's launch wave in one click, no edit/save modal. The
+   public path keeps the plain read-only .wave-badge span. */
+.wave-select {
+  appearance: none;
+  -webkit-appearance: none;
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  cursor: pointer;
+}
+.wave-select:focus-visible { outline: 2px solid var(--accent, #ffb020); outline-offset: 2px; }
+/* No-wave state reads as "unset, click to assign" rather than a real wave pill. */
+.wave-select--empty {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--muted, #9aa3ad);
+  border: 1px dashed rgba(255, 255, 255, 0.28);
+}
+
 /* responsive */
 @media (max-width: 780px) {
   .kanban-board {
@@ -477,9 +494,10 @@
     const STATUS_CLASS = { done: 'done', active: 'active', planned: 'planned' };
 
     // ---- State ----
-    // Admin mode is LOCAL-DEV ONLY. On any non-local host (e.g. production)
-    // the admin toolbar/editing is fully disabled and never shown, regardless
-    // of any stored secret or server env. Edit the roadmap locally, then deploy.
+    // Admin mode is decided by the SERVER (see boot: adminMode = serverSaysAdmin):
+    // a verified world-admin email grants it on production, and the localhost-only
+    // dev secret grants it locally. IS_LOCAL only gates the Ctrl+Shift+A secret
+    // prompt below - it is NOT what enables/disables editing.
     const IS_LOCAL = /^(localhost|127\.0\.0\.1|\[::1\])$/.test(location.hostname);
     let milestones = [];
     let adminSecret = IS_LOCAL ? (sessionStorage.getItem('twAdminSecret') || '') : '';
@@ -535,6 +553,15 @@
     // WAVE launch label pill, or '' when the milestone has no wave.
     function waveBadge(w) {
       return WAVES.includes(w) ? `<span class="wave-badge">${esc(w)}</span>` : '';
+    }
+    // Admin-only inline wave control. A <select> (same No-wave/WAVE1-3 options as the
+    // detail modal) styled as the wave badge: changing it PATCHes the wave directly.
+    // Rendered only on admin cards; the public card path uses waveBadge() instead.
+    function waveControl(m) {
+      const isSet = WAVES.includes(m.wave);
+      const opts = `<option value="none"${!isSet ? ' selected' : ''}>No wave</option>`
+        + WAVES.map(w => `<option value="${w}"${w === m.wave ? ' selected' : ''}>${w}</option>`).join('');
+      return `<select class="wave-badge wave-select${isSet ? '' : ' wave-select--empty'}" data-wave-for="${m.id}" aria-label="Change launch wave">${opts}</select>`;
     }
 
     // Bearer token for the signed-in account, if any. Mirrors scripts/admin-users.js:
@@ -638,7 +665,7 @@
                 <div class="kanban-card-body">
                   <h3>${esc(m.title)}</h3>
                   ${m.description ? `<p>${esc(m.description)}</p>` : ''}
-                  ${waveBadge(m.wave)}
+                  ${waveControl(m)}
                 </div>
               </div>
             </div>`;
@@ -678,6 +705,43 @@
       // Add buttons
       board.querySelectorAll('.kanban-add-btn').forEach(btn => {
         btn.addEventListener('click', () => openNewCard(btn.dataset.add));
+      });
+
+      // Inline wave control (admin). stopPropagation keeps interacting with the
+      // select from also opening the card's detail modal. Change is optimistic:
+      // the UI updates immediately, then reverts if the PATCH fails.
+      board.querySelectorAll('select[data-wave-for]').forEach(sel => {
+        sel.addEventListener('click', e => e.stopPropagation());
+        sel.addEventListener('keydown', e => e.stopPropagation());
+        sel.addEventListener('change', async () => {
+          const id = Number(sel.dataset.waveFor);
+          const m = milestones.find(x => x.id === id);
+          if (!m) return;
+          const prevWave = WAVES.includes(m.wave) ? m.wave : null;
+          const prevValue = prevWave || 'none';
+          const chosen = sel.value; // 'none' | 'WAVE1' | ...
+          const nextWave = WAVES.includes(chosen) ? chosen : null;
+          if (nextWave === prevWave) return;
+          // Optimistic: reflect the choice now.
+          m.wave = nextWave;
+          sel.classList.toggle('wave-select--empty', !nextWave);
+          sel.disabled = true;
+          try {
+            await patchMilestone(id, { wave: chosen });
+            // Reconcile with the server's normalized value (source of truth).
+            const cur = WAVES.includes((milestones.find(x => x.id === id) || {}).wave)
+              ? milestones.find(x => x.id === id).wave : null;
+            sel.value = cur || 'none';
+            sel.classList.toggle('wave-select--empty', !cur);
+          } catch (err) {
+            m.wave = prevWave;
+            sel.value = prevValue;
+            sel.classList.toggle('wave-select--empty', !prevWave);
+            alert(err.message);
+          } finally {
+            sel.disabled = false;
+          }
+        });
       });
 
       // Drag and drop (admin only)


### PR DESCRIPTION
## What

Turns the roadmap WAVE badge into an **inline admin control**. As an admin you click the badge (now a `<select>`) on any roadmap card and pick its launch wave directly - including assigning a wave to a card that has none - with **no edit/save modal**. Public viewers still see only the read-only label.

## 1. Where the wave badge + admin gate live

- **Badge rendering:** `roadmap.html` - `waveBadge(w)` (public read-only `<span class="wave-badge">`) rendered on cards (admin + public) and in the detail modal. Shipped in PR #52.
- **Admin gate:** the client's `adminMode` is set at boot to the server's verdict: `adminMode = serverSaysAdmin` (from `GET /api/roadmap` -> `d.admin`). Server `isAdmin()` in `netlify/functions/roadmap.mjs` resolves a verified world-admin email (works on prod, PR #50) OR the localhost-only dev secret. Other admin affordances (drag-to-restatus, add-card, edit modal) gate on this same `adminMode` - the new control follows that exact pattern.

## 2. Reused the existing roadmap.mjs wave PATCH (no new endpoint)

`PATCH /api/roadmap?id=<id>` with body `{ wave: 'none' | 'WAVE1' | 'WAVE2' | 'WAVE3' }`.
- Server tracks `waveProvided` via `hasOwnProperty('wave')`, so a **wave-only** PATCH is allowed; `normalizeWave()` maps `'none'`/unknown -> `null` (a real clear), WAVE1-3 stored as-is.
- Returns `{ milestone }` (DTO incl. normalized `wave`). The client reconciles the optimistic value against this after the request.
- Verified live against a real DB: assign -> `200` + `{milestone:{wave:'WAVE2'}}`, persisted on reload; public PATCH (no secret) -> `403`; clear -> `null`.

## 3. Inline control + optimistic update + revert

New `waveControl(m)` renders a `<select class="wave-badge wave-select">` (same options as the modal). On `change`: optimistically updates the model + UI and disables the select, fires `patchMilestone(id, { wave })`, reconciles with the server value on success, and on error **reverts** the model + select value and alerts. `click`/`keydown` `stopPropagation` so interacting with the select never opens the card's detail modal. No-wave cards render the select with `wave-select--empty` (dashed/muted "unset" styling).

## 4. Public stays read-only

Only the admin card path swaps `waveBadge(m.wave)` -> `waveControl(m)`. The public card path and public modal are untouched - plain `<span>`, no `<select>`, no admin affordance in the DOM. Verified in-browser: public view = 0 selects, `<span class="wave-badge">WAVE2</span>`; admin view = 21 selects, 0 spans.

## 5. i18n

`roadmap.html` is **outside the i18n checker's scope** - `tools/i18n-check.js` only scans `tiny-world-builder.html` + `engine/world/*.js`. This page is hardcoded English by convention (e.g. existing "No wave", "Shipped", "Add card"). The control **reuses the existing "No wave" label** and matches the existing hardcoded `aria-label="Launch wave"` convention (new `aria-label="Change launch wave"`). No new i18n-scoped strings; `npm run i18n:check` stays green (320 keys x 5 locales).

## 6. Gates

- `npm test` -> 135 pass / 0 fail
- `npm run i18n:check` -> pass
- `npm run build` (`./publish.sh`) -> green; change lands in `dist/roadmap.html`

## Rebuild note

The served app is built `dist/` via `publish.sh`. Netlify runs `./publish.sh` automatically on deploy, so no manual step is needed for prod. `dist/` is gitignored and not committed (repo convention).

## Verification (live, `netlify dev` + real DB, admin on)

- Assign a wave to a no-wave card -> persists.
- Change an existing wave -> `PATCH 200`, persists across reload.
- Non-admin branch renders a plain `<span>`, no select in DOM.
- Forced PATCH failure -> optimistic value reverts, select re-enabled, alert shown.
- Clicking the select does not open the detail modal.

https://claude.ai/code/session_0134fctwzvPFN6ju7B2FEGDC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now edit and update launch wave assignments directly on individual roadmap cards using inline wave controls

* **Improvements**
  * Admin authorization now relies on server-side validation for improved security and consistency
  * Wave selection controls feature updated visual styling matching design patterns throughout the app
  * Implemented automatic error recovery when wave assignment updates encounter issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->