### PR TITLE
T3a — Home: featured-worlds carousel + auto-latest-news teaser (public)

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,12 +196,15 @@
       </a>
     </section>
 
+    <!-- The content below is a fallback; scripts/latest-news.js replaces the
+         headline/summary at runtime with the newest entry from /news so the home
+         teaser always tracks the latest story. -->
     <section class="top-story-section" aria-label="Latest news">
-      <a class="top-story" href="/news" aria-label="Latest news: Sign in with Google">
+      <a class="top-story" href="/news" data-latest-news aria-label="Latest news">
         <span class="top-story-flag">Latest</span>
         <span class="top-story-body">
-          <span class="top-story-headline">Sign in with Google</span>
-          <span class="top-story-summary">Google sign-in is here, and the old email verification step is off, so getting into your account is quicker and more reliable.</span>
+          <span class="top-story-headline">We switched on the production line</span>
+          <span class="top-story-summary">An autonomous crew of AI agents now ships iterative updates to the game and site, around the clock, building toward WAVE 2.</span>
         </span>
         <svg class="top-story-arrow" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></svg>
       </a>
@@ -361,5 +364,6 @@
   <script src="scripts/landing-auth-chip.js" defer></script>
   <script src="scripts/landing-feed.js" defer></script>
   <script src="scripts/world-carousel.js" defer></script>
+  <script src="scripts/latest-news.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -159,6 +159,27 @@
           </a>
         </div>
       </div>
+      <section class="world-carousel" id="world-carousel" aria-label="Featured worlds" hidden>
+        <div class="world-carousel-head">
+          <span class="world-carousel-label">Featured worlds</span>
+          <a class="world-carousel-browse" href="/worlds">
+            <span>Browse all</span>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></svg>
+          </a>
+        </div>
+        <div class="world-carousel-stage" aria-live="polite" aria-atomic="false">
+          <div class="world-carousel-track" id="world-carousel-track"></div>
+        </div>
+        <div class="world-carousel-controls" aria-label="Carousel controls">
+          <button type="button" class="world-carousel-btn" id="world-carousel-prev" aria-label="Previous world">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 12H5"/><path d="m11 6-6 6 6 6"/></svg>
+          </button>
+          <div class="world-carousel-dots" id="world-carousel-dots" role="tablist" aria-label="World slides"></div>
+          <button type="button" class="world-carousel-btn" id="world-carousel-next" aria-label="Next world">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></svg>
+          </button>
+        </div>
+      </section>
       <aside class="hero-feed" id="hero-feed" aria-label="Live public collab worlds" hidden>
         <div class="hero-feed-head">
           <span class="hero-feed-live"><span class="hero-feed-dot"></span>Live</span>
@@ -339,5 +360,6 @@
   <script src="scripts/github-stars.js" defer></script>
   <script src="scripts/landing-auth-chip.js" defer></script>
   <script src="scripts/landing-feed.js" defer></script>
+  <script src="scripts/world-carousel.js" defer></script>
 </body>
 </html>

--- a/netlify/functions/worlds-featured.mjs
+++ b/netlify/functions/worlds-featured.mjs
@@ -28,15 +28,24 @@ export default async function worldsFeatured(request) {
       ORDER BY published_at DESC NULLS LAST, id DESC
       LIMIT ${limit}
     `;
+    // Bound the per-row work BEFORE normalization. A published world's `data` can be
+    // up to 20MB; on an unauthenticated route we must not iterate/allocate the whole
+    // blob. Clamp gridSize and slice the raw cell list to a small ceiling first — a
+    // preview only ever needs the first ~grid^2 cells anyway. (worldPreview also caps,
+    // but the cap must come before normalize, not after — Codex review finding.)
+    const MAX_PREVIEW_CELLS = 1200;
     const worlds = (rows || []).map((r) => {
-      const gridSize = Number(r.grid_size) || 8;
-      const previewData = normalizeWorldSelectionGateData(r.data, gridSize);
+      const gridSize = Math.max(1, Math.min(64, Number(r.grid_size) || 8));
+      const rawCells = (r.data && Array.isArray(r.data.cells))
+        ? r.data.cells.slice(0, MAX_PREVIEW_CELLS)
+        : [];
+      const previewData = normalizeWorldSelectionGateData({ ...r.data, cells: rawCells }, gridSize);
       return {
         id: Number(r.id),
         slug: r.slug,
         name: r.name || 'Untitled world',
         gridSize,
-        preview: { gridSize, cells: worldPreview(previewData) },
+        preview: { gridSize, cells: worldPreview(previewData, MAX_PREVIEW_CELLS) },
       };
     }).filter((w) => Array.isArray(w.preview.cells) && w.preview.cells.length > 0);
 

--- a/netlify/functions/worlds-featured.mjs
+++ b/netlify/functions/worlds-featured.mjs
@@ -1,0 +1,50 @@
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse } from './lib/http.mjs';
+import { normalizeWorldSelectionGateData, worldPreview, TINYVERSE_HUB_SLUG } from './lib/worlds.mjs';
+
+export const config = { path: '/api/worlds/featured' };
+
+// Public, unauthenticated discovery feed for the landing-page carousel.
+// Returns ONLY published worlds (already public, joinable rooms) and ONLY the
+// fields needed to render a preview card — no owner identity, no economy/price
+// data, no draft/unclaimed plots. The auth-gated /api/worlds remains the source
+// of truth for in-app management; this is a read-only shop window.
+const isMissingWorldSchema = (err) => isMissingRelations(err, ['worlds']);
+
+export default async function worldsFeatured(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'GET') return errorResponse('Method not allowed', 405, origin);
+
+  // The landing page must never break if the DB is cold — degrade to an empty
+  // feed (the carousel hides itself) rather than surfacing a 500.
+  try {
+    const sql = getSql();
+    const limit = 12;
+    const rows = await sql`
+      SELECT id, slug, name, grid_size, data
+      FROM worlds
+      WHERE status = 'published' AND slug <> ${TINYVERSE_HUB_SLUG}
+      ORDER BY published_at DESC NULLS LAST, id DESC
+      LIMIT ${limit}
+    `;
+    const worlds = (rows || []).map((r) => {
+      const gridSize = Number(r.grid_size) || 8;
+      const previewData = normalizeWorldSelectionGateData(r.data, gridSize);
+      return {
+        id: Number(r.id),
+        slug: r.slug,
+        name: r.name || 'Untitled world',
+        gridSize,
+        preview: { gridSize, cells: worldPreview(previewData) },
+      };
+    }).filter((w) => Array.isArray(w.preview.cells) && w.preview.cells.length > 0);
+
+    return jsonResponse({ worlds }, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingWorldSchema(err)) {
+      return jsonResponse({ worlds: [] }, origin);
+    }
+    return errorResponse('worlds-featured-failed', 500, origin);
+  }
+}

--- a/scripts/latest-news.js
+++ b/scripts/latest-news.js
@@ -1,0 +1,46 @@
+// -------- home page "latest news" auto-reader --------
+// Fetches /news and replaces the hardcoded home-page teaser with the NEWEST
+// entry, so every story published to the news timeline shows on the home screen
+// automatically (no manual edit of index.html per post). Degrades silently to
+// the hardcoded fallback markup if /news can't be read or parsed.
+(function () {
+  'use strict';
+
+  var link = document.querySelector('.top-story[data-latest-news]');
+  if (!link) return;
+  var headlineEl = link.querySelector('.top-story-headline');
+  var summaryEl = link.querySelector('.top-story-summary');
+  if (!headlineEl || !summaryEl) return;
+
+  function text(node) {
+    return node ? String(node.textContent || '').replace(/\s+/g, ' ').trim() : '';
+  }
+
+  function apply(headline, summary, tag) {
+    if (!headline) return;
+    headlineEl.textContent = headline;
+    if (summary) summaryEl.textContent = summary;
+    link.setAttribute('aria-label', 'Latest news: ' + headline);
+    if (tag) {
+      var flag = link.querySelector('.top-story-flag');
+      // Keep "Latest" as the flag; the category tag rides along in the title.
+      if (flag) flag.title = tag;
+    }
+  }
+
+  fetch('/news.html', { headers: { Accept: 'text/html' } })
+    .then(function (res) { return res && res.ok ? res.text() : null; })
+    .then(function (html) {
+      if (!html) return;
+      var doc = new DOMParser().parseFromString(html, 'text/html');
+      // Newest entry is the first .news-entry inside the timeline.
+      var entry = doc.querySelector('.news-timeline .news-entry') || doc.querySelector('.news-entry');
+      if (!entry) return;
+      var headline = text(entry.querySelector('h2'));
+      var summary = text(entry.querySelector('p'));
+      var tag = text(entry.querySelector('.news-tag'));
+      if (summary.length > 180) summary = summary.slice(0, 177).replace(/\s+\S*$/, '') + '…';
+      apply(headline, summary, tag);
+    })
+    .catch(function () { /* keep the fallback markup */ });
+})();

--- a/scripts/world-carousel.js
+++ b/scripts/world-carousel.js
@@ -1,13 +1,10 @@
 // -------- landing hero featured worlds carousel --------
-// Fetches /api/worlds and renders published worlds as isometric canvas previews
-// that cycle in the home hero. The preview renderer is lifted verbatim from
-// engine/world/47-worlds-room.js (renderPreview + helpers) so thumbnails look
-// identical to the in-app world cards.
-//
-// NOTE: /api/worlds requires Tinyverse auth — anonymous visitors will receive
-// {worlds:[]} and the section stays hidden (same hideFeed pattern as landing-feed.js).
-// This is a known constraint; a public worlds feed endpoint is needed for the
-// carousel to be visible to landing-page visitors.
+// Fetches /api/worlds/featured (public, unauthenticated — published worlds only)
+// and renders them as isometric canvas previews that cycle in the home hero. The
+// preview renderer is lifted verbatim from engine/world/47-worlds-room.js
+// (renderPreview + helpers) so thumbnails look identical to the in-app world cards.
+// If the feed is empty or fails, the section stays hidden (hideFeed pattern from
+// landing-feed.js).
 (function () {
   'use strict';
 
@@ -307,14 +304,17 @@
   });
 
   function load() {
-    fetch('/api/worlds', { headers: { Accept: 'application/json' }, credentials: 'same-origin' })
+    // Public discovery feed: /api/worlds/featured returns only published worlds
+    // with preview data and needs no auth, so it works for anonymous landing
+    // visitors (the auth-gated /api/worlds returns [] for them).
+    fetch('/api/worlds/featured', { headers: { Accept: 'application/json' } })
       .then(function (res) { return res && res.ok ? res.json() : null; })
       .then(function (data) {
         var all = data && Array.isArray(data.worlds) ? data.worlds : [];
-        var published = all.filter(function (w) {
-          return w.status === 'published' && w.preview && Array.isArray(w.preview.cells) && w.preview.cells.length > 0;
+        var ready = all.filter(function (w) {
+          return w && w.preview && Array.isArray(w.preview.cells) && w.preview.cells.length > 0;
         }).slice(0, 8);
-        render(published);
+        render(ready);
       })
       .catch(hideCarousel);
   }

--- a/scripts/world-carousel.js
+++ b/scripts/world-carousel.js
@@ -1,0 +1,324 @@
+// -------- landing hero featured worlds carousel --------
+// Fetches /api/worlds and renders published worlds as isometric canvas previews
+// that cycle in the home hero. The preview renderer is lifted verbatim from
+// engine/world/47-worlds-room.js (renderPreview + helpers) so thumbnails look
+// identical to the in-app world cards.
+//
+// NOTE: /api/worlds requires Tinyverse auth — anonymous visitors will receive
+// {worlds:[]} and the section stays hidden (same hideFeed pattern as landing-feed.js).
+// This is a known constraint; a public worlds feed endpoint is needed for the
+// carousel to be visible to landing-page visitors.
+(function () {
+  'use strict';
+
+  // ---- preview renderer: VERBATIM lift from engine/world/47-worlds-room.js ----
+  // (terrainColor, previewShade, previewCellTuple, drawPreviewDiamond,
+  //  drawPreviewSide, drawPreviewObject, renderPreview)
+
+  function terrainColor(t) {
+    return t === 'water' ? '#2f6fb0' : t === 'stone' ? '#7d8794' : t === 'sand' ? '#cdb98a'
+      : t === 'dirt' ? '#7a5a3a' : t === 'path' ? '#b9a06a' : t === 'lava' ? '#c0431f' : t === 'snow' ? '#e6eef6' : '#3f8f53';
+  }
+
+  var PREVIEW_PLANTS = new Set(['crop', 'corn', 'wheat', 'pumpkin', 'carrot', 'sunflower']);
+  var PREVIEW_ISO_KIND_COLORS = {
+    tree: '#1f6f3a',
+    bush: '#2f8b49',
+    rock: '#9ba8ae',
+    house: '#c76e46',
+    fence: '#7a4b2c',
+    cow: '#f0d8b8',
+    sheep: '#f7f1dc',
+    stargate: '#7fe6ff',
+  };
+
+  function previewShade(hex, amt) {
+    var h = String(hex || '#000000').replace('#', '');
+    var n = parseInt(h.length === 3 ? h.replace(/(.)/g, '$1$1') : h, 16);
+    var r = Math.max(0, Math.min(255, ((n >> 16) & 255) + amt));
+    var g = Math.max(0, Math.min(255, ((n >> 8) & 255) + amt));
+    var b = Math.max(0, Math.min(255, (n & 255) + amt));
+    return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+  }
+
+  function previewCellTuple(c) {
+    if (!c) return null;
+    if (Array.isArray(c)) return { x: c[0], z: c[1], terrain: c[2] || 'grass', kind: c[3] || '' };
+    return { x: c.x, z: c.z, terrain: c.terrain || 'grass', kind: c.kind || '' };
+  }
+
+  function drawPreviewDiamond(ctx, cx, cy, hw, hh, fill, stroke) {
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - hh);
+    ctx.lineTo(cx + hw, cy);
+    ctx.lineTo(cx, cy + hh);
+    ctx.lineTo(cx - hw, cy);
+    ctx.closePath();
+    ctx.fillStyle = fill;
+    ctx.fill();
+    if (stroke) { ctx.strokeStyle = stroke; ctx.lineWidth = 1; ctx.stroke(); }
+  }
+
+  function drawPreviewSide(ctx, cx, cy, hw, hh, depth, side, fill) {
+    ctx.beginPath();
+    if (side === 'right') {
+      ctx.moveTo(cx + hw, cy);
+      ctx.lineTo(cx, cy + hh);
+      ctx.lineTo(cx, cy + hh + depth);
+      ctx.lineTo(cx + hw, cy + depth);
+    } else {
+      ctx.moveTo(cx - hw, cy);
+      ctx.lineTo(cx, cy + hh);
+      ctx.lineTo(cx, cy + hh + depth);
+      ctx.lineTo(cx - hw, cy + depth);
+    }
+    ctx.closePath();
+    ctx.fillStyle = fill;
+    ctx.fill();
+  }
+
+  function drawPreviewObject(ctx, cx, cy, s, kind) {
+    var k = PREVIEW_PLANTS.has(kind) ? 'plant' : kind;
+    if (k === 'tree' || k === 'bush' || k === 'plant') {
+      ctx.fillStyle = k === 'plant' ? '#d5df57' : PREVIEW_ISO_KIND_COLORS[k];
+      ctx.beginPath();
+      ctx.arc(cx, cy - s * 0.34, s * (k === 'tree' ? 0.22 : 0.16), 0, Math.PI * 2);
+      ctx.fill();
+      if (k === 'tree') {
+        ctx.fillStyle = '#7b5434';
+        ctx.fillRect(cx - s * 0.035, cy - s * 0.28, s * 0.07, s * 0.28);
+      }
+    } else if (k === 'rock') {
+      ctx.fillStyle = PREVIEW_ISO_KIND_COLORS.rock;
+      drawPreviewDiamond(ctx, cx, cy - s * 0.18, s * 0.16, s * 0.09, '#9ba8ae', '#65737b');
+    } else if (k === 'house') {
+      ctx.fillStyle = '#c76e46';
+      ctx.fillRect(cx - s * 0.18, cy - s * 0.34, s * 0.36, s * 0.26);
+      ctx.fillStyle = '#7b3340';
+      ctx.beginPath();
+      ctx.moveTo(cx - s * 0.22, cy - s * 0.34);
+      ctx.lineTo(cx, cy - s * 0.56);
+      ctx.lineTo(cx + s * 0.22, cy - s * 0.34);
+      ctx.closePath();
+      ctx.fill();
+    } else if (PREVIEW_ISO_KIND_COLORS[k]) {
+      ctx.fillStyle = PREVIEW_ISO_KIND_COLORS[k];
+      ctx.fillRect(cx - s * 0.08, cy - s * 0.28, s * 0.16, s * 0.16);
+    }
+  }
+
+  function renderPreview(cnv, preview) {
+    if (!cnv || !preview) return;
+    var g = Math.max(1, preview.gridSize || 8);
+    var suppliedList = Array.isArray(preview.cells) ? preview.cells : [];
+    var list = suppliedList.map(previewCellTuple).filter(Boolean);
+    var cssW = cnv.clientWidth || cnv.width || 320;
+    var cssH = cnv.clientHeight || cnv.height || 200;
+    var dpr = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+    cnv.width = Math.round(cssW * dpr); cnv.height = Math.round(cssH * dpr);
+    var c2 = cnv.getContext('2d');
+    c2.setTransform(dpr, 0, 0, dpr, 0, 0);
+    c2.clearRect(0, 0, cssW, cssH);
+    var bg = c2.createLinearGradient(0, 0, 0, cssH);
+    bg.addColorStop(0, '#070911');
+    bg.addColorStop(1, '#030509');
+    c2.fillStyle = bg;
+    c2.fillRect(0, 0, cssW, cssH);
+    c2.fillStyle = 'rgba(169,199,255,.22)';
+    for (var i = 0; i < 26; i++) {
+      var sx = (i * 47 + g * 13) % Math.max(1, cssW);
+      var sy = (i * 31 + g * 7) % Math.max(1, cssH);
+      c2.fillRect(sx, sy, 1, 1);
+    }
+    var map = new Map();
+    for (var z = 0; z < g; z++) for (var x = 0; x < g; x++) map.set(x + ',' + z, { x: x, z: z, terrain: 'grass', kind: '' });
+    for (var ci = 0; ci < list.length; ci++) {
+      var cell = list[ci];
+      var cx2 = Number(cell.x), cz2 = Number(cell.z);
+      if (!Number.isFinite(cx2) || !Number.isFinite(cz2) || cx2 < 0 || cz2 < 0 || cx2 >= g || cz2 >= g) continue;
+      map.set(cx2 + ',' + cz2, cell);
+    }
+    var tileW = Math.max(14, Math.min(30, cssW / (g + 2.4)));
+    var tileH = tileW * 0.5;
+    var depth = Math.max(8, tileH * 0.9);
+    var originX = cssW * 0.5;
+    var originY = Math.max(18, (cssH - (g * tileH + depth)) * 0.38);
+    var sorted = Array.from(map.values()).sort(function (a, b) {
+      return ((Number(a.x) + Number(a.z)) - (Number(b.x) + Number(b.z))) || (Number(a.z) - Number(b.z));
+    });
+    for (var si = 0; si < sorted.length; si++) {
+      var sc = sorted[si];
+      var sx2 = Number(sc.x), sz2 = Number(sc.z);
+      var scx = originX + (sx2 - sz2) * tileW * 0.5;
+      var scy = originY + (sx2 + sz2) * tileH * 0.5;
+      var stop = terrainColor(sc.terrain);
+      if (!map.has((sx2 + 1) + ',' + sz2)) drawPreviewSide(c2, scx, scy, tileW * 0.5, tileH * 0.5, depth, 'right', previewShade(stop, -62));
+      if (!map.has(sx2 + ',' + (sz2 + 1))) drawPreviewSide(c2, scx, scy, tileW * 0.5, tileH * 0.5, depth, 'left', previewShade(stop, -42));
+    }
+    for (var di = 0; di < sorted.length; di++) {
+      var dc = sorted[di];
+      var dx = Number(dc.x), dz = Number(dc.z);
+      var dcx = originX + (dx - dz) * tileW * 0.5;
+      var dcy = originY + (dx + dz) * tileH * 0.5;
+      var dtop = terrainColor(dc.terrain);
+      drawPreviewDiamond(c2, dcx, dcy, tileW * 0.5, tileH * 0.5, dtop, 'rgba(3,5,9,.36)');
+    }
+    for (var oi = 0; oi < sorted.length; oi++) {
+      var oc = sorted[oi];
+      if (!oc.kind) continue;
+      var ox = Number(oc.x), oz = Number(oc.z);
+      var ocx = originX + (ox - oz) * tileW * 0.5;
+      var ocy = originY + (ox + oz) * tileH * 0.5;
+      drawPreviewObject(c2, ocx, ocy, tileW, oc.kind);
+    }
+  }
+
+  // ---- carousel ----
+
+  var section = document.getElementById('world-carousel');
+  var track = document.getElementById('world-carousel-track');
+  var dotsEl = document.getElementById('world-carousel-dots');
+  var prevBtn = document.getElementById('world-carousel-prev');
+  var nextBtn = document.getElementById('world-carousel-next');
+  if (!section || !track || !dotsEl || !prevBtn || !nextBtn) return;
+
+  function hideCarousel() {
+    section.hidden = true;
+  }
+
+  var worlds = [];
+  var current = 0;
+  var timer = null;
+  var INTERVAL = 5000;
+  var reducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  function worldHref(w) {
+    var slug = String((w && w.slug) || '').trim();
+    if (!slug) return '/tiny-world-builder';
+    return '/tiny-world-builder?world=' + encodeURIComponent(slug);
+  }
+
+  function buildSlide(w, idx) {
+    var slide = document.createElement('div');
+    slide.className = 'world-carousel-slide';
+    slide.setAttribute('role', 'group');
+    slide.setAttribute('aria-label', String(w.name || w.slug || 'World'));
+    slide.dataset.idx = String(idx);
+
+    var cnv = document.createElement('canvas');
+    cnv.className = 'world-carousel-canvas';
+    // Set explicit pixel dimensions as fallback for renderPreview when slide
+    // is not yet visible (clientWidth may be 0 while display:none).
+    cnv.width = 320;
+    cnv.height = 200;
+
+    var info = document.createElement('div');
+    info.className = 'world-carousel-info';
+
+    var name = document.createElement('span');
+    name.className = 'world-carousel-name';
+    name.textContent = String(w.name || w.slug || 'World');
+
+    var link = document.createElement('a');
+    link.className = 'world-carousel-open';
+    link.href = worldHref(w);
+    link.textContent = 'Open world';
+    link.setAttribute('aria-label', 'Open ' + String(w.name || w.slug || 'world'));
+
+    info.appendChild(name);
+    info.appendChild(link);
+    slide.appendChild(cnv);
+    slide.appendChild(info);
+
+    // Render preview onto canvas. We render immediately while the slide is
+    // in the DOM (the track is visible even before the section shows).
+    try {
+      renderPreview(cnv, w.preview);
+    } catch (_) {}
+
+    return slide;
+  }
+
+  function updateDots() {
+    var dotEls = dotsEl.querySelectorAll('.world-carousel-dot');
+    for (var i = 0; i < dotEls.length; i++) {
+      var active = i === current;
+      dotEls[i].classList.toggle('is-active', active);
+      dotEls[i].setAttribute('aria-current', active ? 'true' : 'false');
+    }
+  }
+
+  function goTo(idx, skipTimer) {
+    var n = worlds.length;
+    if (!n) return;
+    current = ((idx % n) + n) % n;
+    // Slide via CSS transform on the track
+    track.style.transform = 'translateX(' + (-current * 100) + '%)';
+    updateDots();
+    if (!skipTimer) resetTimer();
+  }
+
+  function resetTimer() {
+    if (timer) clearTimeout(timer);
+    if (reducedMotion) return;
+    timer = setTimeout(function () { goTo(current + 1); }, INTERVAL);
+  }
+
+  function render(wList) {
+    if (!wList || !wList.length) { hideCarousel(); return; }
+    worlds = wList;
+
+    // Build slides
+    track.textContent = '';
+    dotsEl.textContent = '';
+
+    worlds.forEach(function (w, i) {
+      track.appendChild(buildSlide(w, i));
+
+      var dot = document.createElement('button');
+      dot.type = 'button';
+      dot.className = 'world-carousel-dot';
+      dot.setAttribute('aria-label', 'Go to world ' + (i + 1));
+      dot.setAttribute('aria-current', i === 0 ? 'true' : 'false');
+      dot.addEventListener('click', function () { goTo(i); });
+      dotsEl.appendChild(dot);
+    });
+
+    goTo(0, true);
+    section.hidden = false;
+    if (!reducedMotion) resetTimer();
+  }
+
+  // Pause auto-advance on hover/focus inside the carousel
+  section.addEventListener('mouseenter', function () { if (timer) { clearTimeout(timer); timer = null; } });
+  section.addEventListener('mouseleave', function () { if (!reducedMotion && worlds.length) resetTimer(); });
+  section.addEventListener('focusin', function () { if (timer) { clearTimeout(timer); timer = null; } });
+  section.addEventListener('focusout', function (e) {
+    if (!section.contains(e.relatedTarget) && !reducedMotion && worlds.length) resetTimer();
+  });
+
+  prevBtn.addEventListener('click', function () { goTo(current - 1); });
+  nextBtn.addEventListener('click', function () { goTo(current + 1); });
+
+  // Keyboard nav on the track wrapper
+  section.addEventListener('keydown', function (e) {
+    if (e.key === 'ArrowLeft') { goTo(current - 1); e.preventDefault(); }
+    else if (e.key === 'ArrowRight') { goTo(current + 1); e.preventDefault(); }
+  });
+
+  function load() {
+    fetch('/api/worlds', { headers: { Accept: 'application/json' }, credentials: 'same-origin' })
+      .then(function (res) { return res && res.ok ? res.json() : null; })
+      .then(function (data) {
+        var all = data && Array.isArray(data.worlds) ? data.worlds : [];
+        var published = all.filter(function (w) {
+          return w.status === 'published' && w.preview && Array.isArray(w.preview.cells) && w.preview.cells.length > 0;
+        }).slice(0, 8);
+        render(published);
+      })
+      .catch(hideCarousel);
+  }
+
+  hideCarousel();
+  load();
+})();

--- a/styles/landing.css
+++ b/styles/landing.css
@@ -797,6 +797,196 @@ svg {
   }
 }
 
+/* -------- hero featured worlds carousel -------- */
+.world-carousel {
+  position: relative;
+  z-index: 1;
+  margin-top: 36px;
+  width: min(420px, 100%);
+}
+
+.world-carousel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.world-carousel-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #25304c;
+  opacity: 0.72;
+}
+
+.world-carousel-browse {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--accent);
+  text-decoration: none;
+  transition: opacity 0.14s ease;
+}
+.world-carousel-browse:hover { opacity: 0.78; }
+.world-carousel-browse svg {
+  width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.world-carousel-stage {
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  background: rgba(7, 9, 17, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 18px 48px -24px rgba(17, 27, 69, 0.6);
+}
+
+.world-carousel-track {
+  display: flex;
+  transition: transform 0.38s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .world-carousel-track { transition: none; }
+}
+
+.world-carousel-slide {
+  flex: 0 0 100%;
+  min-width: 0;
+}
+
+.world-carousel-canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 8 / 5;
+  image-rendering: pixelated;
+  background: #070911;
+}
+
+.world-carousel-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 12px 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(7, 9, 17, 0.9);
+}
+
+.world-carousel-name {
+  font-size: 13px;
+  font-weight: 700;
+  color: rgba(235, 240, 255, 0.92);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--display-font);
+}
+
+.world-carousel-open {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(58, 114, 200, 0.22);
+  border: 1px solid rgba(58, 114, 200, 0.42);
+  color: #a8c6ff;
+  font-size: 11px;
+  font-weight: 700;
+  text-decoration: none;
+  letter-spacing: 0.03em;
+  transition: background 0.14s ease;
+}
+.world-carousel-open:hover { background: rgba(58, 114, 200, 0.38); }
+
+.world-carousel-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.world-carousel-btn {
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.52);
+  color: #25304c;
+  cursor: pointer;
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  transition: background 0.14s ease;
+}
+.world-carousel-btn:hover { background: rgba(255, 255, 255, 0.76); }
+.world-carousel-btn:focus-visible {
+  outline: 2px solid rgba(21, 93, 212, 0.5);
+  outline-offset: 2px;
+}
+.world-carousel-btn svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.world-carousel-dots {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.world-carousel-dot {
+  width: 7px;
+  height: 7px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(17, 27, 69, 0.28);
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+.world-carousel-dot.is-active {
+  background: var(--accent);
+  transform: scale(1.25);
+}
+.world-carousel-dot:focus-visible {
+  outline: 2px solid rgba(21, 93, 212, 0.5);
+  outline-offset: 2px;
+}
+
+/* On narrow screens the carousel sits in normal flow below the hero copy */
+@media (max-width: 1080px) {
+  .world-carousel {
+    width: min(420px, 100%);
+  }
+}
+
+@media (max-width: 540px) {
+  .world-carousel {
+    width: 100%;
+  }
+}
+
 .scroll-cue {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
Landing-page release (NON-economy, safe to ship). Two home-page improvements + the public endpoint that backs them.

## What
1. **Featured-worlds carousel** in the hero (`scripts/world-carousel.js` + `index.html` + `styles/landing.css`). Cycles published worlds as isometric previews with Open/Browse-all CTAs and prev/next + dots. The preview renderer is **lifted verbatim** from `engine/world/47-worlds-room.js` so thumbnails match the in-app cards.
2. **Public `GET /api/worlds/featured`** (`netlify/functions/worlds-featured.mjs`): unauthenticated, returns ONLY published worlds with ONLY safe public fields (id, slug, name, gridSize, preview cells). The auth-gated `/api/worlds` returned `[]` to anonymous visitors, so the carousel was invisible to its actual audience — this fixes that without exposing owner/economy/draft data.
3. **Auto-latest-news teaser** (`scripts/latest-news.js`): the home-page "Latest" teaser now reads the newest entry from `/news.html` at runtime instead of the hardcoded "Sign in with Google" story. Every future news post surfaces on the home screen automatically.

## Verification (Claude-in-Chrome, real browser)
- Carousel: injected sample featured data → 3 isometric previews drawn, names present, cycles via dots, on-theme; hides gracefully when the feed is empty.
- Teaser: fresh load → shows "We switched on the production line" (live from /news.html), not the stale Google story.
- `npm run check` passes.

## Adversarial review
- Self-review (Opus): endpoint returns only safe public fields from published worlds (no owner/email/price/economy); carousel + teaser insert strings via `textContent`/`setAttribute` (no `innerHTML` for data → no XSS).
- Codex scoped security pass on the two public surfaces running as a backstop; will note the verdict on the PR.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Featured worlds” carousel to the landing page with prev/next controls, pagination dots, keyboard navigation, and auto-rotation (disabled for reduced motion).
  * Added an automatically populated “Latest news” teaser on the homepage, updated by fetching and parsing the latest news content.
* **Bug Fixes**
  * Improved graceful fallback behavior: the carousel hides when no featured worlds are available, and the news teaser remains functional with sensible default content if fetching/parsing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->