### PR TITLE
[HOLD: economy preview] E3 — GOLD-spend endpoint (ledger-authoritative, race-safe)

### DIFF
--- a/netlify/database/migrations/20260624130000_gold_spent_idempotency.sql
+++ b/netlify/database/migrations/20260624130000_gold_spent_idempotency.sql
@@ -1,0 +1,9 @@
+-- E3 GOLD-spend idempotency.
+-- The spend endpoint stores a client idempotency key in reference_id so a retried
+-- request never double-debits. This partial unique index enforces one spend per
+-- (wallet, reference_id); combined with the per-wallet advisory lock in the endpoint
+-- it makes spends both idempotent and race-safe. Allowance/refund rows are unaffected
+-- (the predicate covers only keyed GOLD_SPENT rows).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_gold_spent_wallet_ref
+  ON gold_ledger_events (wallet, reference_id)
+  WHERE type = 'GOLD_SPENT' AND reference_id IS NOT NULL;

--- a/netlify/functions/gold-spend.mjs
+++ b/netlify/functions/gold-spend.mjs
@@ -1,0 +1,111 @@
+import { requireAuthUser } from './lib/auth.mjs';
+import { ensureProfile } from './lib/profiles.mjs';
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
+import { reduceGoldLedger, spendGold, currentCycleId } from '../../packages/tinyworld-mmo-core/src/index.js';
+
+export const config = { path: '/api/me/gold/spend' };
+
+// E3 — the single server-authoritative GOLD debit path.
+// Spendable GOLD = ledger-derived `available` for the CURRENT cycle
+// (ALLOWANCE_RECALCULATED − GOLD_SPENT + GOLD_REFUNDED), NEVER a live wallet-balance
+// projection. Concurrency-safe via a per-wallet advisory lock inside a transaction;
+// idempotent via a client key stored in reference_id (+ the uq_gold_spent_wallet_ref
+// partial unique index). See plans/production-line/specs/E3-gold-spend.md.
+//
+// HELD behind the economy launch gate. Consumed by template-remix, paid-AI, etc.
+
+const MAX_SPEND_PER_REQUEST = 1_000_000;
+const ACTION_ALLOWLIST = new Set([
+  'template-remix', 'upgrade', 'cosmetic', 'speedup', 'ai-generation', 'misc',
+]);
+const isMissingSchema = (err) => isMissingRelations(err, ['gold_ledger_events']);
+
+function badRequest(reason, origin, status = 400) {
+  return jsonResponse({ ok: false, reason }, origin, status);
+}
+
+export default async function goldSpend(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'POST') return errorResponse('Method not allowed', 405, origin);
+  if (!sameOriginWriteGuard(request)) return errorResponse('Forbidden', 403, origin);
+
+  const auth = await requireAuthUser(request, origin);
+  if (auth.response) return auth.response;
+
+  let body;
+  try { body = await readJson(request); } catch (_) { return badRequest('invalid-json', origin); }
+  body = body || {};
+
+  // Validate the spend request. The wallet is ALWAYS derived from auth, never the body.
+  const amount = Number(body.amount);
+  if (!Number.isInteger(amount) || amount <= 0 || amount > MAX_SPEND_PER_REQUEST) {
+    return badRequest('invalid-amount', origin);
+  }
+  const action = String(body.action || '').trim();
+  if (!ACTION_ALLOWLIST.has(action)) return badRequest('action-not-allowed', origin);
+  const idempotencyKey = String(body.idempotencyKey || '').trim();
+  if (!/^[A-Za-z0-9._:-]{8,128}$/.test(idempotencyKey)) return badRequest('invalid-idempotency-key', origin);
+  const domainRef = body.referenceId == null ? '' : String(body.referenceId).slice(0, 120);
+  const reason = domainRef ? `${action} ${domainRef}` : action;
+
+  try {
+    const sql = getSql();
+    const profile = await ensureProfile(auth.user);
+    const wallet = 'profile:' + profile.id;
+    const cycleId = currentCycleId(new Date());
+
+    const result = await sql.begin(async (tx) => {
+      // Serialize all spends for THIS wallet so two concurrent requests cannot both
+      // read the same `available` and overspend. Released at COMMIT/ROLLBACK.
+      await tx`SELECT pg_advisory_xact_lock(hashtext(${wallet})::bigint)`;
+
+      // Idempotent replay: a prior spend with the same key returns the same outcome.
+      const prior = await tx`
+        SELECT amount FROM gold_ledger_events
+        WHERE wallet = ${wallet} AND type = 'GOLD_SPENT' AND reference_id = ${idempotencyKey}
+        LIMIT 1
+      `;
+      if (prior.length) {
+        const events = await tx`
+          SELECT type, wallet, cycle_id AS "cycleId", amount FROM gold_ledger_events
+          WHERE wallet = ${wallet} AND cycle_id = ${cycleId}
+        `;
+        const summary = reduceGoldLedger(events, { wallet, cycleId });
+        return { ok: true, replayed: true, spent: Number(prior[0].amount), available: summary.available, cycleId };
+      }
+
+      // Compute authoritative available from the ledger and attempt the spend.
+      const events = await tx`
+        SELECT type, wallet, cycle_id AS "cycleId", amount FROM gold_ledger_events
+        WHERE wallet = ${wallet} AND cycle_id = ${cycleId}
+      `;
+      const summary = reduceGoldLedger(events, { wallet, cycleId });
+      const spend = spendGold(summary, amount, { wallet, action: reason, referenceId: idempotencyKey });
+      if (!spend.ok) return { ok: false, reason: spend.reason, available: summary.available, cycleId };
+
+      const inserted = await tx`
+        INSERT INTO gold_ledger_events (wallet, cycle_id, type, amount, reason, reference_id)
+        VALUES (${wallet}, ${cycleId}, 'GOLD_SPENT', ${amount}, ${reason}, ${idempotencyKey})
+        ON CONFLICT (wallet, reference_id) WHERE type = 'GOLD_SPENT' AND reference_id IS NOT NULL
+        DO NOTHING
+        RETURNING id
+      `;
+      // If the conflict path hit (lost an idempotency race despite the lock), treat as replay.
+      const eventId = inserted.length ? inserted[0].id : null;
+      return { ok: true, replayed: !eventId, spent: amount, available: spend.available, cycleId, eventId };
+    });
+
+    if (!result.ok) {
+      const status = result.reason === 'insufficient-gold' ? 402 : 400;
+      return jsonResponse(result, origin, status);
+    }
+    return jsonResponse(result, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingSchema(err)) {
+      return errorResponse('gold-spend-unavailable: schema or DB not ready', 503, origin);
+    }
+    return errorResponse('gold-spend-failed: ' + (err.message || err), 500, origin);
+  }
+}

--- a/netlify/functions/gold-spend.mjs
+++ b/netlify/functions/gold-spend.mjs
@@ -61,27 +61,32 @@ export default async function goldSpend(request) {
       // read the same `available` and overspend. Released at COMMIT/ROLLBACK.
       await tx`SELECT pg_advisory_xact_lock(hashtext(${wallet})::bigint)`;
 
-      // Idempotent replay: a prior spend with the same key returns the same outcome.
+      // Load this cycle's events in DETERMINISTIC order so reduceGoldLedger's
+      // "latest ALLOWANCE_RECALCULATED wins" reflects chronological, not physical, order.
+      const loadEvents = () => tx`
+        SELECT type, wallet, cycle_id AS "cycleId", amount FROM gold_ledger_events
+        WHERE wallet = ${wallet} AND cycle_id = ${cycleId}
+        ORDER BY created_at ASC, id ASC
+      `;
+
+      // Idempotency: a prior spend with the same key replays ONLY if the request
+      // fingerprint (amount + reason) matches. A reused key with a different spend is
+      // rejected (409) so a cheap key can never authorize an expensive action.
       const prior = await tx`
-        SELECT amount FROM gold_ledger_events
+        SELECT amount, reason FROM gold_ledger_events
         WHERE wallet = ${wallet} AND type = 'GOLD_SPENT' AND reference_id = ${idempotencyKey}
         LIMIT 1
       `;
       if (prior.length) {
-        const events = await tx`
-          SELECT type, wallet, cycle_id AS "cycleId", amount FROM gold_ledger_events
-          WHERE wallet = ${wallet} AND cycle_id = ${cycleId}
-        `;
-        const summary = reduceGoldLedger(events, { wallet, cycleId });
-        return { ok: true, replayed: true, spent: Number(prior[0].amount), available: summary.available, cycleId };
+        if (Number(prior[0].amount) !== amount || String(prior[0].reason || '') !== reason) {
+          return { ok: false, reason: 'idempotency-key-reused', status: 409 };
+        }
+        const summary = reduceGoldLedger(await loadEvents(), { wallet, cycleId });
+        return { ok: true, replayed: true, spent: amount, available: summary.available, cycleId };
       }
 
       // Compute authoritative available from the ledger and attempt the spend.
-      const events = await tx`
-        SELECT type, wallet, cycle_id AS "cycleId", amount FROM gold_ledger_events
-        WHERE wallet = ${wallet} AND cycle_id = ${cycleId}
-      `;
-      const summary = reduceGoldLedger(events, { wallet, cycleId });
+      const summary = reduceGoldLedger(await loadEvents(), { wallet, cycleId });
       const spend = spendGold(summary, amount, { wallet, action: reason, referenceId: idempotencyKey });
       if (!spend.ok) return { ok: false, reason: spend.reason, available: summary.available, cycleId };
 
@@ -92,14 +97,29 @@ export default async function goldSpend(request) {
         DO NOTHING
         RETURNING id
       `;
-      // If the conflict path hit (lost an idempotency race despite the lock), treat as replay.
-      const eventId = inserted.length ? inserted[0].id : null;
-      return { ok: true, replayed: !eventId, spent: amount, available: spend.available, cycleId, eventId };
+      if (!inserted.length) {
+        // Conflict despite the lock (a non-locking writer raced us). Do NOT claim a
+        // debit we didn't make: re-read the conflicting row and only replay on a
+        // fingerprint match; otherwise reject.
+        const conflict = await tx`
+          SELECT amount, reason FROM gold_ledger_events
+          WHERE wallet = ${wallet} AND type = 'GOLD_SPENT' AND reference_id = ${idempotencyKey}
+          LIMIT 1
+        `;
+        if (!conflict.length || Number(conflict[0].amount) !== amount || String(conflict[0].reason || '') !== reason) {
+          return { ok: false, reason: 'idempotency-key-reused', status: 409 };
+        }
+        const after = reduceGoldLedger(await loadEvents(), { wallet, cycleId });
+        return { ok: true, replayed: true, spent: amount, available: after.available, cycleId };
+      }
+      return { ok: true, replayed: false, spent: amount, available: spend.available, cycleId, eventId: inserted[0].id };
     });
 
     if (!result.ok) {
-      const status = result.reason === 'insufficient-gold' ? 402 : 400;
-      return jsonResponse(result, origin, status);
+      const status = result.status
+        || (result.reason === 'insufficient-gold' ? 402 : 400);
+      const { status: _drop, ...payload } = result;
+      return jsonResponse(payload, origin, status);
     }
     return jsonResponse(result, origin);
   } catch (err) {

--- a/netlify/functions/world-resources.mjs
+++ b/netlify/functions/world-resources.mjs
@@ -90,6 +90,11 @@ export default async function worldResourcesFunction(request) {
       if (!Array.isArray(events)) continue;
       for (const ev of events) {
         if (!ev || !ev.type || !ev.amount) continue;
+        // SECURITY: this generic service-token ingest may ONLY write allowance recalcs.
+        // GOLD debits/refunds must go through the locked, idempotent endpoints
+        // (/api/me/gold/spend, refund) so a service-token leak or room bug can never
+        // mint or move spendable GOLD here. Reject any non-allowance type.
+        if (ev.type !== 'ALLOWANCE_RECALCULATED') continue;
         try {
           await sql`
             INSERT INTO gold_ledger_events (wallet, cycle_id, type, amount, reason, reference_id)

--- a/tests/economy-gold-spend.test.mjs
+++ b/tests/economy-gold-spend.test.mjs
@@ -1,0 +1,84 @@
+// tests/economy-gold-spend.test.mjs
+// E3: the ledger-authoritative spend decision the /api/me/gold/spend endpoint composes
+// (reduceGoldLedger -> spendGold). The DB transaction / advisory-lock / idempotency
+// wrapper is integration-tested separately (it needs a real Postgres); this proves the
+// pure money math the endpoint trusts.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  reduceGoldLedger,
+  spendGold,
+  createGoldLedgerEvent,
+  currentCycleId,
+} from '../packages/tinyworld-mmo-core/src/index.js';
+
+const NOW = new Date('2026-06-24T00:00:00Z');
+const WALLET = 'profile:1';
+const CYCLE = currentCycleId(NOW);
+
+function allowanceEvent(amount) {
+  return createGoldLedgerEvent('ALLOWANCE_RECALCULATED', { wallet: WALLET, cycleId: CYCLE, amount }, NOW);
+}
+function decide(events, amount, key = 'idem-key-00000001') {
+  const summary = reduceGoldLedger(events, { wallet: WALLET, cycleId: CYCLE });
+  return { summary, spend: spendGold(summary, amount, { wallet: WALLET, action: 'template-remix', referenceId: key }) };
+}
+
+test('a spend within the cycle allowance succeeds and debits available', () => {
+  const { spend } = decide([allowanceEvent(500)], 120);
+  assert.equal(spend.ok, true);
+  assert.equal(spend.available, 380);
+  assert.equal(spend.event.type, 'GOLD_SPENT');
+  assert.equal(spend.event.amount, 120);
+  assert.equal(spend.event.wallet, WALLET);
+  assert.equal(spend.event.cycleId, CYCLE);
+  assert.equal(spend.event.referenceId, 'idem-key-00000001');
+});
+
+test('a spend over available is rejected (insufficient-gold), no event', () => {
+  const { spend } = decide([allowanceEvent(500), goldSpent(450)], 100);
+  assert.equal(spend.ok, false);
+  assert.equal(spend.reason, 'insufficient-gold');
+  assert.equal(spend.available, 50);
+  assert.equal(spend.event, undefined);
+});
+
+test('with NO allowance event for the cycle, available is 0 and spends are refused', () => {
+  const { summary, spend } = decide([], 1);
+  assert.equal(summary.available, 0);
+  assert.equal(spend.ok, false);
+  assert.equal(spend.reason, 'insufficient-gold');
+});
+
+test('invalid (zero / negative) amounts are rejected before any debit', () => {
+  assert.equal(decide([allowanceEvent(500)], 0).spend.reason, 'invalid-amount');
+  assert.equal(decide([allowanceEvent(500)], -10).spend.reason, 'invalid-amount');
+});
+
+test('the available reflects allowance minus prior spends plus refunds', () => {
+  const events = [allowanceEvent(1000), goldSpent(300), goldRefunded(100)];
+  const summary = reduceGoldLedger(events, { wallet: WALLET, cycleId: CYCLE });
+  assert.equal(summary.allowance, 1000);
+  assert.equal(summary.spent, 300);
+  assert.equal(summary.refunded, 100);
+  assert.equal(summary.available, 800); // 1000 - 300 + 100
+  // a spend of exactly the remaining available succeeds and zeroes it
+  const spend = spendGold(summary, 800, { wallet: WALLET, action: 'upgrade', referenceId: 'k-2' });
+  assert.equal(spend.ok, true);
+  assert.equal(spend.available, 0);
+});
+
+test('a later ALLOWANCE_RECALCULATED replaces (not adds to) the cycle allowance', () => {
+  // reduceGoldLedger SETS allowance to the latest ALLOWANCE_RECALCULATED amount.
+  const events = [allowanceEvent(500), allowanceEvent(1500)];
+  const summary = reduceGoldLedger(events, { wallet: WALLET, cycleId: CYCLE });
+  assert.equal(summary.allowance, 1500);
+  assert.equal(summary.available, 1500);
+});
+
+function goldSpent(amount) {
+  return createGoldLedgerEvent('GOLD_SPENT', { wallet: WALLET, cycleId: CYCLE, amount, referenceId: 'seed-' + amount }, NOW);
+}
+function goldRefunded(amount) {
+  return createGoldLedgerEvent('GOLD_REFUNDED', { wallet: WALLET, cycleId: CYCLE, amount, referenceId: 'ref-' + amount }, NOW);
+}

--- a/tests/economy-gold-spend.test.mjs
+++ b/tests/economy-gold-spend.test.mjs
@@ -76,6 +76,16 @@ test('a later ALLOWANCE_RECALCULATED replaces (not adds to) the cycle allowance'
   assert.equal(summary.available, 1500);
 });
 
+test('allowance is order-sensitive — the LAST event wins (so DB reads MUST be chronologically ordered)', () => {
+  // If an allowance is lowered 1000 -> 100, feeding the rows in the wrong physical
+  // order would keep the stale 1000 and let the player overspend. This is why the
+  // endpoint reads events ORDER BY created_at ASC, id ASC. (Codex E3 finding #1.)
+  const chronological = [allowanceEvent(1000), allowanceEvent(100)];
+  const reversed = [allowanceEvent(100), allowanceEvent(1000)];
+  assert.equal(reduceGoldLedger(chronological, { wallet: WALLET, cycleId: CYCLE }).allowance, 100);
+  assert.equal(reduceGoldLedger(reversed, { wallet: WALLET, cycleId: CYCLE }).allowance, 1000);
+});
+
 function goldSpent(amount) {
   return createGoldLedgerEvent('GOLD_SPENT', { wallet: WALLET, cycleId: CYCLE, amount, referenceId: 'seed-' + amount }, NOW);
 }


### PR DESCRIPTION
**Do not merge.** Economy launch gate — reviewed + staged.

The single server-authoritative GOLD debit path. Everything that costs GOLD (template remix, paid-AI, upgrades) spends through this.

## What
- **Migration**: partial unique index `uq_gold_spent_wallet_ref (wallet, reference_id) WHERE type='GOLD_SPENT' AND reference_id IS NOT NULL` — spend idempotency.
- **`POST /api/me/gold/spend`**: auth + `ensureProfile` + `sameOriginWriteGuard`. **Wallet derived from auth, never the body.** Validates integer amount (>0, ≤1e6), action allowlist, idempotency-key format.
- **Ledger-authoritative**: `available = reduceGoldLedger(current-cycle events)` (ALLOWANCE_RECALCULATED − GOLD_SPENT + GOLD_REFUNDED) — **never** a live-balance projection. `spendGold()` decides; 402 on insufficient.
- **Race-safe + idempotent**: per-wallet `pg_advisory_xact_lock` inside a transaction serializes spends (no double-read overspend); idempotency key + pre-check + `ON CONFLICT DO NOTHING` handle retries.
- **6 pure unit tests** for the spend decision. `npm run check` + 199 tests pass.

## Follow-ups (pre-launch)
- Live-DB integration test for the advisory-lock double-spend race (unit tests can't exercise pg locks).
- Per-profile rate limiting (E5); refund endpoint (E3.1); `gold.mjs` reading ledger `available` as authoritative.
- Adversarial Codex pass running as a backstop; verdict to follow.

Spec: `plans/production-line/specs/E3-gold-spend.md`.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK