### PR TITLE
[HOLD: economy preview] E2 — weekly holdings-based GOLD payout (admin dry-run)

### DIFF
--- a/netlify/database/migrations/20260624120000_gold_allowance_unique.sql
+++ b/netlify/database/migrations/20260624120000_gold_allowance_unique.sql
@@ -1,0 +1,10 @@
+-- E2 weekly GOLD payout idempotency.
+-- The weekly payout job writes exactly ONE authoritative ALLOWANCE_RECALCULATED row
+-- per (wallet, cycle_id). gold_ledger_events had only non-unique indexes, so an
+-- INSERT ... ON CONFLICT could not dedupe. This partial unique index makes the
+-- payout idempotent: re-running the job within a cycle is a no-op, and each new
+-- weekly cycle_id gets a fresh row. GOLD_SPENT / GOLD_REFUNDED stay append-only
+-- (the partial predicate only covers the allowance type).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_gold_allowance_wallet_cycle
+  ON gold_ledger_events (wallet, cycle_id)
+  WHERE type = 'ALLOWANCE_RECALCULATED';

--- a/netlify/functions/gold-payout.mjs
+++ b/netlify/functions/gold-payout.mjs
@@ -1,0 +1,147 @@
+import { timingSafeEqual } from 'node:crypto';
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse } from './lib/http.mjs';
+import { computeWeeklyPayoutPlan } from '../../packages/tinyworld-mmo-core/src/index.js';
+
+export const config = { path: '/api/admin/gold-payout' };
+
+// E2 — weekly holdings-based GOLD payout.
+// Snapshots each linked wallet's $TINYWORLD holdings + island count, computes the
+// weekly GOLD allowance, and writes ONE authoritative ALLOWANCE_RECALCULATED ledger
+// event per (wallet, cycle_id). The partial unique index uq_gold_allowance_wallet_cycle
+// makes the write idempotent (re-runs within a cycle are no-ops).
+//
+// ADMIN-ONLY + ECONOMY-GATE-FRIENDLY:
+//   GET  -> DRY RUN: compute and return the plan, write NOTHING. Lets the owner
+//           preview exactly what the weekly payout would credit before launch.
+//   POST -> EXECUTE: idempotently upsert the allowance events.
+// Both require the x-admin-secret header (timing-safe). At launch, wire a weekly
+// trigger (Netlify scheduled function or external cron) to POST this endpoint.
+
+const HOLDER_CAP = 5000;
+
+function adminSecret() {
+  return process.env.TINYWORLD_ADMIN_SECRET || '';
+}
+
+function isAdmin(request) {
+  const secret = adminSecret();
+  if (!secret) return false; // never run unguarded
+  const provided = request.headers.get('x-admin-secret') || '';
+  const a = Buffer.from(provided);
+  const b = Buffer.from(secret);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+// Atomic token units -> whole tokens (floored), BigInt throughout. Independent of
+// any other module so this function does not collide with the E1 gold branch.
+function wholeFromAtomic(atomicStr, decimals) {
+  let a = 0n;
+  const raw = String(atomicStr == null ? '0' : atomicStr).trim();
+  if (/^[0-9]+$/.test(raw)) {
+    try { a = BigInt(raw); } catch (_) { a = 0n; }
+  }
+  const d = Math.max(0, Math.min(36, Number(decimals) || 0));
+  if (d === 0) return a.toString();
+  return (a / (10n ** BigInt(d))).toString();
+}
+
+const isMissingSchema = (err) => isMissingRelations(err, ['profiles', 'wallet_accounts', 'gold_ledger_events', 'worlds']);
+
+export default async function goldPayout(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'GET' && request.method !== 'POST') {
+    return errorResponse('Method not allowed', 405, origin);
+  }
+  if (!isAdmin(request)) return errorResponse('Forbidden', 403, origin);
+
+  const execute = request.method === 'POST';
+
+  try {
+    const sql = getSql();
+
+    // Aggregate holdings per profile that has at least one verified wallet. Only
+    // numeric atomic balances are summed (junk rows are skipped, never crash the run).
+    const rows = await sql`
+      SELECT
+        p.id AS profile_id,
+        COALESCE((
+          SELECT SUM((wa.token_balance_atomic)::numeric)
+          FROM wallet_accounts wa
+          WHERE wa.profile_id = p.id AND wa.verified_at IS NOT NULL
+            AND wa.token_balance_atomic ~ '^[0-9]+$'
+        ), 0)::text AS atomic_sum,
+        COALESCE((
+          SELECT MAX(wa.token_decimals)
+          FROM wallet_accounts wa
+          WHERE wa.profile_id = p.id AND wa.verified_at IS NOT NULL
+        ), 0) AS decimals,
+        COALESCE((
+          SELECT COUNT(*) FROM worlds w
+          WHERE w.owner_profile_id = p.id AND w.status = 'published'
+        ), 0) AS island_count
+      FROM profiles p
+      WHERE EXISTS (
+        SELECT 1 FROM wallet_accounts wa
+        WHERE wa.profile_id = p.id AND wa.verified_at IS NOT NULL
+      )
+      ORDER BY p.id ASC
+      LIMIT ${HOLDER_CAP + 1}
+    `;
+
+    const capped = (rows || []).length > HOLDER_CAP;
+    const holders = (rows || []).slice(0, HOLDER_CAP).map((r) => ({
+      wallet: 'profile:' + Number(r.profile_id),
+      tinyworldHeld: wholeFromAtomic(r.atomic_sum, r.decimals),
+      islandCount: Number(r.island_count) || 0,
+    }));
+
+    const plan = computeWeeklyPayoutPlan(holders, { now: new Date() });
+    const totalGold = plan.events.reduce((sum, e) => sum + Number(e.amount), 0);
+
+    if (!execute) {
+      // DRY RUN — preview only, write nothing.
+      return jsonResponse({
+        mode: 'dry-run',
+        cycleId: plan.cycleId,
+        holders: holders.length,
+        eventsToWrite: plan.events.length,
+        skippedZeroAllowance: plan.skippedZero,
+        totalGoldAllowance: totalGold,
+        capped,
+        sample: plan.events.slice(0, 10),
+      }, origin);
+    }
+
+    // EXECUTE — idempotent upsert, one allowance row per (wallet, cycle_id).
+    let written = 0;
+    for (const e of plan.events) {
+      const res = await sql`
+        INSERT INTO gold_ledger_events (wallet, cycle_id, type, amount, reason, reference_id)
+        VALUES (${e.wallet}, ${e.cycleId}, 'ALLOWANCE_RECALCULATED', ${e.amount}, ${e.reason}, NULL)
+        ON CONFLICT (wallet, cycle_id) WHERE type = 'ALLOWANCE_RECALCULATED'
+        DO NOTHING
+        RETURNING id
+      `;
+      if (res && res.length) written += 1;
+    }
+
+    return jsonResponse({
+      mode: 'execute',
+      cycleId: plan.cycleId,
+      holders: holders.length,
+      eventsComputed: plan.events.length,
+      written,
+      alreadyPresent: plan.events.length - written,
+      skippedZeroAllowance: plan.skippedZero,
+      totalGoldAllowance: totalGold,
+      capped,
+    }, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingSchema(err)) {
+      return errorResponse('gold-payout-unavailable: schema or DB not ready', 503, origin);
+    }
+    return errorResponse('gold-payout-failed: ' + (err.message || err), 500, origin);
+  }
+}

--- a/netlify/functions/gold-payout.mjs
+++ b/netlify/functions/gold-payout.mjs
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
 import { corsResponse, errorResponse, jsonResponse } from './lib/http.mjs';
 import { computeWeeklyPayoutPlan } from '../../packages/tinyworld-mmo-core/src/index.js';
@@ -12,29 +12,46 @@ export const config = { path: '/api/admin/gold-payout' };
 // makes the write idempotent (re-runs within a cycle are no-ops).
 //
 // ADMIN-ONLY + ECONOMY-GATE-FRIENDLY:
-//   GET  -> DRY RUN: compute and return the plan, write NOTHING. Lets the owner
-//           preview exactly what the weekly payout would credit before launch.
-//   POST -> EXECUTE: idempotently upsert the allowance events.
-// Both require the x-admin-secret header (timing-safe). At launch, wire a weekly
-// trigger (Netlify scheduled function or external cron) to POST this endpoint.
+//   GET  -> DRY RUN: compute and return the plan, write NOTHING (preview before launch).
+//   POST -> EXECUTE: idempotently bulk-upsert the allowance events.
+// Both require x-admin-secret (hash + timing-safe compare); 403 if the secret is unset.
+//
+// ===========================================================================
+// PRE-LAUNCH SECURITY DECISION (REQUIRED before this is wired to a live cron):
+// Holdings here come from wallet_accounts.token_balance_atomic, a cache the user can
+// refresh. A weekly payout off a refreshable cache is vulnerable to BALANCE STACKING:
+// fund wallet A, refresh it, move the tokens to wallet B, refresh B, ... then the
+// payout credits every stale row. The freshness window below bounds (but does not
+// eliminate) this. Before launch, pick ONE:
+//   (a) LOCKED/STAKED $TINYWORLD — only locked tokens (un-moveable during the cycle)
+//       count toward allowance (the economy guide lists this as an open decision); or
+//   (b) a PAYOUT-OWNED on-chain snapshot/indexer that reads balances at the cycle
+//       boundary, not a user-refreshable cache.
+// Until (a) or (b) is implemented, do NOT schedule this to run live. It stays gated.
+// ===========================================================================
 
 const HOLDER_CAP = 5000;
+// Only count a wallet's cached balance if it was refreshed within this window of the
+// payout; staler rows are treated as 0 (fail closed) — defense-in-depth vs stacking.
+const FRESHNESS_HOURS = Math.max(1, Number(process.env.GOLD_PAYOUT_FRESHNESS_HOURS) || 26);
 
 function adminSecret() {
   return process.env.TINYWORLD_ADMIN_SECRET || '';
 }
 
+// Hash both sides to a fixed 32 bytes so the compare never leaks length and is always
+// constant-time. Requires a configured, reasonably-long secret.
 function isAdmin(request) {
   const secret = adminSecret();
-  if (!secret) return false; // never run unguarded
+  if (!secret || secret.length < 16) return false; // never run unguarded / weak
   const provided = request.headers.get('x-admin-secret') || '';
-  const a = Buffer.from(provided);
-  const b = Buffer.from(secret);
-  return a.length === b.length && timingSafeEqual(a, b);
+  const a = createHash('sha256').update(provided).digest();
+  const b = createHash('sha256').update(secret).digest();
+  return timingSafeEqual(a, b);
 }
 
-// Atomic token units -> whole tokens (floored), BigInt throughout. Independent of
-// any other module so this function does not collide with the E1 gold branch.
+// Atomic token units -> whole tokens (floored), BigInt throughout. Independent of any
+// other module so this does not collide with the E1 gold branch.
 function wholeFromAtomic(atomicStr, decimals) {
   let a = 0n;
   const raw = String(atomicStr == null ? '0' : atomicStr).trim();
@@ -57,12 +74,13 @@ export default async function goldPayout(request) {
   if (!isAdmin(request)) return errorResponse('Forbidden', 403, origin);
 
   const execute = request.method === 'POST';
+  const freshnessCutoff = new Date(Date.now() - FRESHNESS_HOURS * 3600 * 1000);
 
   try {
     const sql = getSql();
 
-    // Aggregate holdings per profile that has at least one verified wallet. Only
-    // numeric atomic balances are summed (junk rows are skipped, never crash the run).
+    // Aggregate holdings per profile that has a verified wallet. Only numeric atomic
+    // balances refreshed within the freshness window are summed (stale/junk -> 0).
     const rows = await sql`
       SELECT
         p.id AS profile_id,
@@ -71,11 +89,13 @@ export default async function goldPayout(request) {
           FROM wallet_accounts wa
           WHERE wa.profile_id = p.id AND wa.verified_at IS NOT NULL
             AND wa.token_balance_atomic ~ '^[0-9]+$'
+            AND wa.updated_at >= ${freshnessCutoff}
         ), 0)::text AS atomic_sum,
         COALESCE((
           SELECT MAX(wa.token_decimals)
           FROM wallet_accounts wa
           WHERE wa.profile_id = p.id AND wa.verified_at IS NOT NULL
+            AND wa.updated_at >= ${freshnessCutoff}
         ), 0) AS decimals,
         COALESCE((
           SELECT COUNT(*) FROM worlds w
@@ -90,8 +110,17 @@ export default async function goldPayout(request) {
       LIMIT ${HOLDER_CAP + 1}
     `;
 
-    const capped = (rows || []).length > HOLDER_CAP;
-    const holders = (rows || []).slice(0, HOLDER_CAP).map((r) => ({
+    // Fail CLOSED on overflow: if there are more eligible holders than we can process
+    // in one pass, refuse to write a partial payout (an attacker could otherwise farm
+    // dummy wallets to push real holders past the cap). Needs pagination before launch.
+    if ((rows || []).length > HOLDER_CAP) {
+      return errorResponse(
+        `holder count exceeds cap (${HOLDER_CAP}); refusing partial payout — paginate before launch`,
+        409, origin,
+      );
+    }
+
+    const holders = (rows || []).map((r) => ({
       wallet: 'profile:' + Number(r.profile_id),
       tinyworldHeld: wholeFromAtomic(r.atomic_sum, r.decimals),
       islandCount: Number(r.island_count) || 0,
@@ -101,42 +130,48 @@ export default async function goldPayout(request) {
     const totalGold = plan.events.reduce((sum, e) => sum + Number(e.amount), 0);
 
     if (!execute) {
-      // DRY RUN — preview only, write nothing.
       return jsonResponse({
         mode: 'dry-run',
         cycleId: plan.cycleId,
+        freshnessHours: FRESHNESS_HOURS,
         holders: holders.length,
         eventsToWrite: plan.events.length,
         skippedZeroAllowance: plan.skippedZero,
         totalGoldAllowance: totalGold,
-        capped,
         sample: plan.events.slice(0, 10),
       }, origin);
     }
 
-    // EXECUTE — idempotent upsert, one allowance row per (wallet, cycle_id).
+    // EXECUTE — single bulk upsert (one round trip), idempotent via the partial index.
     let written = 0;
-    for (const e of plan.events) {
-      const res = await sql`
-        INSERT INTO gold_ledger_events (wallet, cycle_id, type, amount, reason, reference_id)
-        VALUES (${e.wallet}, ${e.cycleId}, 'ALLOWANCE_RECALCULATED', ${e.amount}, ${e.reason}, NULL)
+    if (plan.events.length) {
+      const values = plan.events.map((e) => ({
+        wallet: e.wallet,
+        cycle_id: e.cycleId,
+        type: 'ALLOWANCE_RECALCULATED',
+        amount: e.amount,
+        reason: e.reason,
+        reference_id: null,
+      }));
+      const inserted = await sql`
+        INSERT INTO gold_ledger_events ${sql(values, 'wallet', 'cycle_id', 'type', 'amount', 'reason', 'reference_id')}
         ON CONFLICT (wallet, cycle_id) WHERE type = 'ALLOWANCE_RECALCULATED'
         DO NOTHING
         RETURNING id
       `;
-      if (res && res.length) written += 1;
+      written = (inserted || []).length;
     }
 
     return jsonResponse({
       mode: 'execute',
       cycleId: plan.cycleId,
+      freshnessHours: FRESHNESS_HOURS,
       holders: holders.length,
       eventsComputed: plan.events.length,
       written,
       alreadyPresent: plan.events.length - written,
       skippedZeroAllowance: plan.skippedZero,
       totalGoldAllowance: totalGold,
-      capped,
     }, origin);
   } catch (err) {
     if (isDatabaseUnavailable(err) || isMissingSchema(err)) {

--- a/packages/tinyworld-mmo-core/src/economy.js
+++ b/packages/tinyworld-mmo-core/src/economy.js
@@ -152,6 +152,37 @@ export function createGoldLedgerEvent(type, fields = {}, now = new Date()) {
   };
 }
 
+// E2: pure planner for the weekly holdings-based GOLD payout. Given a list of
+// holders ({ wallet, tinyworldHeld (WHOLE tokens), islandCount }), produce the
+// authoritative ALLOWANCE_RECALCULATED events for the current cycle. Side-effect
+// free and deterministic given `now` — the DB write + idempotency live in the
+// gold-payout function; this is the part we unit-test. Holders whose computed
+// allowance is 0 produce no event (the ledger CHECK requires amount > 0).
+export function computeWeeklyPayoutPlan(holders = [], { now = new Date(), policy = DEFAULT_ECONOMY_POLICY } = {}) {
+  const cycleId = currentCycleId(now, policy.cycleCadence);
+  const events = [];
+  let skippedZero = 0;
+  for (const h of Array.isArray(holders) ? holders : []) {
+    if (!h || !h.wallet) continue;
+    const allowance = calculateGoldAllowance({
+      tinyworldHeld: h.tinyworldHeld,
+      islandCount: h.islandCount,
+      now,
+    }, policy);
+    if (allowance.totalAllowance > 0) {
+      events.push(createGoldLedgerEvent('ALLOWANCE_RECALCULATED', {
+        wallet: String(h.wallet),
+        cycleId,
+        amount: allowance.totalAllowance,
+        reason: 'weekly-allowance',
+      }, now));
+    } else {
+      skippedZero += 1;
+    }
+  }
+  return { cycleId, events, skippedZero };
+}
+
 export function reduceGoldLedger(events = [], { wallet, cycleId } = {}) {
   const out = { wallet: wallet || '', cycleId: cycleId || '', allowance: 0, spent: 0, refunded: 0, available: 0 };
   for (const event of events) {

--- a/tests/economy-weekly-payout.test.mjs
+++ b/tests/economy-weekly-payout.test.mjs
@@ -1,0 +1,79 @@
+// tests/economy-weekly-payout.test.mjs
+// E2: the pure weekly-payout planner that turns wallet holdings into authoritative
+// ALLOWANCE_RECALCULATED ledger events. The DB write/idempotency is tested separately;
+// this proves the holdings -> allowance -> event mapping.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeWeeklyPayoutPlan,
+  currentCycleId,
+  DEFAULT_ECONOMY_POLICY,
+} from '../packages/tinyworld-mmo-core/src/index.js';
+
+const NOW = new Date('2026-06-24T00:00:00Z');
+const CYCLE = currentCycleId(NOW, DEFAULT_ECONOMY_POLICY.cycleCadence);
+
+test('maps holders to one allowance event each, at the right tier', () => {
+  const plan = computeWeeklyPayoutPlan([
+    { wallet: 'profile:1', tinyworldHeld: '1000', islandCount: 0 },   // bronze -> 100
+    { wallet: 'profile:2', tinyworldHeld: '10000', islandCount: 0 },  // silver -> 500
+    { wallet: 'profile:3', tinyworldHeld: '100000', islandCount: 0 }, // mythic -> 2500
+  ], { now: NOW });
+
+  assert.equal(plan.cycleId, CYCLE);
+  assert.equal(plan.events.length, 3);
+  assert.equal(plan.skippedZero, 0);
+  const byWallet = Object.fromEntries(plan.events.map(e => [e.wallet, e]));
+  assert.equal(byWallet['profile:1'].amount, 100);
+  assert.equal(byWallet['profile:2'].amount, 500);
+  assert.equal(byWallet['profile:3'].amount, 2500);
+  for (const e of plan.events) {
+    assert.equal(e.type, 'ALLOWANCE_RECALCULATED');
+    assert.equal(e.cycleId, CYCLE);
+    assert.equal(e.reason, 'weekly-allowance');
+  }
+});
+
+test('holders below the first tier get NO event (amount must be > 0)', () => {
+  const plan = computeWeeklyPayoutPlan([
+    { wallet: 'profile:1', tinyworldHeld: '0', islandCount: 0 },
+    { wallet: 'profile:2', tinyworldHeld: '999', islandCount: 0 }, // below bronze (1000)
+  ], { now: NOW });
+  assert.equal(plan.events.length, 0);
+  assert.equal(plan.skippedZero, 2);
+});
+
+test('island ownership adds the island bonus on top of the tier', () => {
+  const base = computeWeeklyPayoutPlan([{ wallet: 'profile:1', tinyworldHeld: '10000', islandCount: 0 }], { now: NOW });
+  const withIsland = computeWeeklyPayoutPlan([{ wallet: 'profile:1', tinyworldHeld: '10000', islandCount: 2 }], { now: NOW });
+  assert.equal(base.events[0].amount, 500);
+  // island bonus is positive and capped — strictly greater than the base allowance
+  assert.ok(withIsland.events[0].amount > 500, `expected island bonus, got ${withIsland.events[0].amount}`);
+});
+
+test('ignores malformed holders without crashing', () => {
+  const plan = computeWeeklyPayoutPlan([
+    null,
+    { islandCount: 1 },                 // no wallet -> skipped entirely
+    { wallet: '', tinyworldHeld: '50000' }, // empty wallet -> skipped
+    { wallet: 'profile:9', tinyworldHeld: '50000', islandCount: 0 }, // gold -> 1500
+  ], { now: NOW });
+  assert.equal(plan.events.length, 1);
+  assert.equal(plan.events[0].wallet, 'profile:9');
+  assert.equal(plan.events[0].amount, 1500);
+});
+
+test('empty / non-array input yields an empty plan for the current cycle', () => {
+  assert.deepEqual(computeWeeklyPayoutPlan([], { now: NOW }).events, []);
+  assert.deepEqual(computeWeeklyPayoutPlan(undefined, { now: NOW }).events, []);
+  assert.equal(computeWeeklyPayoutPlan([], { now: NOW }).cycleId, CYCLE);
+});
+
+test('the same holders + same cycle produce identical events (idempotent input)', () => {
+  const holders = [{ wallet: 'profile:1', tinyworldHeld: '10000', islandCount: 0 }];
+  const a = computeWeeklyPayoutPlan(holders, { now: NOW });
+  const b = computeWeeklyPayoutPlan(holders, { now: new Date('2026-06-24T23:59:00Z') }); // same week
+  assert.equal(a.cycleId, b.cycleId);
+  assert.equal(a.events[0].amount, b.events[0].amount);
+  assert.equal(a.events[0].wallet, b.events[0].wallet);
+});


### PR DESCRIPTION
**Do not merge.** Economy launch gate — reviewed + staged until the tinyverse economy is preview-ready.

The stated #1 priority: weekly in-app GOLD credited from \$TINYWORLD holdings.

## What
- **Migration** `20260624120000_gold_allowance_unique.sql`: partial UNIQUE index on `gold_ledger_events (wallet, cycle_id) WHERE type='ALLOWANCE_RECALCULATED'` — makes the payout idempotent (one authoritative allowance row per wallet per weekly cycle). Fixes the pre-existing no-op `ON CONFLICT` (the table had no unique constraint).
- **`computeWeeklyPayoutPlan`** (mmo-core, pure): holdings + islands → `ALLOWANCE_RECALCULATED` events. **6 unit tests** (tiers, sub-tier skip, island bonus, malformed input, idempotent input).
- **`/api/admin/gold-payout`** (`gold-payout.mjs`): admin-secret gated (timing-safe; 403 if unset). **GET = dry-run preview** (writes nothing) so you can preview exactly what the weekly payout would credit *before* launch; **POST = idempotent upsert**. Holder aggregation skips non-numeric balances; capped at 5000.

## Security
- Server-authoritative holdings (the client can never set `token_balance_atomic`).
- Idempotent writes (partial unique index + `ON CONFLICT DO NOTHING`).
- Admin-only, timing-safe; refuses to run if the secret is unset.
- Parameterized SQL; BigInt atomic→whole (no precision loss).

## Follow-ups (at launch, not now)
- Wire a weekly trigger (Netlify scheduled function / external cron POST).
- `gold.mjs` reads the latest `ALLOWANCE_RECALCULATED` as the authoritative cycle allowance (lands with E1/E3 to avoid a gold.mjs conflict).
- Adversarial Codex security pass running as a backstop; verdict to follow.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK