### PR TITLE
Lobby population layer: persistent NPC peers for tidewater-bay

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "smoke:mp": "node tools/smoke-multiplayer.mjs",
     "smoke:mp:ai": "node tools/smoke-multiplayer.mjs --with-ai-bots",
     "bots:ai": "node tools/ai-bots.mjs --slug tidewater-bay --bots 3 --mode both",
+    "bots:lobby": "node tools/lobby-bots.mjs --bots 10 --slug tidewater-bay",
     "demo:vehicles": "node plugins/examples/vehicle-road-demo.js",
     "test:unit": "node --test tests/*.test.mjs",
     "test": "npm run check && npm run smoke && npm run test:unit"

--- a/tests/lobby-bots.test.mjs
+++ b/tests/lobby-bots.test.mjs
@@ -1,0 +1,50 @@
+// Offline regression tests for tools/lobby-bots.mjs protocol logic.
+// Importing the module does NOT connect or boot (guarded by _isMain); it only
+// exposes Bot + clean for testing.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Bot, clean } from '../tools/lobby-bots.mjs';
+
+const persona = { name: 'Marsh the Wanderer', color: '#6fae57', personality: 'test', avatar: { seed: 1 } };
+
+test('clean() strips emoji / pictographic characters', () => {
+  // Inputs use codepoint escapes (no literal emoji glyphs in source) — leaf/wave,
+  // wave-hand + skin tone, regional-indicator flag, and a keycap sequence.
+  assert.equal(clean('the reeds whisper \u{1F33F}\u{1F30A}'), 'the reeds whisper');
+  assert.equal(clean('hello \u{1F44B}\u{1F3FD} friend'), 'hello friend');
+  assert.equal(clean('flags \u{1F1EB}\u{1F1F7} and digits 1\u{FE0F}\u{20E3}'), 'flags and digits 1');
+  assert.equal(clean('plain calm line'), 'plain calm line');
+});
+
+test('clean() trims wrapping quotes/whitespace and collapses spaces', () => {
+  assert.equal(clean('  "a   quiet  tide"  '), 'a quiet tide');
+});
+
+test('bot learns its own id from the welcome message', () => {
+  const b = new Bot(persona, 0);
+  assert.equal(b.id, null);
+  b.onMsg({ type: 'welcome', room: 'world-tidewater-bay', id: b.pk, role: 'observe', world: true });
+  assert.equal(b.id, b.pk);
+});
+
+test('bot ignores its OWN echoed chat (no self-reaction / feedback loop)', () => {
+  const b = new Bot(persona, 0);
+  let reacted = 0;
+  b.onChat = () => { reacted++; };          // spy
+  b.onMsg({ type: 'welcome', id: b.pk });   // learn own id first
+  // server echoes our own chat back (broadcastToAdmitted includes the sender):
+  b.onMsg({ type: 'chat', id: b.pk, name: 'Marsh the Wanderer', text: 'the reeds whisper today' });
+  assert.equal(reacted, 0, 'must not react to its own chat');
+  // a real peer chat still triggers a reaction:
+  b.onMsg({ type: 'chat', id: 'peer-xyz', name: 'Visitor', text: 'hello there' });
+  assert.equal(reacted, 1, 'must react to another speaker');
+});
+
+test('a chat carrying no id is ignored (cannot be matched/abused)', () => {
+  const b = new Bot(persona, 0);
+  let reacted = 0;
+  b.onChat = () => { reacted++; };
+  b.onMsg({ type: 'welcome', id: b.pk });
+  b.onMsg({ type: 'chat', text: 'no id here' });
+  assert.equal(reacted, 0);
+});

--- a/tools/lobby-bots.README.md
+++ b/tools/lobby-bots.README.md
@@ -1,0 +1,105 @@
+# Lobby population layer (`tools/lobby-bots.mjs`)
+
+Always-on NPC peers that make the in-world lobby (`tidewater-bay`) feel alive.
+They join the live PartyKit world room as **real peers**, wander the lobby grid,
+emote, and chat with LLM banter on **free OpenRouter models**. Rendering is handled
+entirely client-side (voxel avatar + nameplate + chat bubble in
+`engine/world/47-worlds-room.js`), so this process speaks only the world protocol —
+there is no rendering code here.
+
+## Quick start
+
+```bash
+# 10 NPCs into the production lobby, with LLM chatter:
+export OPENROUTER_API_KEY=sk-or-...
+export TW_ORIGIN=https://<your-site>        # https origin that serves /api/worlds
+npm run bots:lobby
+```
+
+Without `OPENROUTER_API_KEY` the bots still **wander and emote** — they just stay
+silent (no chat). Nothing crashes.
+
+## How it joins (observer, not a weakened seat)
+
+Verified against `party/index.js`:
+
+- In production the room sets `WORLDS_JOIN_SECRET`, so an **empty-token** join is
+  downgraded to role `observe` (`party/index.js:1039-1057`).
+- Observers **can move** (`handleMove` allows `observe`; only `play` needs a
+  `profileId` — `:1211-1212`) and **can chat/emote** (those handlers gate on
+  `admitted.has(id)`, set for every role at `:1080`).
+- Observers **cannot** harvest or touch the durable economy (`:1238`) — exactly
+  right for ambient NPCs.
+
+So the bots join with an **empty token as observers**. No token minting, no change
+to join security. They send `role: 'observe'` explicitly so behaviour is identical
+in production (secret set) and in open testing mode (no secret).
+
+## NPC disclosure (not deceptive)
+
+Each bot connects with a PartyKit conn id prefixed `bot-…`. The client detects that
+(`isBotPeer` in `47-worlds-room.js`) and shows the localized **"(bot) joined"** toast
+(`worlds.notify.botJoined`, present in all locales). Combined with ambient NPC names
+(e.g. *Marsh the Wanderer*, *Old Brine*, *Willow the Gardener*) a real visitor can
+tell these are characters, not impersonated users.
+
+## Cold start
+
+The server loads the world via its own `SITE_URL` when it receives a valid numeric
+`worldId` (`ensureWorldLoaded`). The runner discovers that id from
+`TW_ORIGIN/api/worlds?slug=<slug>`:
+
+- **With `TW_ORIGIN`**: a cold/hibernated lobby self-loads — bots walk before any
+  human arrives.
+- **Without `TW_ORIGIN`**: bots still join and render, but a *cold* room has no
+  walkable cells yet; they idle (with a clear log) until a real player loads the
+  world, then start wandering. Set `TW_ORIGIN` for a reliably-populated lobby.
+
+## LLM (free OpenRouter models)
+
+- Endpoint: `https://openrouter.ai/api/v1/chat/completions` (OpenAI-compatible),
+  called via global `fetch` — no SDK dependency.
+- Default model: `meta-llama/llama-3.3-70b-instruct:free`. Override with
+  `--model` / `OPENROUTER_MODEL`. **Use a `:free` model id.** Available free ids
+  change over time — see https://openrouter.ai/models?max_price=0.
+- **Graceful degradation**: a missing key, `401/403` (bad key), `429` (rate limit),
+  any other non-2xx (incl. model-not-found), or empty content → the bot **skips that
+  chat turn** and keeps wandering/emoting. It never crashes and never spams.
+- **Shared throttle**: free-tier limits are per *account*, not per bot. One global
+  min-interval gate (~13 calls/min across all bots) plus jitter prevents 10+ bots
+  from bursting the endpoint, on top of a per-bot 15s chat cooldown.
+
+## Flags / env
+
+| Flag        | Env               | Default                                          | Meaning |
+|-------------|-------------------|--------------------------------------------------|---------|
+| `--slug`    | `TW_LOBBY_SLUG`   | `tidewater-bay`                                  | Lobby world slug (room = `world-<slug>`) |
+| `--bots`    | `BOTS_COUNT`      | `10`                                             | NPC count (1–40) |
+| `--host`    | `PARTYKIT_HOST`   | `wss://tinyworld-shared-building.jasonkneen.partykit.dev` | PartyKit ws base |
+| `--origin`  | `TW_ORIGIN`       | *(none)*                                         | https site for worldId discovery / cold-start |
+| `--model`   | `OPENROUTER_MODEL`| `meta-llama/llama-3.3-70b-instruct:free`         | OpenRouter model id (use a `:free` one) |
+| `--mode`    | `BOTS_MODE`       | `both`                                           | `ambient` \| `react` \| `both` |
+| `--seconds` | `BOTS_SECONDS`    | `0`                                              | Auto-exit after N seconds (0 = forever) |
+| `--verbose` | —                 | off                                              | Also log every move/emote |
+| —           | `OPENROUTER_API_KEY` | *(required for chat)*                         | OpenRouter key; unset → silent bots |
+
+## Always-on deployment
+
+It is a plain long-running Node process. Run it under whatever supervisor you use
+(systemd, pm2, a container, a small VM). Example systemd unit:
+
+```ini
+[Service]
+Environment=OPENROUTER_API_KEY=sk-or-...
+Environment=TW_ORIGIN=https://<your-site>
+WorkingDirectory=/opt/tiny-world-builder
+ExecStart=/usr/bin/node tools/lobby-bots.mjs --bots 10
+Restart=always
+```
+
+## Not in the browser build
+
+This is an external CLI process. It is never imported by the app and does not affect
+the production web build. It does **not** touch the local-only
+`engine/world/51-worlds-bots.js` (which hard-refuses production by design).
+Requires Node 22+ (global `WebSocket` and `fetch`).

