### PR TITLE
Announce the autonomous production line (Wave 2 build-up)

### DIFF
--- a/news.html
+++ b/news.html
@@ -227,6 +227,33 @@
 
       <ol class="news-timeline">
 
+        <li class="news-entry is-featured cat-smarter">
+          <div class="news-meta">
+            <span class="news-date">June 24, 2026</span>
+            <span class="news-tag">The workshop</span>
+          </div>
+          <h2>We switched on the production line</h2>
+          <p>
+            Starting today we have an autonomous production line running on TinyWorld. It is a
+            self-directing crew of AI agents that dreams up, specs, builds, reviews, and ships
+            improvements to the game and the site in small pieces, around the clock, all week,
+            building up to WAVE 2. Watch this space: new features land, a fresh story goes up
+            here on the news page and on the home screen, and the world quietly gets bigger
+            while you sleep.
+          </p>
+          <p>
+            This is one of the rare times a fully autonomous build-and-deploy loop has been put
+            in charge of growing a real web app and game in public, for an audience of humans
+            and agents alike. Ideas in one end, reviewed and tested features out the other,
+            with people steering and machines doing the heavy lifting. We are genuinely excited
+            about what is coming, and we are building it where you can see it happen.
+          </p>
+          <blockquote class="news-quote">
+            "Dream big, build small, ship often. Now with a night shift that never clocks off."
+            <cite>The TinyWorld workshop</cite>
+          </blockquote>
+        </li>
+
         <li class="news-entry is-featured cat-signin">
           <div class="news-meta">
             <span class="news-date">June 23, 2026</span>


### PR DESCRIPTION
First delivery of the **autonomous production line** (see \`plans/production-line/\`).

Adds one news entry to the \`/news\` timeline announcing that an AI agent crew will ship iterative updates across the site and game all week, leading into WAVE 2.

**Pipeline run on this change:**
- Spec: trivial (content) — copy brief from owner
- Build: Haiku-tier content edit, in isolated worktree \`pl/announce-production-line\`
- Review (adversarial): Codex GPT editorial+HTML+legal pass → verdict **SHIP** (well-formed HTML, no financial/returns claims, consistent with the GOLD-not-money stance)
- Test: visual — renders as a standard \`news-entry\` \`<li>\` in the existing timeline

No code paths touched. View-facing, so \`publish.sh\` runs on merge.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new featured news timeline entry dated June 24, 2026.
  * The latest item now appears first and includes additional narrative text plus a quoted citation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->