### PR TITLE
[HOLD: economy preview] EC1 — Earned GOLD ledger + atomic credit/debit/transfer

### DIFF
--- a/netlify/database/migrations/20260624140000_coins_earned_gold.sql
+++ b/netlify/database/migrations/20260624140000_coins_earned_gold.sql
@@ -21,7 +21,13 @@ CREATE TABLE IF NOT EXISTS coin_ledger (
   reason TEXT,
   reference_id TEXT,
   counterparty_profile_id BIGINT REFERENCES profiles(id) ON DELETE SET NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- Audit integrity: a credit must be positive, a debit negative — so a poisoned
+  -- caller cannot record a positive DEBIT or negative CREDIT.
+  CONSTRAINT coin_ledger_sign_type CHECK (
+    (delta > 0 AND type IN ('CREDIT', 'TRANSFER_IN')) OR
+    (delta < 0 AND type IN ('DEBIT', 'TRANSFER_OUT'))
+  )
 );
 
 CREATE INDEX IF NOT EXISTS idx_coin_ledger_profile ON coin_ledger (profile_id, created_at DESC);

--- a/netlify/database/migrations/20260624140000_coins_earned_gold.sql
+++ b/netlify/database/migrations/20260624140000_coins_earned_gold.sql
@@ -1,0 +1,33 @@
+-- EC1 — "Earned GOLD" (Coins): the transferable in-game currency (owner decision D2).
+-- Distinct from holdings-based Allowance GOLD (gold_ledger_events), which stays
+-- non-transferable. Coins are earned (template sales, referral rewards, paid actions)
+-- and spent/transferred player-to-player.
+--
+-- coin_balances is the source of truth for spend checks (CHECK keeps it >= 0, the
+-- ultimate backstop against overspend). coin_ledger is the append-only audit trail
+-- and the idempotency surface.
+
+CREATE TABLE IF NOT EXISTS coin_balances (
+  profile_id BIGINT PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+  balance BIGINT NOT NULL DEFAULT 0 CHECK (balance >= 0),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS coin_ledger (
+  id BIGSERIAL PRIMARY KEY,
+  profile_id BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  delta BIGINT NOT NULL CHECK (delta <> 0),
+  type TEXT NOT NULL CHECK (type IN ('CREDIT', 'DEBIT', 'TRANSFER_IN', 'TRANSFER_OUT')),
+  reason TEXT,
+  reference_id TEXT,
+  counterparty_profile_id BIGINT REFERENCES profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_coin_ledger_profile ON coin_ledger (profile_id, created_at DESC);
+
+-- Idempotency: at most one ledger entry per (profile_id, reference_id) when a key is
+-- supplied, so a retried credit/debit/transfer never double-applies.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_coin_ledger_profile_ref
+  ON coin_ledger (profile_id, reference_id)
+  WHERE reference_id IS NOT NULL;

--- a/netlify/functions/coins.mjs
+++ b/netlify/functions/coins.mjs
@@ -1,0 +1,43 @@
+import { requireAuthUser } from './lib/auth.mjs';
+import { ensureProfile } from './lib/profiles.mjs';
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse } from './lib/http.mjs';
+import { getCoinBalance } from './lib/coins.mjs';
+
+export const config = { path: '/api/me/coins' };
+
+// Read the authenticated player's Earned GOLD (Coins) balance + recent ledger.
+// Coins are MOVED only by the server-authoritative primitives in lib/coins.mjs
+// (template sales, referral rewards, paid actions) — never written from the client.
+const isMissingSchema = (err) => isMissingRelations(err, ['coin_balances', 'coin_ledger']);
+
+export default async function coins(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'GET') return errorResponse('Method not allowed', 405, origin);
+
+  const auth = await requireAuthUser(request, origin);
+  if (auth.response) return auth.response;
+
+  try {
+    const sql = getSql();
+    const profile = await ensureProfile(auth.user);
+    const balance = await getCoinBalance(sql, profile.id);
+    let recent = [];
+    try {
+      recent = await sql`
+        SELECT delta, type, reason, created_at AS "createdAt"
+        FROM coin_ledger
+        WHERE profile_id = ${Number(profile.id)}
+        ORDER BY created_at DESC, id DESC
+        LIMIT 20
+      `;
+    } catch (_) { recent = []; }
+    return jsonResponse({ balance, recent }, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingSchema(err)) {
+      return jsonResponse({ balance: 0, recent: [] }, origin);
+    }
+    return errorResponse('coins-failed', 500, origin);
+  }
+}

--- a/netlify/functions/lib/coins.mjs
+++ b/netlify/functions/lib/coins.mjs
@@ -1,12 +1,15 @@
 // EC1 — Earned GOLD (Coins) primitive: atomic, idempotent, race-safe credit / debit /
 // transfer. The keystone every coin-moving feature (template sales, referral rewards,
-// paid-AI) builds on. Same discipline as the GOLD-spend path (E3):
+// paid-AI) builds on. Discipline (hardened per adversarial review):
 //   - a per-profile advisory lock SERIALIZES all coin ops for a profile inside the
 //     transaction, so balance read + check + write can't interleave (no overspend);
-//   - an idempotency key (reference_id) makes retries safe;
-//   - coin_balances.CHECK(balance >= 0) is the ultimate backstop.
-// The *WithinTx functions run inside a caller-provided transaction so a feature can
-// compose them atomically (e.g. remix = debit buyer + credit author + duplicate world).
+//   - EVERY money move requires a non-empty server-generated idempotency key
+//     (reference_id), and replays are bound to a FINGERPRINT (amount + type +
+//     counterparty) — a key reused for a different op is rejected, not silently replayed;
+//   - coin_balances.CHECK(balance >= 0) and the ledger sign/type CHECK are DB backstops;
+//   - the raw in-tx helpers are NOT exported — features compose via coinsTransaction()
+//     / the wrappers, which always run inside sql.begin (the advisory xact lock is
+//     worthless outside a transaction, so we never let a caller pass the root sql).
 
 export const MAX_COIN_AMOUNT = 100_000_000;
 
@@ -14,6 +17,10 @@ export function validateCoinAmount(amount) {
   const n = Number(amount);
   if (!Number.isInteger(n) || n <= 0 || n > MAX_COIN_AMOUNT) return null;
   return n;
+}
+
+export function isValidCoinRef(referenceId) {
+  return typeof referenceId === 'string' && /^[A-Za-z0-9._:-]{8,128}$/.test(referenceId);
 }
 
 async function lockProfile(tx, profileId) {
@@ -26,21 +33,32 @@ async function balanceOf(tx, profileId) {
 }
 
 async function priorByRef(tx, profileId, referenceId) {
-  if (!referenceId) return null;
   const rows = await tx`
-    SELECT id FROM coin_ledger
+    SELECT delta, type, counterparty_profile_id AS cpid FROM coin_ledger
     WHERE profile_id = ${Number(profileId)} AND reference_id = ${referenceId}
     LIMIT 1
   `;
   return rows.length ? rows[0] : null;
 }
 
-// Credit coins to a profile. Runs inside the caller's transaction `tx`.
-export async function creditWithinTx(tx, { profileId, amount, type = 'CREDIT', reason = null, referenceId = null, counterpartyProfileId = null }) {
+function fingerprintMatches(prior, { delta, type, counterpartyProfileId }) {
+  const priorCp = prior.cpid == null ? null : Number(prior.cpid);
+  const wantCp = counterpartyProfileId == null ? null : Number(counterpartyProfileId);
+  return Number(prior.delta) === delta && String(prior.type) === type && priorCp === wantCp;
+}
+
+// --- raw in-transaction helpers (module-private; require a real tx + a valid ref) ---
+
+async function _credit(tx, { profileId, amount, type = 'CREDIT', reason = null, referenceId, counterpartyProfileId = null }) {
   const amt = validateCoinAmount(amount);
   if (amt === null) return { ok: false, reason: 'invalid-amount' };
+  if (!isValidCoinRef(referenceId)) return { ok: false, reason: 'invalid-reference' };
   await lockProfile(tx, profileId);
-  if (await priorByRef(tx, profileId, referenceId)) {
+  const prior = await priorByRef(tx, profileId, referenceId);
+  if (prior) {
+    if (!fingerprintMatches(prior, { delta: amt, type, counterpartyProfileId })) {
+      return { ok: false, reason: 'idempotency-key-reused' };
+    }
     return { ok: true, replayed: true, balance: await balanceOf(tx, profileId) };
   }
   const rows = await tx`
@@ -55,17 +73,20 @@ export async function creditWithinTx(tx, { profileId, amount, type = 'CREDIT', r
   return { ok: true, replayed: false, balance: Number(rows[0].balance) };
 }
 
-// Debit coins from a profile. Returns { ok:false, reason:'insufficient-coins' } if short.
-export async function debitWithinTx(tx, { profileId, amount, type = 'DEBIT', reason = null, referenceId = null, counterpartyProfileId = null }) {
+async function _debit(tx, { profileId, amount, type = 'DEBIT', reason = null, referenceId, counterpartyProfileId = null }) {
   const amt = validateCoinAmount(amount);
   if (amt === null) return { ok: false, reason: 'invalid-amount' };
+  if (!isValidCoinRef(referenceId)) return { ok: false, reason: 'invalid-reference' };
   await lockProfile(tx, profileId);
-  if (await priorByRef(tx, profileId, referenceId)) {
+  const prior = await priorByRef(tx, profileId, referenceId);
+  if (prior) {
+    if (!fingerprintMatches(prior, { delta: -amt, type, counterpartyProfileId })) {
+      return { ok: false, reason: 'idempotency-key-reused' };
+    }
     return { ok: true, replayed: true, balance: await balanceOf(tx, profileId) };
   }
   const bal = await balanceOf(tx, profileId);
   if (bal < amt) return { ok: false, reason: 'insufficient-coins', balance: bal };
-  // Conditional UPDATE is the backstop even if the lock were ever absent.
   const rows = await tx`
     UPDATE coin_balances SET balance = balance - ${amt}, updated_at = NOW()
     WHERE profile_id = ${Number(profileId)} AND balance >= ${amt}
@@ -79,35 +100,54 @@ export async function debitWithinTx(tx, { profileId, amount, type = 'DEBIT', rea
   return { ok: true, replayed: false, balance: Number(rows[0].balance) };
 }
 
-// Atomic player-to-player transfer: debit `from`, credit `to`, in ONE transaction.
-// Locks both profiles in id order to avoid deadlock. Idempotent on `from`'s reference_id.
-export async function transferCoins(sql, { fromProfileId, toProfileId, amount, reason = null, referenceId = null }) {
+// Sentinel so a soft-fail mid-transfer (e.g. recipient ref collision) rolls the whole
+// transfer back instead of committing a half-applied debit.
+class CoinAbort extends Error {
+  constructor(result) { super('coin-abort'); this.result = result; }
+}
+
+// --- public API: always runs inside sql.begin ---
+
+// Atomic player-to-player transfer. Locks BOTH profiles in id order (deadlock-safe),
+// debits `from`, credits `to`. If either leg soft-fails, the whole transfer rolls back.
+export async function transferCoins(sql, { fromProfileId, toProfileId, amount, reason = null, referenceId }) {
   const from = Number(fromProfileId), to = Number(toProfileId);
   if (!Number.isInteger(from) || !Number.isInteger(to) || from < 1 || to < 1) return { ok: false, reason: 'invalid-profile' };
   if (from === to) return { ok: false, reason: 'self-transfer' };
-  const amt = validateCoinAmount(amount);
-  if (amt === null) return { ok: false, reason: 'invalid-amount' };
-
-  return sql.begin(async (tx) => {
-    // Deterministic lock order prevents deadlock between two opposing transfers.
-    const [lo, hi] = from < to ? [from, to] : [to, from];
-    await lockProfile(tx, lo);
-    await lockProfile(tx, hi);
-
-    if (await priorByRef(tx, from, referenceId)) {
-      return { ok: true, replayed: true, fromBalance: await balanceOf(tx, from), toBalance: await balanceOf(tx, to) };
-    }
-
-    const debit = await debitWithinTx(tx, { profileId: from, amount: amt, type: 'TRANSFER_OUT', reason, referenceId, counterpartyProfileId: to });
-    if (!debit.ok) return debit;
-    const credit = await creditWithinTx(tx, { profileId: to, amount: amt, type: 'TRANSFER_IN', reason, referenceId, counterpartyProfileId: from });
-    return { ok: true, replayed: false, fromBalance: debit.balance, toBalance: credit.balance };
-  });
+  if (validateCoinAmount(amount) === null) return { ok: false, reason: 'invalid-amount' };
+  if (!isValidCoinRef(referenceId)) return { ok: false, reason: 'invalid-reference' };
+  try {
+    return await sql.begin(async (tx) => {
+      const [lo, hi] = from < to ? [from, to] : [to, from];
+      await lockProfile(tx, lo);
+      await lockProfile(tx, hi);
+      const debit = await _debit(tx, { profileId: from, amount, type: 'TRANSFER_OUT', reason, referenceId, counterpartyProfileId: to });
+      if (!debit.ok) throw new CoinAbort(debit);
+      const credit = await _credit(tx, { profileId: to, amount, type: 'TRANSFER_IN', reason, referenceId, counterpartyProfileId: from });
+      if (!credit.ok) throw new CoinAbort(credit); // rolls back the debit
+      return { ok: true, replayed: debit.replayed || credit.replayed, fromBalance: debit.balance, toBalance: credit.balance };
+    });
+  } catch (e) {
+    if (e instanceof CoinAbort) return e.result;
+    throw e;
+  }
 }
 
-// Standalone wrappers (own transaction) for single credits/debits.
-export function creditCoins(sql, opts) { return sql.begin((tx) => creditWithinTx(tx, opts)); }
-export function debitCoins(sql, opts) { return sql.begin((tx) => debitWithinTx(tx, opts)); }
+// Single credit / debit, each in its own transaction.
+export function creditCoins(sql, opts) { return sql.begin((tx) => _credit(tx, opts)); }
+export function debitCoins(sql, opts) { return sql.begin((tx) => _debit(tx, opts)); }
+
+// Atomic multi-op composer for features that move coins alongside other writes
+// (e.g. template remix = debit buyer + credit author + duplicate world, all-or-nothing).
+// The callback receives in-transaction credit/debit bound to a real tx — callers can
+// never accidentally run a coin op outside a transaction.
+export function coinsTransaction(sql, fn) {
+  return sql.begin((tx) => fn({
+    credit: (opts) => _credit(tx, opts),
+    debit: (opts) => _debit(tx, opts),
+    tx,
+  }));
+}
 
 export function getCoinBalance(sql, profileId) {
   return sql`SELECT balance FROM coin_balances WHERE profile_id = ${Number(profileId)}`

--- a/netlify/functions/lib/coins.mjs
+++ b/netlify/functions/lib/coins.mjs
@@ -1,0 +1,115 @@
+// EC1 — Earned GOLD (Coins) primitive: atomic, idempotent, race-safe credit / debit /
+// transfer. The keystone every coin-moving feature (template sales, referral rewards,
+// paid-AI) builds on. Same discipline as the GOLD-spend path (E3):
+//   - a per-profile advisory lock SERIALIZES all coin ops for a profile inside the
+//     transaction, so balance read + check + write can't interleave (no overspend);
+//   - an idempotency key (reference_id) makes retries safe;
+//   - coin_balances.CHECK(balance >= 0) is the ultimate backstop.
+// The *WithinTx functions run inside a caller-provided transaction so a feature can
+// compose them atomically (e.g. remix = debit buyer + credit author + duplicate world).
+
+export const MAX_COIN_AMOUNT = 100_000_000;
+
+export function validateCoinAmount(amount) {
+  const n = Number(amount);
+  if (!Number.isInteger(n) || n <= 0 || n > MAX_COIN_AMOUNT) return null;
+  return n;
+}
+
+async function lockProfile(tx, profileId) {
+  await tx`SELECT pg_advisory_xact_lock(hashtext(${'coin:' + Number(profileId)})::bigint)`;
+}
+
+async function balanceOf(tx, profileId) {
+  const rows = await tx`SELECT balance FROM coin_balances WHERE profile_id = ${Number(profileId)}`;
+  return rows.length ? Number(rows[0].balance) : 0;
+}
+
+async function priorByRef(tx, profileId, referenceId) {
+  if (!referenceId) return null;
+  const rows = await tx`
+    SELECT id FROM coin_ledger
+    WHERE profile_id = ${Number(profileId)} AND reference_id = ${referenceId}
+    LIMIT 1
+  `;
+  return rows.length ? rows[0] : null;
+}
+
+// Credit coins to a profile. Runs inside the caller's transaction `tx`.
+export async function creditWithinTx(tx, { profileId, amount, type = 'CREDIT', reason = null, referenceId = null, counterpartyProfileId = null }) {
+  const amt = validateCoinAmount(amount);
+  if (amt === null) return { ok: false, reason: 'invalid-amount' };
+  await lockProfile(tx, profileId);
+  if (await priorByRef(tx, profileId, referenceId)) {
+    return { ok: true, replayed: true, balance: await balanceOf(tx, profileId) };
+  }
+  const rows = await tx`
+    INSERT INTO coin_balances (profile_id, balance) VALUES (${Number(profileId)}, ${amt})
+    ON CONFLICT (profile_id) DO UPDATE SET balance = coin_balances.balance + ${amt}, updated_at = NOW()
+    RETURNING balance
+  `;
+  await tx`
+    INSERT INTO coin_ledger (profile_id, delta, type, reason, reference_id, counterparty_profile_id)
+    VALUES (${Number(profileId)}, ${amt}, ${type}, ${reason}, ${referenceId}, ${counterpartyProfileId == null ? null : Number(counterpartyProfileId)})
+  `;
+  return { ok: true, replayed: false, balance: Number(rows[0].balance) };
+}
+
+// Debit coins from a profile. Returns { ok:false, reason:'insufficient-coins' } if short.
+export async function debitWithinTx(tx, { profileId, amount, type = 'DEBIT', reason = null, referenceId = null, counterpartyProfileId = null }) {
+  const amt = validateCoinAmount(amount);
+  if (amt === null) return { ok: false, reason: 'invalid-amount' };
+  await lockProfile(tx, profileId);
+  if (await priorByRef(tx, profileId, referenceId)) {
+    return { ok: true, replayed: true, balance: await balanceOf(tx, profileId) };
+  }
+  const bal = await balanceOf(tx, profileId);
+  if (bal < amt) return { ok: false, reason: 'insufficient-coins', balance: bal };
+  // Conditional UPDATE is the backstop even if the lock were ever absent.
+  const rows = await tx`
+    UPDATE coin_balances SET balance = balance - ${amt}, updated_at = NOW()
+    WHERE profile_id = ${Number(profileId)} AND balance >= ${amt}
+    RETURNING balance
+  `;
+  if (!rows.length) return { ok: false, reason: 'insufficient-coins', balance: bal };
+  await tx`
+    INSERT INTO coin_ledger (profile_id, delta, type, reason, reference_id, counterparty_profile_id)
+    VALUES (${Number(profileId)}, ${-amt}, ${type}, ${reason}, ${referenceId}, ${counterpartyProfileId == null ? null : Number(counterpartyProfileId)})
+  `;
+  return { ok: true, replayed: false, balance: Number(rows[0].balance) };
+}
+
+// Atomic player-to-player transfer: debit `from`, credit `to`, in ONE transaction.
+// Locks both profiles in id order to avoid deadlock. Idempotent on `from`'s reference_id.
+export async function transferCoins(sql, { fromProfileId, toProfileId, amount, reason = null, referenceId = null }) {
+  const from = Number(fromProfileId), to = Number(toProfileId);
+  if (!Number.isInteger(from) || !Number.isInteger(to) || from < 1 || to < 1) return { ok: false, reason: 'invalid-profile' };
+  if (from === to) return { ok: false, reason: 'self-transfer' };
+  const amt = validateCoinAmount(amount);
+  if (amt === null) return { ok: false, reason: 'invalid-amount' };
+
+  return sql.begin(async (tx) => {
+    // Deterministic lock order prevents deadlock between two opposing transfers.
+    const [lo, hi] = from < to ? [from, to] : [to, from];
+    await lockProfile(tx, lo);
+    await lockProfile(tx, hi);
+
+    if (await priorByRef(tx, from, referenceId)) {
+      return { ok: true, replayed: true, fromBalance: await balanceOf(tx, from), toBalance: await balanceOf(tx, to) };
+    }
+
+    const debit = await debitWithinTx(tx, { profileId: from, amount: amt, type: 'TRANSFER_OUT', reason, referenceId, counterpartyProfileId: to });
+    if (!debit.ok) return debit;
+    const credit = await creditWithinTx(tx, { profileId: to, amount: amt, type: 'TRANSFER_IN', reason, referenceId, counterpartyProfileId: from });
+    return { ok: true, replayed: false, fromBalance: debit.balance, toBalance: credit.balance };
+  });
+}
+
+// Standalone wrappers (own transaction) for single credits/debits.
+export function creditCoins(sql, opts) { return sql.begin((tx) => creditWithinTx(tx, opts)); }
+export function debitCoins(sql, opts) { return sql.begin((tx) => debitWithinTx(tx, opts)); }
+
+export function getCoinBalance(sql, profileId) {
+  return sql`SELECT balance FROM coin_balances WHERE profile_id = ${Number(profileId)}`
+    .then((rows) => (rows.length ? Number(rows[0].balance) : 0));
+}

--- a/tests/coins-validate.test.mjs
+++ b/tests/coins-validate.test.mjs
@@ -4,7 +4,7 @@
 // live-DB rollback smoke test + integration plan, not unit tests.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateCoinAmount, MAX_COIN_AMOUNT } from '../netlify/functions/lib/coins.mjs';
+import { validateCoinAmount, MAX_COIN_AMOUNT, isValidCoinRef } from '../netlify/functions/lib/coins.mjs';
 
 test('accepts positive integers within range', () => {
   assert.equal(validateCoinAmount(1), 1);
@@ -26,4 +26,15 @@ test('rejects non-integers and junk', () => {
   assert.equal(validateCoinAmount(undefined), null);
   assert.equal(validateCoinAmount(NaN), null);
   assert.equal(validateCoinAmount(Infinity), null);
+});
+
+test('coin refs must be non-empty, bounded, server-key-shaped (idempotency requires one)', () => {
+  assert.equal(isValidCoinRef('remix:42:1718000000'), true);
+  assert.equal(isValidCoinRef('a1b2c3d4'), true); // 8 chars min
+  assert.equal(isValidCoinRef('short'), false);   // < 8
+  assert.equal(isValidCoinRef(''), false);
+  assert.equal(isValidCoinRef(null), false);
+  assert.equal(isValidCoinRef(undefined), false);
+  assert.equal(isValidCoinRef('has spaces!'), false);
+  assert.equal(isValidCoinRef('x'.repeat(129)), false); // > 128
 });

--- a/tests/coins-validate.test.mjs
+++ b/tests/coins-validate.test.mjs
@@ -1,0 +1,29 @@
+// tests/coins-validate.test.mjs
+// EC1: the pure amount-validation gate every coin credit/debit/transfer passes through.
+// The atomic DB behaviour (advisory lock, idempotency, balance >= 0) is covered by the
+// live-DB rollback smoke test + integration plan, not unit tests.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateCoinAmount, MAX_COIN_AMOUNT } from '../netlify/functions/lib/coins.mjs';
+
+test('accepts positive integers within range', () => {
+  assert.equal(validateCoinAmount(1), 1);
+  assert.equal(validateCoinAmount(500), 500);
+  assert.equal(validateCoinAmount(MAX_COIN_AMOUNT), MAX_COIN_AMOUNT);
+});
+
+test('rejects zero, negative, and over-cap amounts', () => {
+  assert.equal(validateCoinAmount(0), null);
+  assert.equal(validateCoinAmount(-5), null);
+  assert.equal(validateCoinAmount(MAX_COIN_AMOUNT + 1), null);
+});
+
+test('rejects non-integers and junk', () => {
+  assert.equal(validateCoinAmount(1.5), null);
+  assert.equal(validateCoinAmount('10'), 10); // numeric string coerces to a valid integer
+  assert.equal(validateCoinAmount('abc'), null);
+  assert.equal(validateCoinAmount(null), null);
+  assert.equal(validateCoinAmount(undefined), null);
+  assert.equal(validateCoinAmount(NaN), null);
+  assert.equal(validateCoinAmount(Infinity), null);
+});


### PR DESCRIPTION
**Do not merge.** Economy launch gate — reviewed + staged.

The keystone for the transferable currency (your **two-balance decision, D2**). Template sales (T2), referral rewards (G1), paid-AI (AI1) all move **Earned GOLD** through this — kept separate from non-transferable holdings-based Allowance GOLD.

## What
- **Migration**: `coin_balances` (source of truth, `CHECK balance >= 0`) + `coin_ledger` (append-only audit) + partial unique index for idempotency.
- **`lib/coins.mjs`** — atomic, idempotent, race-safe primitives:
  - `creditWithinTx` / `debitWithinTx` — compose inside a caller's transaction (so e.g. remix = debit buyer + credit author + duplicate world, all atomic).
  - `transferCoins` — own transaction, **dual-lock in id order** (deadlock-safe), idempotent.
  - Same rigor as E3: per-profile `pg_advisory_xact_lock` serializes ops; `reference_id` idempotency; conditional `UPDATE ... WHERE balance >= amt` + `CHECK` backstop against overspend.
- **`GET /api/me/coins`** — authenticated balance + recent ledger (coins are never client-written).

## Verification
- 3 pure unit tests (`validateCoinAmount`); `npm run check` + full suite pass.
- **Live-DB rollback smoke test PASSED** (nothing persisted): credit→100, replay→100 (no double), debit→70, replay→70, overspend→insufficient (70 intact), transfer→A50/B20, transfer-replay (no double).

## Follow-ups (pre-launch)
- Full integration test for `transferCoins` (own-tx + dual-lock) + a concurrency harness.
- Then T2 (template paid remix), G1 (referrals), AI1 (paid-AI) build on this.

Codex adversarial pass running; verdict to follow.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK