### PR TITLE
Lock Tinyverse access to Jason accounts

### DIFF
--- a/.codex/skills/tinyworld-integrations/SKILL.md
+++ b/.codex/skills/tinyworld-integrations/SKILL.md
@@ -89,6 +89,11 @@ backend:
   world data should normalize to one center `stargate` with
   `dest: '__world-picker'`, and PartyKit `safeSpawn()` should prefer that gate
   so players arrive where the in-world picker exit is.
+- Tinyverse/lobby access is locked to the Jason account allowlist in
+  `netlify/functions/lib/tinyverse-access.mjs`. Do not use
+  `accountMeetsCriteria()` or a raw `profiles.lobby_access` flag as the
+  authoritative gate; migrations should keep `lobby_access` default false and
+  clear it for every non-allowlisted profile.
 - Tinyverse room join/refresh payloads use compact cells. Terrain-only cells may
   be `[x,z,terrain]`; object/resource cells are `[x,z,terrain,kind]`. Keep the
   renderer validator and `applyState()` tolerant of both tuple lengths.

--- a/netlify/database/migrations/20260621050000_lock_tinyverse_access.sql
+++ b/netlify/database/migrations/20260621050000_lock_tinyverse_access.sql
@@ -1,0 +1,14 @@
+-- Tinyverse/lobby access is invite-only again. Keep world-admin status separate:
+-- the Gmail account can enter Tinyverse without becoming a world admin.
+ALTER TABLE profiles
+  ALTER COLUMN lobby_access SET DEFAULT FALSE;
+
+UPDATE profiles
+SET lobby_access = CASE
+  WHEN LOWER(COALESCE(email, '')) IN (
+    'jason@bouncingfish.com',
+    'jason.kneen@bouncingfish.com',
+    'jason.kneen@gmail.com'
+  ) THEN TRUE
+  ELSE FALSE
+END;

--- a/netlify/functions/admin-users.mjs
+++ b/netlify/functions/admin-users.mjs
@@ -1,8 +1,9 @@
-import { accountMeetsCriteria, requireAuthUser } from './lib/auth.mjs';
+import { requireAuthUser } from './lib/auth.mjs';
 import { getSql, isDatabaseUnavailable } from './lib/db.mjs';
 import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
 import { ensureProfile, normalizeProfileHandle, normalizeProfileImageUrl, normalizeUsername, profileDto } from './lib/profiles.mjs';
 import { isWorldAdminEmail, worldAdminEmails } from './lib/worlds.mjs';
+import { isTinyverseAccessEmail, tinyverseAccessEmails } from './lib/tinyverse-access.mjs';
 
 export const config = { path: '/api/admin-users' };
 
@@ -23,31 +24,21 @@ function adminEmailsArray() {
   return Array.from(worldAdminEmails()).map(e => String(e || '').trim().toLowerCase()).filter(Boolean);
 }
 
-function isBuiltInTinyverseEmail(email) {
-  const e = cleanEmail(email);
-  if (e === 'jason.kneen@gmail.com') return false; // alt is non-admin
-  return adminEmailsArray().includes(e);
+function tinyverseAccessEmailsArray() {
+  return Array.from(tinyverseAccessEmails()).map(e => String(e || '').trim().toLowerCase()).filter(Boolean);
 }
 
-function canAccessTinyverse(user, profile) {
+export function canAccessTinyverse(user, profile) {
   if (!user || !user.id) return false;
-
   const email = cleanEmail(user.email || (profile && profile.email) || '');
-  const allowedEmails = [
-    'jason@bouncingfish.com',
-    'jason.kneen@bouncingfish.com',
-    'jason.kneen@gmail.com'
-  ];
-  if (allowedEmails.includes(email)) return true;
-
-  return false;
+  return isTinyverseAccessEmail(email);
 }
 
 function adminUserDto(row) {
   const dto = profileDto(row);
   if (!dto) return null;
-  dto.lobbyAccess = row.lobby_access !== false; // default true
-  dto.builtInAccess = isBuiltInTinyverseEmail(row.email);
+  dto.lobbyAccess = isTinyverseAccessEmail(row.email);
+  dto.builtInAccess = isTinyverseAccessEmail(row.email);
   return dto;
 }
 
@@ -61,7 +52,7 @@ function validateAdminEdit(body) {
   const email = cleanEmail(body && body.email);
   const twitter = normalizeProfileHandle(body && body.twitter);
   const github = normalizeProfileHandle(body && body.github);
-  const lobbyAccess = !!(body && body.lobbyAccess);
+  const lobbyAccess = isTinyverseAccessEmail(email);
   if (!/^[a-z0-9_]{3,24}$/.test(username)) return { error: 'Username must be 3-24 lowercase letters, numbers, underscores' };
   if (!displayName) return { error: 'Display name required' };
   if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return { error: 'Email is invalid' };
@@ -120,23 +111,21 @@ export default async function adminUsersFunction(request) {
   const user = auth.user;
 
   try {
-    const profile = await ensureProfile(user);
     const url = new URL(request.url);
     if (request.method === 'GET' && url.searchParams.get('action') === 'tinyverse-access') {
-            try {
+      try {
         const profile = await ensureProfile(user);
         return jsonResponse({ allowed: canAccessTinyverse(user, profile), admin: isWorldAdminEmail(user && user.email) }, origin);
       } catch (err) {
         if (isDatabaseUnavailable(err)) {
-  const email = cleanEmail(user && user.email);
-  const allowedEmails = ['jason@bouncingfish.com', 'jason.kneen@bouncingfish.com', 'jason.kneen@gmail.com'];
-  const allowed = allowedEmails.includes(email);
+          const allowed = isTinyverseAccessEmail(user && user.email);
           return jsonResponse({ allowed, admin: isWorldAdminEmail(user && user.email) }, origin);
         }
         return jsonResponse({ allowed: false }, origin);
       }
     }
 
+    await ensureProfile(user);
     if (!isWorldAdminEmail(user && user.email)) return errorResponse('Forbidden', 403, origin);
 
     const sql = getSql();
@@ -162,7 +151,7 @@ export default async function adminUsersFunction(request) {
             ORDER BY updated_at DESC, id DESC
             LIMIT 100
           `;
-      return jsonResponse({ users: rows.map(adminUserDto), adminEmails: adminEmailsArray() }, origin);
+      return jsonResponse({ users: rows.map(adminUserDto), adminEmails: adminEmailsArray(), tinyverseAccessEmails: tinyverseAccessEmailsArray() }, origin);
     }
 
     if (request.method === 'PUT') {

--- a/netlify/functions/lib/profiles.mjs
+++ b/netlify/functions/lib/profiles.mjs
@@ -1,5 +1,6 @@
 import { getSql } from './db.mjs';
 import { absoluteSiteUrl } from './http.mjs';
+import { tinyverseLobbyAccessForEmail } from './tinyverse-access.mjs';
 
 export const PROFILE_AVATAR_KEYS = ['knight', 'wizard', 'builder', 'explorer', 'knave', 'robot', 'fox', 'cat'];
 
@@ -121,10 +122,11 @@ export async function ensureProfile(user) {
   const displayName = defaultDisplayNameForUser(user);
   const image = defaultImageForUser(user);
   const email = userEmail(user);
+  const lobbyAccess = tinyverseLobbyAccessForEmail(email);
   try {
     const inserted = await sql`
       INSERT INTO profiles (auth0_id, email, username, display_name, about, image, lobby_access)
-      VALUES (${user.id}, ${email}, ${username}, ${displayName}, '', ${image}, true)
+      VALUES (${user.id}, ${email}, ${username}, ${displayName}, '', ${image}, ${lobbyAccess})
       ON CONFLICT (auth0_id) DO NOTHING
       RETURNING id, auth0_id, email, username, display_name, about, image, twitter, github, lobby_access, password_reset_requested_at, archived_at, merged_into_profile_id, created_at, updated_at
     `;
@@ -136,7 +138,7 @@ export async function ensureProfile(user) {
   const fallbackUsername = ('builder_' + profileSuffix(user.id)).slice(0, 24);
   const fallback = await sql`
     INSERT INTO profiles (auth0_id, email, username, display_name, about, image, lobby_access)
-    VALUES (${user.id}, ${email}, ${fallbackUsername}, ${displayName}, '', ${image}, true)
+    VALUES (${user.id}, ${email}, ${fallbackUsername}, ${displayName}, '', ${image}, ${lobbyAccess})
     ON CONFLICT (auth0_id) DO UPDATE SET updated_at = profiles.updated_at
     RETURNING id, auth0_id, email, username, display_name, about, image, twitter, github, lobby_access, password_reset_requested_at, archived_at, merged_into_profile_id, created_at, updated_at
   `;

--- a/netlify/functions/lib/tinyverse-access.mjs
+++ b/netlify/functions/lib/tinyverse-access.mjs
@@ -1,0 +1,23 @@
+const TINYVERSE_ACCESS_DEFAULT_EMAILS = [
+  'jason@bouncingfish.com',
+  'jason.kneen@bouncingfish.com',
+  'jason.kneen@gmail.com',
+];
+
+function cleanTinyverseEmail(value) {
+  return String(value == null ? '' : value).trim().toLowerCase();
+}
+
+export function tinyverseAccessEmails() {
+  return new Set(TINYVERSE_ACCESS_DEFAULT_EMAILS);
+}
+
+export function isTinyverseAccessEmail(email) {
+  const e = cleanTinyverseEmail(email);
+  if (!e) return false;
+  return tinyverseAccessEmails().has(e);
+}
+
+export function tinyverseLobbyAccessForEmail(email) {
+  return isTinyverseAccessEmail(email);
+}

--- a/netlify/functions/worlds.mjs
+++ b/netlify/functions/worlds.mjs
@@ -3,6 +3,7 @@ import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs'
 import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
 import { ensureProfile, profileDto } from './lib/profiles.mjs';
 import { activeSuspension } from './lib/community-moderation.mjs';
+import { isTinyverseAccessEmail } from './lib/tinyverse-access.mjs';
 import {
   cleanWorldName, cleanTaxPercent, computeWorldPrice, deriveTerrainCounts,
   worldDto, worldPreview, signJoinToken, isWorldAdminEmail, getTaxCooldownInfo,
@@ -71,6 +72,7 @@ export default async function worldsFunction(request) {
     // God-admin: a small email allowlist may edit ANY world live (incl. the
     // ownerless published lobby) and save to the live record. Follows the account.
     const isWorldAdmin = isWorldAdminEmail(user && user.email);
+    const canAccessTinyverse = isTinyverseAccessEmail(user && (user.email || (profile && profile.email)));
     const worldId = worldIdFromRequest(request);
     const worldSlug = slugFromRequest(request);
 
@@ -78,6 +80,7 @@ export default async function worldsFunction(request) {
       const economy = await loadEconomy(sql);
 
       if (worldId || worldSlug) {
+        if (!canAccessTinyverse) return errorResponse('Tinyverse access is invite-only', 403, origin);
         const rows = worldId
           ? await sql`
               SELECT w.*, p.display_name AS owner_name
@@ -132,6 +135,7 @@ export default async function worldsFunction(request) {
           perTileBase: String(economy.per_tile_base || '0'),
         } }, origin);
       }
+      if (!canAccessTinyverse) return errorResponse('Tinyverse access is invite-only', 403, origin);
 
       const rows = await sql`
         SELECT w.*, p.display_name AS owner_name
@@ -163,6 +167,7 @@ export default async function worldsFunction(request) {
 
     // ---- writes require auth + same-origin ----
     if (!profile) return errorResponse('Unauthorized', 401, origin);
+    if (!canAccessTinyverse) return errorResponse('Tinyverse access is invite-only', 403, origin);
     if (!sameOriginWriteGuard(request)) return errorResponse('Forbidden', 403, origin);
 
     if (request.method === 'PUT') {

--- a/tests/account-criteria.test.mjs
+++ b/tests/account-criteria.test.mjs
@@ -1,6 +1,6 @@
-// Unit tests for accountMeetsCriteria() - the single centralized predicate that
-// decides whether an account auto-qualifies for Tinyverse/lobby/multiplayer
-// access. Run with: npm run test:unit
+// Unit tests for accountMeetsCriteria() - the shared registered-account
+// predicate. Tinyverse access is separately locked to the Jason allowlist.
+// Run with: npm run test:unit
 //
 // The rule is intentionally narrow for now (registered, email-verified Identity
 // account) because a wallet-access policy decision is still pending upstream.

--- a/tests/tinyverse-access.test.mjs
+++ b/tests/tinyverse-access.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isTinyverseAccessEmail,
+  tinyverseAccessEmails,
+  tinyverseLobbyAccessForEmail,
+} from '../netlify/functions/lib/tinyverse-access.mjs';
+import { canAccessTinyverse } from '../netlify/functions/admin-users.mjs';
+
+test('Tinyverse access is locked to the Jason account allowlist', () => {
+  const set = tinyverseAccessEmails();
+  assert.equal(set.has('jason@bouncingfish.com'), true);
+  assert.equal(set.has('jason.kneen@bouncingfish.com'), true);
+  assert.equal(set.has('jason.kneen@gmail.com'), true);
+  assert.equal(isTinyverseAccessEmail('  Jason.Kneen@Gmail.com  '), true);
+  assert.equal(isTinyverseAccessEmail('someone@example.com'), false);
+  assert.equal(isTinyverseAccessEmail(''), false);
+});
+
+test('new profile lobby flag defaults to the Tinyverse allowlist only', () => {
+  assert.equal(tinyverseLobbyAccessForEmail('jason.kneen@gmail.com'), true);
+  assert.equal(tinyverseLobbyAccessForEmail('new-user@example.com'), false);
+});
+
+test('admin Tinyverse check ignores stale lobby flags for non-allowed users', () => {
+  const user = { id: 'user-123', email: 'new-user@example.com' };
+  const profile = { email: 'new-user@example.com', lobby_access: true };
+  assert.equal(canAccessTinyverse(user, profile), false);
+  assert.equal(canAccessTinyverse({ id: 'user-456', email: 'jason.kneen@gmail.com' }, null), true);
+});


### PR DESCRIPTION
## Summary
- add a shared Tinyverse access allowlist for Jason accounts
- force admin/user profile access flags to that allowlist and default new profiles to locked
- gate direct /api/worlds loads and writes behind the Tinyverse allowlist
- add a migration to reset existing lobby_access flags for non-allowlisted users

## Tests
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tinyverse/lobby access is now restricted to an invite-only allowlist. Access permissions have been consolidated to ensure consistent enforcement across all entry points, with database defaults updated to reflect the restricted access model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->