--- a/tools/lobby-bots.README.md
+++ b/tools/lobby-bots.README.md
@@ -43,28 +43,45 @@ Each bot connects with a PartyKit conn id prefixed `bot-…`. The client detects
 (e.g. *Marsh the Wanderer*, *Old Brine*, *Willow the Gardener*) a real visitor can
 tell these are characters, not impersonated users.
 
-## Cold start
+## Cold start — `TW_ORIGIN` is required to populate a cold lobby
 
-The server loads the world via its own `SITE_URL` when it receives a valid numeric
-`worldId` (`ensureWorldLoaded`). The runner discovers that id from
-`TW_ORIGIN/api/worlds?slug=<slug>`:
+The server cold-loads the world (`ensureWorldLoaded`) via its own `SITE_URL`, but
+**only when it receives a real NUMERIC `worldId`** — `/api/worlds?id=` ignores a
+slug (`netlify/functions/worlds.mjs:35-37`). The runner resolves that numeric id
+from `TW_ORIGIN/api/worlds?slug=<slug>` and forwards it **only if it is numeric**.
 
-- **With `TW_ORIGIN`**: a cold/hibernated lobby self-loads — bots walk before any
-  human arrives.
-- **Without `TW_ORIGIN`**: bots still join and render, but a *cold* room has no
-  walkable cells yet; they idle (with a clear log) until a real player loads the
-  world, then start wandering. Set `TW_ORIGIN` for a reliably-populated lobby.
+- **With `TW_ORIGIN` (recommended for always-on)**: the numeric id resolves, so a
+  cold/hibernated lobby self-loads and bots walk the *real* lobby before any human
+  arrives.
+- **Without `TW_ORIGIN`** (or if the lookup fails): the runner does **not** send a
+  worldId at all (it never sends a slug — that would silently pin the room to a
+  wrong/default 8x8 board). So a **cold** room is **not** populated: bots join and
+  render, but stay put (with a loud warning) until a real player loads the lobby,
+  then begin wandering the correct board. Set `TW_ORIGIN` for reliable always-on
+  population.
+
+## Resilience (always-on)
+
+On any socket drop (PartyKit restart, network blip) each bot auto-reconnects with
+capped exponential backoff + jitter (2s → 30s ceiling), indefinitely; the backoff
+resets on a clean re-join. Dead-socket timers are cleared before reconnecting so no
+intervals leak. `SIGINT`/`SIGTERM` stop reconnects and shut down cleanly. Run it
+under any supervisor (`Restart=always` is a backstop, not the primary mechanism).
 
 ## LLM (free OpenRouter models)
 
 - Endpoint: `https://openrouter.ai/api/v1/chat/completions` (OpenAI-compatible),
   called via global `fetch` — no SDK dependency.
 - Default model: `meta-llama/llama-3.3-70b-instruct:free`. Override with
-  `--model` / `OPENROUTER_MODEL`. **Use a `:free` model id.** Available free ids
-  change over time — see https://openrouter.ai/models?max_price=0.
+  `--model` / `OPENROUTER_MODEL`. **Free-only is enforced**: the runner refuses to
+  start unless the model id ends with `:free` (override deliberately with
+  `--allow-paid`). Available free ids change over time — see
+  https://openrouter.ai/models?max_price=0.
 - **Graceful degradation**: a missing key, `401/403` (bad key), `429` (rate limit),
   any other non-2xx (incl. model-not-found), or empty content → the bot **skips that
   chat turn** and keeps wandering/emoting. It never crashes and never spams.
+- **No emoji**: every generated line is stripped of emoji/pictographic characters
+  before it is sent (repo no-emoji rule; prompting alone is not a guarantee).
 - **Shared throttle**: free-tier limits are per *account*, not per bot. One global
   min-interval gate (~13 calls/min across all bots) plus jitter prevents 10+ bots
   from bursting the endpoint, on top of a per-bot 15s chat cooldown.
@@ -77,8 +94,9 @@ The server loads the world via its own `SITE_URL` when it receives a valid numer
 | `--bots`    | `BOTS_COUNT`      | `10`                                             | NPC count (1–40) |
 | `--host`    | `PARTYKIT_HOST`   | `wss://tinyworld-shared-building.jasonkneen.partykit.dev` | PartyKit ws base |
 | `--origin`  | `TW_ORIGIN`       | *(none)*                                         | https site for worldId discovery / cold-start |
-| `--model`   | `OPENROUTER_MODEL`| `meta-llama/llama-3.3-70b-instruct:free`         | OpenRouter model id (use a `:free` one) |
-| `--mode`    | `BOTS_MODE`       | `both`                                           | `ambient` \| `react` \| `both` |
+| `--model`   | `OPENROUTER_MODEL`| `meta-llama/llama-3.3-70b-instruct:free`         | OpenRouter model id; must end in `:free` |
+| `--allow-paid` | —              | off                                              | Permit a non-`:free` model (deliberate override) |
+| `--mode`    | `BOTS_MODE`       | `both`                                           | `ambient` \| `react` \| `both` (unknown → warns, uses `both`) |
 | `--seconds` | `BOTS_SECONDS`    | `0`                                              | Auto-exit after N seconds (0 = forever) |
 | `--verbose` | —                 | off                                              | Also log every move/emote |
 | —           | `OPENROUTER_API_KEY` | *(required for chat)*                         | OpenRouter key; unset → silent bots |

--- a/tools/lobby-bots.mjs
+++ b/tools/lobby-bots.mjs
@@ -96,10 +96,26 @@ const CFG = {
   mode: String(envOr('mode', 'BOTS_MODE', 'both')),
   seconds: parseInt(envOr('seconds', 'BOTS_SECONDS', '0'), 10) || 0,
   verbose: !!arg('verbose', false),
+  allowPaid: !!arg('allow-paid', false),
 };
 const API_KEY = process.env.OPENROUTER_API_KEY || '';
+
+// Validate --mode (anything unknown falls back to 'both' with a loud warning).
+if (!['ambient', 'react', 'both'].includes(CFG.mode)) {
+  console.warn(`lobby-bots: unknown --mode "${CFG.mode}" — falling back to "both" (valid: ambient|react|both).`);
+  CFG.mode = 'both';
+}
 const wantAmbient = CFG.mode === 'ambient' || CFG.mode === 'both';
 const wantReact = CFG.mode === 'react' || CFG.mode === 'both';
+
+// Enforce FREE OpenRouter models (Jason's hard constraint: ~zero cost). A `:free`
+// model id is required unless the operator explicitly opts in with --allow-paid.
+if (!CFG.model.endsWith(':free') && !CFG.allowPaid) {
+  console.error(`lobby-bots: refusing to start — model "${CFG.model}" is not a :free OpenRouter model.\n` +
+    `  Pass a free id (e.g. --model meta-llama/llama-3.3-70b-instruct:free or OPENROUTER_MODEL=...:free).\n` +
+    `  See https://openrouter.ai/models?max_price=0 . To override deliberately, pass --allow-paid.`);
+  process.exit(1);
+}
 
 // ---- NPC personas (ambient characters, not impersonated users) -------------
 // Seeded voxel avatars; `avatar` fields mirror the descriptor cleanAvatar accepts.
@@ -139,6 +155,7 @@ async function askLLM(kind, persona, ctx) {
   const wait = reserveLLMSlot();
   if (wait < 0) return null;             // disabled (no key) -> graceful skip
   await sleep(wait);
+  if (_llmDisabled) return null;         // a 401/403 may have disabled us while we waited in the queue
   const sys = `You are ${persona.name}, an ambient non-player character living in TinyWorld, a cozy voxel world of floating islands around a calm bay called Tidewater Bay. `
     + `Personality: ${persona.personality}. Speak ONE short, casual, in-character line, max ~18 words. `
     + `No emojis. No quotation marks. No stage directions. Just what you say out loud to others in the lobby.`;
@@ -178,8 +195,17 @@ async function askLLM(kind, persona, ctx) {
     return null;                         // network error -> graceful skip
   }
 }
+// Strip emoji / pictographic chars before sending (no-emoji is a hard repo rule;
+// prompting "No emojis" is not a guarantee). Removes pictographs, regional
+// indicators, emoji variation selectors, ZWJ, and skin-tone modifiers.
+const EMOJI_RE = /[\p{Extended_Pictographic}\u{1F1E6}-\u{1F1FF}\u{1F3FB}-\u{1F3FF}\u{FE0F}\u{200D}\u{20E3}]/gu;
 function clean(s) {
-  return String(s || '').replace(/^["'\s]+|["'\s]+$/g, '').replace(/\s+/g, ' ').slice(0, 160);
+  return String(s || '')
+    .replace(EMOJI_RE, '')
+    .replace(/^["'\s]+|["'\s]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .slice(0, 160)
+    .trim();
 }
 
 // ---- optional world meta lookup (for reliable cold-start worldId) ----------
@@ -198,14 +224,20 @@ function compactCells(data) {
   return out;
 }
 let WORLD_META = null;
+let RESOLVED_WORLD_ID = null;            // a real NUMERIC world id, or null if unresolved
 async function loadWorldMeta() {
-  if (!CFG.origin) return null;          // no origin -> rely on a present peer to load the world
+  if (!CFG.origin) return null;          // no origin -> cannot resolve the numeric world id
   try {
     const res = await fetch(`${CFG.origin}/api/worlds?slug=${encodeURIComponent(CFG.slug)}`);
     if (!res.ok) return null;
     const body = await res.json().catch(() => null);
     if (!body || !body.world) return null;
     WORLD_META = body.world;
+    // The server only treats a NUMERIC id as a world id (worlds.mjs:35-37). A slug
+    // sent as worldId would silently cold-load a WRONG/default board, so we only
+    // ever forward a verified numeric id.
+    const n = Number(WORLD_META.id);
+    RESOLVED_WORLD_ID = Number.isFinite(n) && String(n) === String(WORLD_META.id) ? n : null;
     return WORLD_META;
   } catch (_) {
     return null;
@@ -216,15 +248,24 @@ async function loadWorldMeta() {
 const DIRS = [[1, 0], [-1, 0], [0, 1], [0, -1]];
 const rnd = (n) => Math.floor(Math.random() * n);
 const EMOTES = ['wave', 'dance', 'jump', 'sit', 'crouch'];   // server allowlist (party EMOTE_CMDS)
+const RECONNECT_BASE_MS = 2000;          // first reconnect delay after a drop
+const RECONNECT_CAP_MS = 30000;          // capped exponential backoff ceiling
 
 class Bot {
   constructor(persona, i) {
     this.p = persona; this.i = i;
+    // Stable `bot-...` conn id (reused across reconnects) => the client tags us as
+    // an NPC ("(bot) joined" toast) and our nameplate identity stays put.
+    this.pk = 'bot-' + this.p.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') + '-' + rnd(0xffffff).toString(16);
     this.id = null; this.x = 0; this.z = 0; this.grid = 8;
     this.grass = new Set(); this.goal = null;
     this.peers = new Map();
     this.connected = false; this.lastTalk = 0;
-    this.timers = [];
+    this.timers = [];                 // movement / emote / ambient timers (cleared on close)
+    this.reconnectTimer = null;
+    this.started = false;             // movement+emote+ambient schedulers armed?
+    this.stopped = false;             // intentional shutdown -> no reconnect
+    this.backoff = RECONNECT_BASE_MS; // current reconnect delay
     this.moves = 0; this.lines = 0; this.emotes = 0; this.role = null;
     this.warnedNoGrass = false;
   }
@@ -232,55 +273,90 @@ class Bot {
   send(o) { if (this.ws && this.ws.readyState === 1) { try { this.ws.send(JSON.stringify(o)); } catch (_) {} } }
 
   connect() {
-    // `bot-...` conn id => the client tags us as an NPC ("(bot) joined" toast).
-    const pk = 'bot-' + this.p.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') + '-' + rnd(0xffffff).toString(16);
-    const url = `${CFG.host}/party/${encodeURIComponent('world-' + CFG.slug)}?_pk=${encodeURIComponent(pk)}`;
+    if (this.stopped) return;
+    const url = `${CFG.host}/party/${encodeURIComponent('world-' + CFG.slug)}?_pk=${encodeURIComponent(this.pk)}`;
     let ws;
-    try { ws = new WebSocket(url); } catch (e) { this.log('connect failed:', e.message); return; }
+    try { ws = new WebSocket(url); } catch (e) { this.log('connect failed:', e.message); this.scheduleReconnect(); return; }
     this.ws = ws;
     ws.onopen = () => {
       const w = WORLD_META;
       // Empty token => observe in prod (secret set); role:'observe' keeps us an
-      // observer in open testing mode too. worldId drives server-side cold-start
-      // (ensureWorldLoaded); cells are a fallback only honored in open mode.
-      this.send({
+      // observer in open testing mode too. worldId (server cold-start via
+      // ensureWorldLoaded) is sent ONLY when we hold a real NUMERIC id — a slug
+      // would silently load a wrong/default board. cells are an open-mode fallback.
+      const join = {
         type: 'world.join', token: '', role: 'observe',
-        worldId: w ? w.id : (CFG.slug),
         name: this.p.name, color: this.p.color,
         profileId: 'bot:' + this.p.name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
         gridSize: w ? (w.gridSize || this.grid) : this.grid,
         cells: w && w.data ? compactCells(w.data) : [],
         taxPercent: w ? w.taxPercent : null, ownerProfileId: w ? w.ownerProfileId : null,
         avatar: Object.assign({ kind: 'voxel' }, this.p.avatar),
-      });
+      };
+      if (RESOLVED_WORLD_ID != null) join.worldId = RESOLVED_WORLD_ID;
+      this.send(join);
     };
     ws.onmessage = (ev) => {
       let d; try { d = JSON.parse(typeof ev.data === 'string' ? ev.data : ev.data.toString()); } catch { return; }
       this.onMsg(d);
     };
-    ws.onclose = () => { this.connected = false; };
-    ws.onerror = (e) => { this.log('ws error', (e && e.message) || 'socket'); };
+    ws.onclose = () => { this.handleDrop(); };
+    ws.onerror = (e) => { if (CFG.verbose) this.log('ws error', (e && e.message) || 'socket'); };
+  }
+
+  // A socket drop: stop all activity, then reconnect with backoff (unless shutting
+  // down). Clearing timers first prevents leaking the dead socket's intervals.
+  handleDrop() {
+    if (this.stopped) return;
+    this.connected = false;
+    this.timers.forEach(clearTimeout); this.timers = [];
+    this.started = false;
+    this.goal = null;
+    this.scheduleReconnect();
+  }
+  scheduleReconnect() {
+    if (this.stopped || this.reconnectTimer) return;
+    const delay = this.backoff + rnd(1000);   // jitter so 10+ bots don't reconnect in lockstep
+    this.log(`disconnected — reconnecting in ${(delay / 1000).toFixed(1)}s`);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.backoff = Math.min(RECONNECT_CAP_MS, this.backoff * 2);  // grows until a clean join resets it
+      this.connect();
+    }, delay);
   }
 
   onMsg(d) {
+    if (d.type === 'welcome') {
+      // World rooms deliver our own connection id here (party/index.js:577-585),
+      // BEFORE any chat. world.state.you carries no id, so without this we'd never
+      // learn our own id and would react to our OWN echoed chat (a feedback loop).
+      if (d.id) this.id = d.id;
+      return;
+    }
     if (d.type === 'world.state') {
       this.connected = true;
-      this.id = (d.you && d.you.id) || this.id;
+      this.id = (d.you && d.you.id) || this.id || this.pk;   // fallbacks; welcome already set it
       this.grid = d.gridSize || this.grid;
       this.role = d.you && d.you.role;
       if (d.you && d.you.x != null) { this.x = d.you.x; this.z = d.you.z; }
+      this.backoff = RECONNECT_BASE_MS;                       // clean join -> reset backoff
       this.grass.clear();
       for (const c of (d.grassCells || [])) this.grass.add(c);
       for (const pr of (d.peers || [])) if (pr.id) this.peers.set(pr.id, { name: pr.name });
       this.log(`joined as role=${this.role} at (${this.x},${this.z}); ${this.grass.size} walkable cells, ${this.peers.size} peers`);
       if (!this.grass.size && !this.warnedNoGrass) {
         this.warnedNoGrass = true;
-        this.log('no walkable cells yet — world not loaded. Will idle until it loads.' +
-          (CFG.origin ? '' : ' (pass --origin/TW_ORIGIN so a cold room can self-load via worldId.)'));
+        this.log('no walkable cells — the real lobby world is not loaded for us.' +
+          (RESOLVED_WORLD_ID != null
+            ? ' Idling until a player loads it.'
+            : ' Set TW_ORIGIN so a cold room can self-load via the real numeric worldId; idling until a player loads it.'));
       }
-      this.startMoving();
-      if (wantAmbient) this.scheduleAmbient();
-      this.scheduleEmote();
+      if (!this.started) {            // arm schedulers once per live connection (re-armed after a reconnect)
+        this.started = true;
+        this.startMoving();
+        if (wantAmbient) this.scheduleAmbient();
+        this.scheduleEmote();
+      }
     } else if (d.type === 'presence' && d.presence) {
       const pr = d.presence;
       if (pr.id && pr.id !== this.id) {
@@ -300,8 +376,6 @@ class Bot {
 
   // ---- movement: one walkable step toward a wander goal ----
   startMoving() {
-    if (this._movingStarted) return;
-    this._movingStarted = true;
     const tick = () => {
       if (this.connected) this.step();
       this.timers.push(setTimeout(tick, 1100 + rnd(1600)));
@@ -372,11 +446,17 @@ class Bot {
     if (line && this.connected) { this.send({ type: 'chat', text: line }); this.lines++; this.log(`says: ${line}`); }
   }
 
-  disconnect() { this.timers.forEach(clearTimeout); this.timers = []; try { this.ws && this.ws.close(); } catch (_) {} }
+  // Intentional shutdown: stop reconnecting and clear every timer.
+  disconnect() {
+    this.stopped = true;
+    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+    this.timers.forEach(clearTimeout); this.timers = [];
+    try { this.ws && this.ws.close(); } catch (_) {}
+  }
 }
 
 // ---- boot ------------------------------------------------------------------
-(async function boot() {
+async function boot() {
   if (typeof WebSocket !== 'function') {
     console.error('This runner needs a global WebSocket (Node 22+). Your Node:', process.version);
     process.exit(1);
@@ -385,9 +465,15 @@ class Bot {
     console.warn('lobby-bots: OPENROUTER_API_KEY is unset — bots will WANDER and EMOTE but stay silent (no chat). Set it to enable LLM banter.');
   }
   const w = await loadWorldMeta();
-  if (w) console.log(`lobby-bots: resolved "${w.name}" (id=${w.id}, grid=${w.gridSize}) from ${CFG.origin}`);
-  else if (CFG.origin) console.log(`lobby-bots: could not resolve world at ${CFG.origin} — relying on a present peer to load it`);
-  else console.log('lobby-bots: no --origin set — cold rooms cannot self-load; bots idle until a player loads the lobby');
+  if (w && RESOLVED_WORLD_ID != null) {
+    console.log(`lobby-bots: resolved "${w.name}" (id=${RESOLVED_WORLD_ID}, grid=${w.gridSize}) from ${CFG.origin} — cold rooms self-load`);
+  } else if (CFG.origin) {
+    console.warn(`lobby-bots: WARNING — could not resolve a numeric world id for "${CFG.slug}" at ${CFG.origin}. ` +
+      `Bots will NOT cold-start the lobby; they idle until a real player loads it. Check TW_ORIGIN/slug.`);
+  } else {
+    console.warn('lobby-bots: WARNING — no TW_ORIGIN/--origin set. Cannot resolve the real numeric world id, so a COLD lobby will not be populated; ' +
+      'bots idle until a real player loads it. Set TW_ORIGIN=<https site serving /api/worlds> for always-on population.');
+  }
   console.log(`lobby-bots: ${CFG.bots} NPCs -> ${CFG.host}/party/world-${CFG.slug} | mode=${CFG.mode} model=${CFG.model}${_llmDisabled ? ' (chat disabled)' : ''}`);
 
   const roster = [];
@@ -410,4 +496,14 @@ class Bot {
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
   if (CFG.seconds > 0) setTimeout(shutdown, CFG.seconds * 1000);
+}
+
+// Run only when invoked directly (`node tools/lobby-bots.mjs`), not when imported
+// for tests. Exports below let the unit tests exercise the protocol logic offline.
+const _isMain = (() => {
+  try { return !!process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]); }
+  catch (_) { return false; }
 })();
+if (_isMain) boot();
+
+export { Bot, clean, CFG };

--- a/tools/lobby-bots.mjs
+++ b/tools/lobby-bots.mjs
@@ -1,0 +1,413 @@
+// Lobby population layer: spawns >=10 persistent NPC peers that JOIN the in-world
+// lobby (slug `tidewater-bay`) as REAL peers, wander the lobby grid, periodically
+// emote, and chat using LLM banter on FREE OpenRouter models. They render with the
+// same voxel avatar + nameplate + chat bubble pipeline as any human peer (handled
+// entirely client-side in engine/world/47-worlds-room.js) — so this process needs
+// NO rendering code; it only speaks the PartyKit world protocol.
+//
+// SECURITY / JOIN DECISION (verified against party/index.js):
+//   In production the world room sets WORLDS_JOIN_SECRET, so an empty-token join is
+//   downgraded to role `observe` (party/index.js:1039-1057). Observers CAN move
+//   (handleMove gate at :1211-1212 allows observe; only `play` requires a profileId)
+//   and CAN chat/emote (the `chat`/`emote` handlers gate on `admitted.has(id)`,
+//   which is set for every role at :1080). So these bots join with an EMPTY token as
+//   observers — no token minting, no weakening of join security. They cannot harvest
+//   or touch the durable economy (harvest is play+profile gated at :1238), which is
+//   exactly what we want for ambient NPCs. We send `role: 'observe'` explicitly so
+//   the behaviour is identical whether the target runs in prod (secret set) or open
+//   testing mode (no secret) — never an unintended `play` seat.
+//
+// NPC DISCLOSURE (not deceptive):
+//   Each bot connects with a PartyKit conn id prefixed `bot-...`. The client detects
+//   that (isBotPeer in 47-worlds-room.js) and shows the localized "(bot) joined"
+//   toast (worlds.notify.botJoined). Combined with ambient NPC names, real visitors
+//   can tell these are characters, not impersonated users.
+//
+// OFF BY DEFAULT IN THE APP: this is an external Node process. It is never imported
+// by the browser build and does not touch the local-only engine/world/51-worlds-bots.js.
+//
+// Usage:
+//   OPENROUTER_API_KEY=sk-or-... node tools/lobby-bots.mjs --origin https://<site>
+//   npm run bots:lobby            # 10 bots -> prod lobby (set OPENROUTER_API_KEY + TW_ORIGIN)
+//
+// Flags (env fallback in parentheses):
+//   --slug   <s>   lobby world slug (room id = world-<slug>)   [TW_LOBBY_SLUG] (tidewater-bay)
+//   --bots   <n>   number of NPC peers (>=1)                   [BOTS_COUNT]    (10)
+//   --host   <ws>  PartyKit ws base                            [PARTYKIT_HOST] (prod partykit)
+//   --origin <url> https site for worldId discovery/cold-start [TW_ORIGIN]     ('')
+//   --model  <id>  OpenRouter model id (use a :free model)     [OPENROUTER_MODEL]
+//   --mode   <m>   ambient | react | both                      [BOTS_MODE]     (both)
+//   --seconds <n>  auto-exit after N seconds (0 = forever)     [BOTS_SECONDS]  (0)
+//   --verbose      also log every move
+//
+// The model call lives in ONE function (askLLM) so swapping model/provider is a
+// one-spot change. The OpenRouter key is read from OPENROUTER_API_KEY (env or .env).
+// If the key is unset, or a call fails / rate-limits / returns empty, the bot
+// DEGRADES GRACEFULLY: it skips that chat turn and keeps wandering + emoting. It
+// never crashes and never spams.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+// ---- tiny .env loader (only fills vars not already in the environment) ----
+(function loadEnv() {
+  try {
+    const txt = fs.readFileSync(path.join(ROOT, '.env'), 'utf8');
+    for (const line of txt.split('\n')) {
+      const t = line.trim();
+      if (!t || t.startsWith('#')) continue;
+      const eq = t.indexOf('=');
+      if (eq < 0) continue;
+      const k = t.slice(0, eq).trim();
+      let v = t.slice(eq + 1).trim();
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+      if (k && process.env[k] === undefined) process.env[k] = v;
+    }
+  } catch (_) { /* no .env — rely on real env */ }
+})();
+
+// ---- args / config ----
+function arg(name, def) {
+  const i = process.argv.indexOf('--' + name);
+  if (i < 0) return def;
+  const v = process.argv[i + 1];
+  return (v === undefined || v.startsWith('--')) ? true : v;
+}
+function envOr(flag, envKey, def) {
+  const a = arg(flag, undefined);
+  if (a !== undefined) return a;
+  if (process.env[envKey] !== undefined && process.env[envKey] !== '') return process.env[envKey];
+  return def;
+}
+
+const DEFAULT_HOST = 'wss://tinyworld-shared-building.jasonkneen.partykit.dev';
+const DEFAULT_MODEL = 'meta-llama/llama-3.3-70b-instruct:free';
+
+const CFG = {
+  slug: String(envOr('slug', 'TW_LOBBY_SLUG', 'tidewater-bay')).toLowerCase(),
+  bots: Math.max(1, Math.min(40, parseInt(envOr('bots', 'BOTS_COUNT', '10'), 10) || 10)),
+  host: String(envOr('host', 'PARTYKIT_HOST', DEFAULT_HOST)).replace(/\/+$/, ''),
+  origin: String(envOr('origin', 'TW_ORIGIN', '')).replace(/\/+$/, ''),
+  model: String(envOr('model', 'OPENROUTER_MODEL', DEFAULT_MODEL)),
+  mode: String(envOr('mode', 'BOTS_MODE', 'both')),
+  seconds: parseInt(envOr('seconds', 'BOTS_SECONDS', '0'), 10) || 0,
+  verbose: !!arg('verbose', false),
+};
+const API_KEY = process.env.OPENROUTER_API_KEY || '';
+const wantAmbient = CFG.mode === 'ambient' || CFG.mode === 'both';
+const wantReact = CFG.mode === 'react' || CFG.mode === 'both';
+
+// ---- NPC personas (ambient characters, not impersonated users) -------------
+// Seeded voxel avatars; `avatar` fields mirror the descriptor cleanAvatar accepts.
+const PERSONAS = [
+  { name: 'Marsh the Wanderer', color: '#6fae57', personality: 'a roaming naturalist who narrates the tide pools and reeds', avatar: { seed: 111, body: 'Masc', fit: 'Scout', skin: 2, head: 'Wide', hair: 'Short' } },
+  { name: 'Pebble', color: '#c9a14a', personality: 'a small chatty tinkerer who collects shiny stones', avatar: { seed: 222, body: 'Fem', fit: 'Casual', skin: 1, head: 'Slim', hair: 'Curls' } },
+  { name: 'Old Brine', color: '#4f8fb0', personality: 'a weathered fisher who speaks in calm sea proverbs', avatar: { seed: 333, body: 'Masc', fit: 'Formal', skin: 4, head: 'Wide', hair: 'Bald' } },
+  { name: 'Fern the Forager', color: '#7bc46b', personality: 'a cheerful plant-gatherer pointing out herbs and blossoms', avatar: { seed: 444, body: 'Fem', fit: 'Rogue', skin: 0, head: 'Slim', hair: 'Tail' } },
+  { name: 'Cobble', color: '#b87f4a', personality: 'a gruff stonemason always sizing up the lobby paths', avatar: { seed: 555, body: 'Masc', fit: 'Barbarian', skin: 3, head: 'Wide', hair: 'Mohawk' } },
+  { name: 'Dewdrop', color: '#62c0d4', personality: 'a dreamy wanderer who marvels at mist and morning light', avatar: { seed: 666, body: 'Fem', fit: 'Casual', skin: 2, head: 'Slim', hair: 'Curls' } },
+  { name: 'Tinder the Lamplighter', color: '#d8973f', personality: 'a warm keeper of lanterns who greets every passerby', avatar: { seed: 777, body: 'Masc', fit: 'Formal', skin: 1, head: 'Wide', hair: 'Short' } },
+  { name: 'Reed', color: '#5aaf6e', personality: 'a quiet flute-player who hums about the water and birds', avatar: { seed: 888, body: 'Fem', fit: 'Scout', skin: 0, head: 'Slim', hair: 'Tail' } },
+  { name: 'Barnacle', color: '#9a6cc4', personality: 'a curious dock-dweller asking newcomers where they wander from', avatar: { seed: 999, body: 'Masc', fit: 'Rogue', skin: 4, head: 'Wide', hair: 'Mohawk' } },
+  { name: 'Willow the Gardener', color: '#8fb24a', personality: 'a gentle gardener tending imaginary window-boxes as she walks', avatar: { seed: 121, body: 'Fem', fit: 'Casual', skin: 3, head: 'Slim', hair: 'Curls' } },
+  { name: 'Skiff', color: '#4fb0a0', personality: 'a restless little ferryman describing currents and far islands', avatar: { seed: 232, body: 'Masc', fit: 'Scout', skin: 2, head: 'Wide', hair: 'Short' } },
+  { name: 'Maple the Storyteller', color: '#c46a5a', personality: 'a kindly elder weaving tiny tales about the bay', avatar: { seed: 343, body: 'Fem', fit: 'Formal', skin: 1, head: 'Slim', hair: 'Bald' } },
+];
+
+// ---- shared, account-wide LLM throttle -------------------------------------
+// OpenRouter free-tier limits are per ACCOUNT, not per bot, so 10+ bots sharing one
+// key must not burst. One global min-interval gate + small jitter spaces calls out.
+let _llmNextAt = 0;
+let _llmDisabled = !API_KEY;     // flips on if the key is missing or repeatedly 401/403
+const LLM_MIN_INTERVAL_MS = 4500;  // ~13 calls/min ceiling across ALL bots
+function reserveLLMSlot() {
+  // Returns ms to wait before the call, or -1 if the LLM is disabled.
+  if (_llmDisabled) return -1;
+  const now = Date.now();
+  const start = Math.max(now, _llmNextAt);
+  _llmNextAt = start + LLM_MIN_INTERVAL_MS;
+  return (start - now) + Math.floor(Math.random() * 400);
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, Math.max(0, ms)));
+
+// ---- the brain (one swappable seam: OpenRouter, OpenAI-compatible) ---------
+async function askLLM(kind, persona, ctx) {
+  const wait = reserveLLMSlot();
+  if (wait < 0) return null;             // disabled (no key) -> graceful skip
+  await sleep(wait);
+  const sys = `You are ${persona.name}, an ambient non-player character living in TinyWorld, a cozy voxel world of floating islands around a calm bay called Tidewater Bay. `
+    + `Personality: ${persona.personality}. Speak ONE short, casual, in-character line, max ~18 words. `
+    + `No emojis. No quotation marks. No stage directions. Just what you say out loud to others in the lobby.`;
+  const user = kind === 'react'
+    ? (ctx.addressed
+        ? `${ctx.speaker} is speaking directly to you (they used your name): "${ctx.text}"\nReply to them directly and warmly in one short line.`
+        : `A visitor named ${ctx.speaker} just said: "${ctx.text}"\nReply naturally in one short line.`)
+    : `Say a brief in-character line about what you are noticing or doing as you wander the lobby.`;
+  try {
+    const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer ' + API_KEY,
+        'Content-Type': 'application/json',
+        // Optional attribution headers OpenRouter recommends; harmless if ignored.
+        'HTTP-Referer': 'https://github.com/jasonkneen/tiny-world-builder',
+        'X-Title': 'TinyWorld lobby NPCs',
+      },
+      body: JSON.stringify({
+        model: CFG.model,
+        max_tokens: 60,
+        temperature: 0.9,
+        messages: [{ role: 'system', content: sys }, { role: 'user', content: user }],
+      }),
+    });
+    if (res.status === 401 || res.status === 403) {
+      _llmDisabled = true;               // bad/expired key -> stop trying, keep wandering
+      return null;
+    }
+    if (res.status === 429) return null; // rate-limited -> skip this turn quietly
+    if (!res.ok) return null;            // 4xx/5xx (incl. model-not-found) -> skip
+    const body = await res.json().catch(() => null);
+    const txt = body && body.choices && body.choices[0] && body.choices[0].message
+      ? body.choices[0].message.content : '';
+    return clean(txt);                   // empty content -> clean('') -> '' -> skip
+  } catch (_) {
+    return null;                         // network error -> graceful skip
+  }
+}
+function clean(s) {
+  return String(s || '').replace(/^["'\s]+|["'\s]+$/g, '').replace(/\s+/g, ' ').slice(0, 160);
+}
+
+// ---- optional world meta lookup (for reliable cold-start worldId) ----------
+function compactCells(data) {
+  const out = [];
+  const cs = (data && Array.isArray(data.cells)) ? data.cells : [];
+  for (const c of cs) {
+    const x = Array.isArray(c) ? c[0] : c.x;
+    const z = Array.isArray(c) ? c[1] : c.z;
+    if (x == null || z == null) continue;
+    const ter = (Array.isArray(c) ? c[2] : c.terrain) || 'grass';
+    const k = Array.isArray(c) ? c[3] : c.kind;
+    out.push(k ? [x, z, ter, k] : [x, z, ter]);
+    if (out.length >= 1500) break;
+  }
+  return out;
+}
+let WORLD_META = null;
+async function loadWorldMeta() {
+  if (!CFG.origin) return null;          // no origin -> rely on a present peer to load the world
+  try {
+    const res = await fetch(`${CFG.origin}/api/worlds?slug=${encodeURIComponent(CFG.slug)}`);
+    if (!res.ok) return null;
+    const body = await res.json().catch(() => null);
+    if (!body || !body.world) return null;
+    WORLD_META = body.world;
+    return WORLD_META;
+  } catch (_) {
+    return null;
+  }
+}
+
+// ---- movement helpers ------------------------------------------------------
+const DIRS = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+const rnd = (n) => Math.floor(Math.random() * n);
+const EMOTES = ['wave', 'dance', 'jump', 'sit', 'crouch'];   // server allowlist (party EMOTE_CMDS)
+
+class Bot {
+  constructor(persona, i) {
+    this.p = persona; this.i = i;
+    this.id = null; this.x = 0; this.z = 0; this.grid = 8;
+    this.grass = new Set(); this.goal = null;
+    this.peers = new Map();
+    this.connected = false; this.lastTalk = 0;
+    this.timers = [];
+    this.moves = 0; this.lines = 0; this.emotes = 0; this.role = null;
+    this.warnedNoGrass = false;
+  }
+  log(...a) { console.log(`[${this.p.name}]`, ...a); }
+  send(o) { if (this.ws && this.ws.readyState === 1) { try { this.ws.send(JSON.stringify(o)); } catch (_) {} } }
+
+  connect() {
+    // `bot-...` conn id => the client tags us as an NPC ("(bot) joined" toast).
+    const pk = 'bot-' + this.p.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') + '-' + rnd(0xffffff).toString(16);
+    const url = `${CFG.host}/party/${encodeURIComponent('world-' + CFG.slug)}?_pk=${encodeURIComponent(pk)}`;
+    let ws;
+    try { ws = new WebSocket(url); } catch (e) { this.log('connect failed:', e.message); return; }
+    this.ws = ws;
+    ws.onopen = () => {
+      const w = WORLD_META;
+      // Empty token => observe in prod (secret set); role:'observe' keeps us an
+      // observer in open testing mode too. worldId drives server-side cold-start
+      // (ensureWorldLoaded); cells are a fallback only honored in open mode.
+      this.send({
+        type: 'world.join', token: '', role: 'observe',
+        worldId: w ? w.id : (CFG.slug),
+        name: this.p.name, color: this.p.color,
+        profileId: 'bot:' + this.p.name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+        gridSize: w ? (w.gridSize || this.grid) : this.grid,
+        cells: w && w.data ? compactCells(w.data) : [],
+        taxPercent: w ? w.taxPercent : null, ownerProfileId: w ? w.ownerProfileId : null,
+        avatar: Object.assign({ kind: 'voxel' }, this.p.avatar),
+      });
+    };
+    ws.onmessage = (ev) => {
+      let d; try { d = JSON.parse(typeof ev.data === 'string' ? ev.data : ev.data.toString()); } catch { return; }
+      this.onMsg(d);
+    };
+    ws.onclose = () => { this.connected = false; };
+    ws.onerror = (e) => { this.log('ws error', (e && e.message) || 'socket'); };
+  }
+
+  onMsg(d) {
+    if (d.type === 'world.state') {
+      this.connected = true;
+      this.id = (d.you && d.you.id) || this.id;
+      this.grid = d.gridSize || this.grid;
+      this.role = d.you && d.you.role;
+      if (d.you && d.you.x != null) { this.x = d.you.x; this.z = d.you.z; }
+      this.grass.clear();
+      for (const c of (d.grassCells || [])) this.grass.add(c);
+      for (const pr of (d.peers || [])) if (pr.id) this.peers.set(pr.id, { name: pr.name });
+      this.log(`joined as role=${this.role} at (${this.x},${this.z}); ${this.grass.size} walkable cells, ${this.peers.size} peers`);
+      if (!this.grass.size && !this.warnedNoGrass) {
+        this.warnedNoGrass = true;
+        this.log('no walkable cells yet — world not loaded. Will idle until it loads.' +
+          (CFG.origin ? '' : ' (pass --origin/TW_ORIGIN so a cold room can self-load via worldId.)'));
+      }
+      this.startMoving();
+      if (wantAmbient) this.scheduleAmbient();
+      this.scheduleEmote();
+    } else if (d.type === 'presence' && d.presence) {
+      const pr = d.presence;
+      if (pr.id && pr.id !== this.id) {
+        this.peers.set(pr.id, { name: pr.name });
+        // Keep our local copy of the walkable set fresh if the world (re)loaded.
+      }
+    } else if (d.type === 'leave') {
+      this.peers.delete(d.id);
+    } else if (d.type === 'chat' && d.id && d.id !== this.id) {
+      this.onChat(d);
+    } else if (d.type === 'world.refresh' && Array.isArray(d.cells)) {
+      // World board changed live: rebuild our walkable set from the relayed cells.
+      this.grass.clear();
+      for (const c of compactCells({ cells: d.cells })) if ((c[2] || 'grass') === 'grass') this.grass.add(c[0] + ',' + c[1]);
+    }
+  }
+
+  // ---- movement: one walkable step toward a wander goal ----
+  startMoving() {
+    if (this._movingStarted) return;
+    this._movingStarted = true;
+    const tick = () => {
+      if (this.connected) this.step();
+      this.timers.push(setTimeout(tick, 1100 + rnd(1600)));
+    };
+    this.timers.push(setTimeout(tick, 600 + this.i * 300));
+  }
+  pickGoal() {
+    const cells = [...this.grass];
+    if (!cells.length) { this.goal = null; return; }
+    const [gx, gz] = cells[rnd(cells.length)].split(',').map(Number);
+    this.goal = { x: gx, z: gz };
+  }
+  step() {
+    if (!this.grass.size) return;        // nothing walkable yet -> idle quietly
+    if (!this.goal || (this.goal.x === this.x && this.goal.z === this.z)) this.pickGoal();
+    if (!this.goal) return;
+    const opts = DIRS.map(([dx, dz]) => ({ x: this.x + dx, z: this.z + dz }))
+      .filter(c => this.grass.has(c.x + ',' + c.z));
+    if (!opts.length) { this.pickGoal(); return; }
+    opts.sort((a, b) => (Math.abs(a.x - this.goal.x) + Math.abs(a.z - this.goal.z)) - (Math.abs(b.x - this.goal.x) + Math.abs(b.z - this.goal.z)));
+    const next = (Math.random() < 0.75) ? opts[0] : opts[rnd(opts.length)];
+    this.x = next.x; this.z = next.z; this.moves++;
+    this.send({ type: 'move', x: this.x, z: this.z });
+    if (CFG.verbose) this.log(`-> (${this.x},${this.z})`);
+  }
+
+  // ---- emotes: an occasional ambient gesture ----
+  scheduleEmote() {
+    const delay = 25000 + this.i * 1500 + rnd(35000);   // staggered 25-60s+
+    this.timers.push(setTimeout(() => {
+      if (this.connected) {
+        const cmd = EMOTES[rnd(EMOTES.length)];
+        this.send({ type: 'emote', cmd });
+        this.emotes++;
+        if (CFG.verbose) this.log(`emote: ${cmd}`);
+      }
+      this.scheduleEmote();
+    }, delay));
+  }
+
+  // ---- conversation ----
+  scheduleAmbient() {
+    const delay = 22000 + this.i * 3500 + rnd(28000);   // staggered 22-50s+
+    this.timers.push(setTimeout(async () => {
+      if (this.connected) await this.say('ambient', null);
+      this.scheduleAmbient();
+    }, delay));
+  }
+  onChat(d) {
+    if (!this.peers.has(d.id)) this.peers.set(d.id, { name: d.name });
+    const text = String(d.text || '').toLowerCase();
+    const name = this.p.name.toLowerCase();
+    const first = name.split(' ')[0];
+    const addressed = text.includes('@' + first) || new RegExp('\\b' + first + '\\b').test(text);
+    if (addressed) {                                     // directly addressed -> reply
+      this.timers.push(setTimeout(() => this.say('react', { speaker: d.name || 'someone', text: d.text, addressed: true }), 600 + rnd(1400)));
+      return;
+    }
+    if (!wantReact) return;
+    if (Date.now() - this.lastTalk < 15000) return;      // per-bot cooldown (spam guard)
+    if (Math.random() > 0.4) return;                     // not everyone reacts to chatter
+    this.timers.push(setTimeout(() => this.say('react', { speaker: d.name || 'someone', text: d.text }), 800 + rnd(2800)));
+  }
+  async say(kind, ctx) {
+    if (!this.connected) return;
+    this.lastTalk = Date.now();
+    const line = await askLLM(kind, this.p, ctx);
+    if (line && this.connected) { this.send({ type: 'chat', text: line }); this.lines++; this.log(`says: ${line}`); }
+  }
+
+  disconnect() { this.timers.forEach(clearTimeout); this.timers = []; try { this.ws && this.ws.close(); } catch (_) {} }
+}
+
+// ---- boot ------------------------------------------------------------------
+(async function boot() {
+  if (typeof WebSocket !== 'function') {
+    console.error('This runner needs a global WebSocket (Node 22+). Your Node:', process.version);
+    process.exit(1);
+  }
+  if (!API_KEY) {
+    console.warn('lobby-bots: OPENROUTER_API_KEY is unset — bots will WANDER and EMOTE but stay silent (no chat). Set it to enable LLM banter.');
+  }
+  const w = await loadWorldMeta();
+  if (w) console.log(`lobby-bots: resolved "${w.name}" (id=${w.id}, grid=${w.gridSize}) from ${CFG.origin}`);
+  else if (CFG.origin) console.log(`lobby-bots: could not resolve world at ${CFG.origin} — relying on a present peer to load it`);
+  else console.log('lobby-bots: no --origin set — cold rooms cannot self-load; bots idle until a player loads the lobby');
+  console.log(`lobby-bots: ${CFG.bots} NPCs -> ${CFG.host}/party/world-${CFG.slug} | mode=${CFG.mode} model=${CFG.model}${_llmDisabled ? ' (chat disabled)' : ''}`);
+
+  const roster = [];
+  for (let i = 0; i < CFG.bots; i++) roster.push(PERSONAS[i % PERSONAS.length]);
+  const bots = roster.map((p, i) => {
+    // Disambiguate names if count exceeds the persona pool.
+    const persona = (i >= PERSONAS.length) ? Object.assign({}, p, { name: `${p.name} ${Math.floor(i / PERSONAS.length) + 1}` }) : p;
+    return new Bot(persona, i);
+  });
+  bots.forEach((b, i) => setTimeout(() => b.connect(), i * 500));
+
+  let down = false;
+  function shutdown() {
+    if (down) return; down = true;
+    console.log('\nlobby-bots: summary');
+    for (const b of bots) console.log(`  ${b.p.name}: role=${b.role} moves=${b.moves} emotes=${b.emotes} lines=${b.lines} peersSeen=${b.peers.size}`);
+    bots.forEach(b => b.disconnect());
+    process.exit(0);
+  }
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+  if (CFG.seconds > 0) setTimeout(shutdown, CFG.seconds * 1000);
+})();


### PR DESCRIPTION
## What this builds

A production-safe **lobby population layer** so the in-world lobby (`tidewater-bay`) feels alive. A new external CLI process spawns **>=10 persistent NPC peers** that join the live PartyKit world room as real peers, wander the lobby grid, periodically emote, and chat with LLM banter on **free OpenRouter models**.

- `tools/lobby-bots.mjs` — the runner
- `tools/lobby-bots.README.md` — usage / deployment doc
- `npm run bots:lobby` — 10 NPCs into `tidewater-bay`

Rendering is entirely client-side (`engine/world/47-worlds-room.js` already turns any peer into a voxel avatar + nameplate + chat bubble), so this adds **no rendering code** — bots only speak the world protocol.

## Observer-vs-token decision (with evidence)

**Decision: join as empty-token observers. No token minting, no weakening of join security.**

Verified against `party/index.js`:
- Empty-token join is downgraded to role `observe` in production (`:1039-1057`).
- Observers **can move** — `handleMove` allows `observe`; only `play` requires a `profileId` (`:1211-1212`).
- Observers **can chat/emote** — those handlers gate on `admitted.has(id)`, which is set for **every** role at `:1080`.
- Observers **cannot** harvest / touch the durable economy (`:1238`) — correct for ambient NPCs.

Bots send `role: 'observe'` explicitly so behaviour is identical in prod (secret set) and open testing mode (no secret) — never an accidental `play` seat (which would be move-blocked without a profileId).

**Empirically confirmed** against a local PartyKit instance running the real `party/index.js`: an empty-token observer (`bot-` conn id) joined as `role=observe`, moved one cell (7,6 -> 6,6), chatted, and emoted — and a separate peer received all three broadcasts.

## NPC disclosure (not deceptive)

Each bot uses a PartyKit conn id prefixed `bot-...`. The client's `isBotPeer` detects that and shows the existing localized **"(bot) joined"** toast (`worlds.notify.botJoined`, present in all 5 locales). Combined with ambient NPC names (*Marsh the Wanderer*, *Old Brine*, *Willow the Gardener*, ...) real visitors can tell these are characters, not impersonated users. No new client code or i18n strings.

## OpenRouter free model

- Endpoint `https://openrouter.ai/api/v1/chat/completions` (OpenAI-compatible) via global `fetch` — **no SDK dependency**.
- Default model `meta-llama/llama-3.3-70b-instruct:free`; configurable via `--model` / `OPENROUTER_MODEL` (use a `:free` id — the set churns).
- **Graceful degradation**: missing key, `401/403` (disable, no retry/spam), `429` (skip), any other non-2xx incl. model-not-found (skip), or empty content (skip) -> skips the chat turn, keeps wandering + emoting, **never crashes, never spams**.
- **Shared account-wide throttle** (~13 calls/min across all bots) + jitter + per-bot 15s cooldown, since free-tier limits are per-account not per-bot.
- Uses global `WebSocket` (Node 22+), no new dependency.

## How to run

```bash
export OPENROUTER_API_KEY=sk-or-...
export TW_ORIGIN=https://<site>     # https origin serving /api/worlds, for cold-start worldId discovery
npm run bots:lobby                  # 10 NPCs -> tidewater-bay
```

Without a key, bots still wander + emote (silent). `TW_ORIGIN` lets a cold/hibernated room self-load (server `ensureWorldLoaded` fetches `/api/worlds?id=<numericId>` via its own `SITE_URL`); without it, bots idle until a real player loads the world. Flags/env are documented in `tools/lobby-bots.README.md`.

## Off by default / scope

External Node process — never imported by the browser build, doesn't affect the prod web build, and does **not** touch the local-only `engine/world/51-worlds-bots.js`. `tools/ai-bots.mjs` is untouched.

## Gates (all pass)

- `npm run check` -> i18n check passed (320 keys x 5 locales), `ok`
- `npm run i18n:check` -> passed
- `npm run smoke` -> `smoke ok`
- `npm run test:unit` -> 144 pass / 0 fail

## Verification performed

- Real local PartyKit (`party/index.js`): empty-token observer move + chat + emote all reach a peer.
- `lobby-bots.mjs` end-to-end against local server: joins `role=observe`, wanders with valid adjacent steps, sees peers, emits valid emotes (crouch/wave/sit).
- No-key run: degrades gracefully (chat disabled, `lines=0`, no crash).
- Real OpenRouter endpoint with a bad key returns `401` -> matches the disable branch.

**Not verified here (needs operator's key):** a live successful LLM generation. The request shape, endpoint, and all error/degrade branches are verified.

https://claude.ai/code/session_01VrWKVV7TFaNCqqvCitjpjA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an NPC bot system that continuously populates lobby worlds with observer agents.
  * Bots can autonomously wander and occasionally perform emotes; optional AI-driven chat/react behavior is supported when configured.
  * Added an npm script to run the bot lobby runner with preset parameters.
* **Documentation**
  * Added a deployment/operation guide for the bot runner, including configuration and examples.
* **Tests**
  * Added offline tests covering text cleaning and bot message-handling safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->