### PR TITLE
[HOLD: economy preview] E1 — live $TINYWORLD balance into GOLD + fix latent /api/me/gold 500

### DIFF
--- a/netlify/functions/gold.mjs
+++ b/netlify/functions/gold.mjs
@@ -61,19 +61,18 @@ export default async function meGold(request) {
         WHERE profile_id = ${profileId} AND verified_at IS NOT NULL
       `;
       walletLinked = (wallets || []).length > 0;
-      let atomicSum = 0n;
-      let decimals = 0;
+      // Convert each wallet to whole tokens with ITS OWN decimals, then sum — correct
+      // regardless of any per-row decimals inconsistency across linked wallets.
+      let wholeSum = 0n;
       for (const w of wallets || []) {
         // Reject hostile/garbled atomic strings rather than letting a wild value through.
         const raw = String(w.token_balance_atomic || "0").trim();
         if (/^[0-9]{1,40}$/.test(raw)) {
-          try { atomicSum += BigInt(raw); } catch (_) {}
+          try { wholeSum += BigInt(wholeTokensHeld(raw, Number(w.token_decimals) || 0)); } catch (_) {}
         }
-        const d = Number(w.token_decimals) || 0;
-        if (d > decimals) decimals = d;
         if (w.updated_at && (!balanceAsOf || w.updated_at > balanceAsOf)) balanceAsOf = w.updated_at;
       }
-      if (atomicSum > 0n) tinyworldHeld = wholeTokensHeld(atomicSum, decimals);
+      if (wholeSum > 0n) tinyworldHeld = wholeSum.toString();
     } catch (e) {}
 
     const base = calculateGoldAllowance({

--- a/netlify/functions/gold.mjs
+++ b/netlify/functions/gold.mjs
@@ -1,4 +1,5 @@
 import { requireAuthUser } from "./lib/auth.mjs";
+import { ensureProfile } from "./lib/profiles.mjs";
 import { getSql } from "./lib/db.mjs";
 import { corsResponse, errorResponse, jsonResponse } from "./lib/http.mjs";
 import {
@@ -6,6 +7,7 @@ import {
   DEFAULT_ECONOMY_POLICY,
   reduceGoldLedger,
   createGoldLedgerEvent,
+  wholeTokensHeld,
 } from "../../packages/tinyworld-mmo-core/src/index.js";
 
 export const config = { path: "/api/me/gold" };
@@ -15,12 +17,16 @@ export default async function meGold(request) {
   if (request.method === "OPTIONS") return corsResponse(origin);
   if (request.method !== "GET") return errorResponse("Method not allowed", 405, origin);
 
-  try {
-    const user = await requireAuthUser(request);
-    if (!user) return errorResponse("Unauthorized", 401, origin);
+  // requireAuthUser returns { response } (401) or { user }; resolve the profile via the
+  // shared ensureProfile helper, matching every other authenticated endpoint. (The old
+  // `const user = await requireAuthUser(...)` shape dereferenced a wrapper and 500'd.)
+  const auth = await requireAuthUser(request, origin);
+  if (auth.response) return auth.response;
 
+  try {
     const sql = getSql();
-    const profileId = user.profile.id;
+    const profile = await ensureProfile(auth.user);
+    const profileId = profile.id;
     const walletKey = "profile:" + profileId;
 
     let islandCount = 0;
@@ -40,8 +46,38 @@ export default async function meGold(request) {
       events = rows || [];
     } catch (e) {}
 
+    // Real $TINYWORLD holdings from the profile's verified, server-written wallet cache.
+    // token_balance_atomic is refreshed by wallet.mjs via an on-chain read against
+    // TINYWORLD_TOKEN_MINT; the client can never set it. Sum across linked wallets in
+    // BigInt (a whale balance overflows Number), then floor to whole tokens for tiering.
+    // Degrades honestly to "0" (no-tier) when no wallet is linked or the mint is unset.
+    let tinyworldHeld = "0";
+    let walletLinked = false;
+    let balanceAsOf = null;
+    try {
+      const wallets = await sql`
+        SELECT token_balance_atomic, token_decimals, updated_at
+        FROM wallet_accounts
+        WHERE profile_id = ${profileId} AND verified_at IS NOT NULL
+      `;
+      walletLinked = (wallets || []).length > 0;
+      let atomicSum = 0n;
+      let decimals = 0;
+      for (const w of wallets || []) {
+        // Reject hostile/garbled atomic strings rather than letting a wild value through.
+        const raw = String(w.token_balance_atomic || "0").trim();
+        if (/^[0-9]{1,40}$/.test(raw)) {
+          try { atomicSum += BigInt(raw); } catch (_) {}
+        }
+        const d = Number(w.token_decimals) || 0;
+        if (d > decimals) decimals = d;
+        if (w.updated_at && (!balanceAsOf || w.updated_at > balanceAsOf)) balanceAsOf = w.updated_at;
+      }
+      if (atomicSum > 0n) tinyworldHeld = wholeTokensHeld(atomicSum, decimals);
+    } catch (e) {}
+
     const base = calculateGoldAllowance({
-      tinyworldHeld: "0",
+      tinyworldHeld,
       islandCount,
       spentThisCycle: 0,
       now: new Date(),
@@ -53,9 +89,19 @@ export default async function meGold(request) {
       ...base,
       spent: summary.spent,
       available: Math.max(0, base.totalAllowance - summary.spent),
-      tinyworldHeld: "22000000", // demo 22m: wire real SPL balance from wallet
       ledgerEvents: events.slice(-5),
-      note: "LIVE mmo-core + gold_ledger_events. Full wallet balance + harvest accrual next burst.",
+      walletLinked,
+      balanceAsOf,
+      // INVARIANT (security): this allowance is a PROJECTION from the last cached wallet
+      // balance, shown for UX. It does NOT grant spendable GOLD. The authoritative,
+      // spendable allowance is the ledger sum of ALLOWANCE_RECALCULATED events written by
+      // the weekly snapshot job (E2, which does its own fresh on-chain read) minus
+      // GOLD_SPENT. The spend endpoint (E3) MUST validate against the ledger, never against
+      // this projection — so a stale cache can never be turned into durable spend power.
+      projection: true,
+      note: walletLinked
+        ? "Projected allowance from your verified wallet's $TINYWORLD balance + island bonus, net of this cycle's spend. Weekly snapshot is authoritative."
+        : "No verified wallet linked (or token mint unset) — link a wallet to earn a GOLD allowance from your $TINYWORLD holdings.",
     };
 
     return jsonResponse(final, origin);

--- a/packages/tinyworld-mmo-core/src/economy.js
+++ b/packages/tinyworld-mmo-core/src/economy.js
@@ -49,6 +49,18 @@ export function toNonNegativeBigInt(value) {
   }
 }
 
+// Convert an on-chain atomic token amount (smallest units) to whole $TINYWORLD,
+// flooring fractional tokens. GOLD tiers are expressed in whole tokens, so this is
+// the bridge between wallet_accounts.token_balance_atomic and calculateGoldAllowance.
+// Uses BigInt throughout — a 100M-token balance at 9 decimals overflows Number.
+export function wholeTokensHeld(atomicAmount, decimals = 0) {
+  const atomic = toNonNegativeBigInt(atomicAmount);
+  const dec = Math.max(0, Math.min(36, Math.floor(Number(decimals) || 0)));
+  if (dec === 0) return atomic.toString();
+  const divisor = 10n ** BigInt(dec);
+  return (atomic / divisor).toString();
+}
+
 export function currentCycleId(now = new Date(), cadence = DEFAULT_ECONOMY_POLICY.cycleCadence) {
   const date = now instanceof Date ? now : new Date(now);
   const t = Number.isFinite(date.getTime()) ? date.getTime() : Date.now();

--- a/tests/economy-gold-balance.test.mjs
+++ b/tests/economy-gold-balance.test.mjs
@@ -1,0 +1,55 @@
+// tests/economy-gold-balance.test.mjs
+// E1: converting on-chain atomic $TINYWORLD balances into whole-token holdings that
+// feed the GOLD allowance. The precision risk is real — a 100M-token balance at 9
+// decimals is 1e17 atomic units, well past Number.MAX_SAFE_INTEGER (~9e15).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  wholeTokensHeld,
+  calculateGoldAllowance,
+  DEFAULT_ECONOMY_POLICY,
+} from '../packages/tinyworld-mmo-core/src/index.js';
+
+test('floors atomic to whole tokens at the given decimals', () => {
+  // 10,000.999999999 TINYWORLD at 9 decimals -> 10000 whole
+  assert.equal(wholeTokensHeld('10000999999999', 9), '10000');
+  // exact 1,000 at 9 decimals
+  assert.equal(wholeTokensHeld('1000000000000', 9), '1000');
+});
+
+test('zero decimals returns the atomic value verbatim', () => {
+  assert.equal(wholeTokensHeld('50000', 0), '50000');
+  assert.equal(wholeTokensHeld('50000'), '50000');
+});
+
+test('no precision loss on whale balances beyond Number.MAX_SAFE_INTEGER', () => {
+  // 100,000,000 tokens at 9 decimals = 1e17 atomic (Number would lose digits)
+  const atomic = '100000000000000000';
+  assert.equal(wholeTokensHeld(atomic, 9), '100000000');
+  // a value Number cannot represent exactly still floors correctly
+  assert.equal(wholeTokensHeld('9007199254740993000000000', 9), '9007199254740993');
+});
+
+test('garbage / negative / null inputs degrade to "0"', () => {
+  assert.equal(wholeTokensHeld('', 9), '0');
+  assert.equal(wholeTokensHeld(null, 9), '0');
+  assert.equal(wholeTokensHeld('-5000000000', 9), '0');
+  assert.equal(wholeTokensHeld('not-a-number', 9), '0');
+});
+
+test('a sub-1-token balance floors to "0" (no free tier from dust)', () => {
+  assert.equal(wholeTokensHeld('999999999', 9), '0'); // 0.999999999 token
+});
+
+test('the converted holdings drive the real GOLD tier (end-to-end)', () => {
+  // 10,000 TINYWORLD at 9 decimals should land on the Silver tier (500 GOLD), NOT
+  // the old hardcoded display value. Proves the value actually feeds the calc.
+  const held = wholeTokensHeld('10000000000000', 9);
+  const out = calculateGoldAllowance(
+    { tinyworldHeld: held, islandCount: 0, spentThisCycle: 0, now: new Date('2026-06-24T00:00:00Z') },
+    DEFAULT_ECONOMY_POLICY,
+  );
+  assert.equal(out.tinyworldHeld, '10000');
+  assert.equal(out.tier, 'silver');
+  assert.equal(out.totalAllowance, 500);
+});


### PR DESCRIPTION
**Do not merge yet.** Per owner: the tinyverse / proper economy does not launch until it is preview-ready. This PR is reviewed and green, staged on a branch until then.

## What
Priority-1 economy slice E1 (see `plans/production-line/ROADMAP.md`).

- **Live holdings → GOLD.** `gold.mjs` now derives the weekly GOLD allowance from the player's real $TINYWORLD balance (`wallet_accounts.token_balance_atomic`, the server-written cache refreshed on-chain against `TINYWORLD_TOKEN_MINT`), summed across verified wallets in BigInt and floored to whole tokens. Removes the hardcoded `"22000000"` demo value — and the latent bug where the displayed holdings (22m) didn't even match the allowance, which was computed from `"0"`.
- **New tested helper** `wholeTokensHeld(atomic, decimals)` in `mmo-core` (BigInt; whale balances overflow Number). 6 unit tests: flooring, zero-decimals, precision beyond `MAX_SAFE_INTEGER`, hostile/negative/null input, sub-1-token dust, and an end-to-end tier check.
- **Latent CRITICAL fixed.** `gold.mjs` used the wrong `requireAuthUser` return shape and dereferenced `user.profile.id` → `/api/me/gold` **500'd for every caller**. Now uses the canonical `auth.response` / `ensureProfile(auth.user)` pattern (matches `builds.mjs`, `assets.mjs`).
- **Hardening:** regex-guard atomic strings, expose `balanceAsOf`, per-wallet decimals correctness, and document the security invariant that this allowance is a **projection** — spendable GOLD comes only from the ledger (E2's weekly fresh-read snapshot minus spends), so a stale cache can never become durable spend power.

## Adversarial review trail (the point of this exercise)
1. **Codex GPT security pass #1 → BLOCK.** Found: CRITICAL auth-shape 500; HIGH stale-cache inflation; HIGH mint-mismatch; MEDIUM silent-503; MEDIUM decimals clamp; LOW unbounded parse.
2. Verified the CRITICAL against source (real, pre-existing). Fixed it + the HIGH (projection invariant + `balanceAsOf`) + the LOW (regex guard). MEDIUMs documented as follow-ups (economy not launching).
3. **Codex GPT pass #2 → RESOLVED**, one non-blocking note (mixed decimals).
4. Addressed the note (per-wallet whole-token conversion). 

## Tests
`npm run check` ✓ · `node --test tests/*.test.mjs` → 199 pass ✓

## Follow-ups (tracked, not launching)
- E2 weekly snapshot must do its own fresh on-chain read (authoritative credit path).
- Classify DB-unavailable as 503 vs `walletLinked=false`.
- DB `CHECK (token_balance_atomic ~ '^[0-9]{1,40}$')`.
- Set `TINYWORLD_TOKEN_MINT` for live balances.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK