### PR TITLE
Fix WAVE badge chips: render amber, not blue

### DIFF
--- a/features.html
+++ b/features.html
@@ -304,9 +304,9 @@
   letter-spacing: 0.04em;
   padding: 2px 8px;
   border-radius: 999px;
-  background: var(--accent, #ffb020);
-  color: #1a1205;
-  border: 1px solid rgba(0,0,0,0.08);
+  background: #fff7e6;
+  color: #6a4a00;
+  border: 1px solid #e6c98a;
 }
 .admin-wave-select {
   font: inherit;

--- a/roadmap.html
+++ b/roadmap.html
@@ -384,7 +384,7 @@
 
 /* roadmap status badges (reused inside modal) */
 
-/* WAVE launch badge — small accent pill shown on cards + in the detail modal. */
+/* WAVE launch badge — small amber pill shown on cards + in the detail modal. */
 .wave-badge {
   display: inline-block;
   font-size: 11px;
@@ -392,9 +392,9 @@
   letter-spacing: 0.04em;
   padding: 2px 8px;
   border-radius: 999px;
-  background: var(--accent, #ffb020);
-  color: #1a1205;
-  border: 1px solid rgba(0,0,0,0.08);
+  background: #fff7e6;
+  color: #6a4a00;
+  border: 1px solid #e6c98a;
   vertical-align: middle;
 }
 .kanban-card .wave-badge { margin-top: 8px; }


### PR DESCRIPTION
## Problem
On the roadmap and suggestions pages, every WAVE1/WAVE2/WAVE3 badge rendered **blue**, indistinguishable from the status/accent chips.

**Root cause:** `.wave-badge` used `background: var(--accent, #ffb020)`, intending an amber fallback. But `styles/landing.css` defines `--accent: #3a72c8` (blue) globally, so the `#ffb020` fallback **never** applied — the badges always took the blue accent.

## Fix
Hardcode the brand wave amber (matching the admin wave `<select>` chip) so the WAVE pill no longer depends on `--accent`:

- `background: #fff7e6`
- `color: #6a4a00`
- `border: 1px solid #e6c98a`

Applied to `.wave-badge` in `roadmap.html` and `features.html` only. Status chips (open/planned/done/rejected) and the admin select are untouched.

## Verification
- Gates green: `npm run check`, `npm run smoke`, `npm run i18n:check`, `npm run build`.
- Unit tests: 144 pass / 0 fail in this environment (no regression).
- Real browser (dev server, both pages, with `--accent` confirmed `#3a72c8` blue and active):
  - computed `.wave-badge` -> bg `rgb(255,247,230)`, ink `rgb(106,74,0)`, border `rgb(230,201,138)` (amber, not blue).
  - WCAG contrast `#6a4a00` on `#fff7e6` = **7.60:1** (passes AA and AAA).
  - Visually distinct from the blue accent chip.
- Pure ASCII; no emoji.

https://claude.ai/code/session_0154wqCuQ14ARYcyJ2itD656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated wave badge styling with a new fixed amber and yellow color palette across the application, replacing the previous theme-variable-based approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->