### PR TITLE
[HOLD: economy preview] G1 — referral rewards (earned, on EC1)

### DIFF
--- a/netlify/database/migrations/20260624140000_coins_earned_gold.sql
+++ b/netlify/database/migrations/20260624140000_coins_earned_gold.sql
@@ -21,7 +21,13 @@ CREATE TABLE IF NOT EXISTS coin_ledger (
   reason TEXT,
   reference_id TEXT,
   counterparty_profile_id BIGINT REFERENCES profiles(id) ON DELETE SET NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- Audit integrity: a credit must be positive, a debit negative — so a poisoned
+  -- caller cannot record a positive DEBIT or negative CREDIT.
+  CONSTRAINT coin_ledger_sign_type CHECK (
+    (delta > 0 AND type IN ('CREDIT', 'TRANSFER_IN')) OR
+    (delta < 0 AND type IN ('DEBIT', 'TRANSFER_OUT'))
+  )
 );
 
 CREATE INDEX IF NOT EXISTS idx_coin_ledger_profile ON coin_ledger (profile_id, created_at DESC);

--- a/netlify/database/migrations/20260624140000_coins_earned_gold.sql
+++ b/netlify/database/migrations/20260624140000_coins_earned_gold.sql
@@ -1,0 +1,33 @@
+-- EC1 — "Earned GOLD" (Coins): the transferable in-game currency (owner decision D2).
+-- Distinct from holdings-based Allowance GOLD (gold_ledger_events), which stays
+-- non-transferable. Coins are earned (template sales, referral rewards, paid actions)
+-- and spent/transferred player-to-player.
+--
+-- coin_balances is the source of truth for spend checks (CHECK keeps it >= 0, the
+-- ultimate backstop against overspend). coin_ledger is the append-only audit trail
+-- and the idempotency surface.
+
+CREATE TABLE IF NOT EXISTS coin_balances (
+  profile_id BIGINT PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+  balance BIGINT NOT NULL DEFAULT 0 CHECK (balance >= 0),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS coin_ledger (
+  id BIGSERIAL PRIMARY KEY,
+  profile_id BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  delta BIGINT NOT NULL CHECK (delta <> 0),
+  type TEXT NOT NULL CHECK (type IN ('CREDIT', 'DEBIT', 'TRANSFER_IN', 'TRANSFER_OUT')),
+  reason TEXT,
+  reference_id TEXT,
+  counterparty_profile_id BIGINT REFERENCES profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_coin_ledger_profile ON coin_ledger (profile_id, created_at DESC);
+
+-- Idempotency: at most one ledger entry per (profile_id, reference_id) when a key is
+-- supplied, so a retried credit/debit/transfer never double-applies.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_coin_ledger_profile_ref
+  ON coin_ledger (profile_id, reference_id)
+  WHERE reference_id IS NOT NULL;

--- a/netlify/database/migrations/20260624150000_world_templates.sql
+++ b/netlify/database/migrations/20260624150000_world_templates.sql
@@ -1,0 +1,15 @@
+-- T2 — world templates. An owner can list a world as a template with an Earned GOLD
+-- (Coins) price; others pay to remix it (duplicate into their own editable copy).
+-- Builds on EC1 (coin_ledger) for the payment + author payout.
+ALTER TABLE worlds ADD COLUMN IF NOT EXISTS is_template BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE worlds ADD COLUMN IF NOT EXISTS template_price BIGINT;          -- in Earned GOLD; NULL unless listed
+ALTER TABLE worlds ADD COLUMN IF NOT EXISTS template_author_id BIGINT REFERENCES profiles(id) ON DELETE SET NULL;
+ALTER TABLE worlds ADD COLUMN IF NOT EXISTS remix_count INTEGER NOT NULL DEFAULT 0;
+
+-- Price bounds: a listed template must have a non-negative, sane price.
+DO $$ BEGIN
+  ALTER TABLE worlds ADD CONSTRAINT worlds_template_price_ck
+    CHECK (template_price IS NULL OR (template_price >= 0 AND template_price <= 1000000));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS idx_worlds_is_template ON worlds (is_template) WHERE is_template = TRUE;

--- a/netlify/database/migrations/20260624150000_world_templates.sql
+++ b/netlify/database/migrations/20260624150000_world_templates.sql
@@ -13,3 +13,19 @@ DO $$ BEGIN
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 CREATE INDEX IF NOT EXISTS idx_worlds_is_template ON worlds (is_template) WHERE is_template = TRUE;
+
+-- Durable remix operation log: the idempotency surface for BOTH free and paid remixes
+-- (a retry with the same (buyer, key) returns the original build instead of making a
+-- second one), and it binds a key to a specific world (reuse across worlds is rejected).
+CREATE TABLE IF NOT EXISTS world_remixes (
+  id BIGSERIAL PRIMARY KEY,
+  buyer_profile_id BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  world_id BIGINT NOT NULL REFERENCES worlds(id) ON DELETE CASCADE,
+  build_id BIGINT REFERENCES builds(id) ON DELETE SET NULL,
+  author_profile_id BIGINT REFERENCES profiles(id) ON DELETE SET NULL,
+  price BIGINT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_world_remixes_buyer_key
+  ON world_remixes (buyer_profile_id, idempotency_key);

--- a/netlify/database/migrations/20260624160000_referrals.sql
+++ b/netlify/database/migrations/20260624160000_referrals.sql
@@ -18,3 +18,13 @@ CREATE TABLE IF NOT EXISTS referrals (
   CONSTRAINT referrals_no_self CHECK (referrer_profile_id <> referee_profile_id)
 );
 CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals (referrer_profile_id, status);
+
+-- Race-free per-referrer per-cycle reward cap: a single counter row updated atomically
+-- (INSERT ... ON CONFLICT DO UPDATE ... WHERE count < cap RETURNING) so concurrent
+-- payouts for different referees under one referrer can't all slip past the cap.
+CREATE TABLE IF NOT EXISTS referral_reward_counters (
+  referrer_profile_id BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  cycle_id TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (referrer_profile_id, cycle_id)
+);

--- a/netlify/database/migrations/20260624160000_referrals.sql
+++ b/netlify/database/migrations/20260624160000_referrals.sql
@@ -1,0 +1,20 @@
+-- G1 — referral rewards (earned, not given). A referrer earns Earned GOLD only AFTER
+-- the referee completes a verified action (publishes a world). Each user can be
+-- referred at most once (referee UNIQUE); self-referral is blocked; rewards are capped
+-- per referrer per weekly cycle.
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS referral_code TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_profiles_referral_code
+  ON profiles (referral_code) WHERE referral_code IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS referrals (
+  id BIGSERIAL PRIMARY KEY,
+  referrer_profile_id BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  referee_profile_id BIGINT NOT NULL UNIQUE REFERENCES profiles(id) ON DELETE CASCADE,
+  code TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'rewarded', 'rejected')),
+  cycle_id TEXT,
+  rewarded_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT referrals_no_self CHECK (referrer_profile_id <> referee_profile_id)
+);
+CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals (referrer_profile_id, status);

--- a/netlify/functions/coins.mjs
+++ b/netlify/functions/coins.mjs
@@ -1,0 +1,43 @@
+import { requireAuthUser } from './lib/auth.mjs';
+import { ensureProfile } from './lib/profiles.mjs';
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse } from './lib/http.mjs';
+import { getCoinBalance } from './lib/coins.mjs';
+
+export const config = { path: '/api/me/coins' };
+
+// Read the authenticated player's Earned GOLD (Coins) balance + recent ledger.
+// Coins are MOVED only by the server-authoritative primitives in lib/coins.mjs
+// (template sales, referral rewards, paid actions) — never written from the client.
+const isMissingSchema = (err) => isMissingRelations(err, ['coin_balances', 'coin_ledger']);
+
+export default async function coins(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'GET') return errorResponse('Method not allowed', 405, origin);
+
+  const auth = await requireAuthUser(request, origin);
+  if (auth.response) return auth.response;
+
+  try {
+    const sql = getSql();
+    const profile = await ensureProfile(auth.user);
+    const balance = await getCoinBalance(sql, profile.id);
+    let recent = [];
+    try {
+      recent = await sql`
+        SELECT delta, type, reason, created_at AS "createdAt"
+        FROM coin_ledger
+        WHERE profile_id = ${Number(profile.id)}
+        ORDER BY created_at DESC, id DESC
+        LIMIT 20
+      `;
+    } catch (_) { recent = []; }
+    return jsonResponse({ balance, recent }, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingSchema(err)) {
+      return jsonResponse({ balance: 0, recent: [] }, origin);
+    }
+    return errorResponse('coins-failed', 500, origin);
+  }
+}

--- a/netlify/functions/lib/coins.mjs
+++ b/netlify/functions/lib/coins.mjs
@@ -1,12 +1,15 @@
 // EC1 — Earned GOLD (Coins) primitive: atomic, idempotent, race-safe credit / debit /
 // transfer. The keystone every coin-moving feature (template sales, referral rewards,
-// paid-AI) builds on. Same discipline as the GOLD-spend path (E3):
+// paid-AI) builds on. Discipline (hardened per adversarial review):
 //   - a per-profile advisory lock SERIALIZES all coin ops for a profile inside the
 //     transaction, so balance read + check + write can't interleave (no overspend);
-//   - an idempotency key (reference_id) makes retries safe;
-//   - coin_balances.CHECK(balance >= 0) is the ultimate backstop.
-// The *WithinTx functions run inside a caller-provided transaction so a feature can
-// compose them atomically (e.g. remix = debit buyer + credit author + duplicate world).
+//   - EVERY money move requires a non-empty server-generated idempotency key
+//     (reference_id), and replays are bound to a FINGERPRINT (amount + type +
+//     counterparty) — a key reused for a different op is rejected, not silently replayed;
+//   - coin_balances.CHECK(balance >= 0) and the ledger sign/type CHECK are DB backstops;
+//   - the raw in-tx helpers are NOT exported — features compose via coinsTransaction()
+//     / the wrappers, which always run inside sql.begin (the advisory xact lock is
+//     worthless outside a transaction, so we never let a caller pass the root sql).
 
 export const MAX_COIN_AMOUNT = 100_000_000;
 
@@ -14,6 +17,10 @@ export function validateCoinAmount(amount) {
   const n = Number(amount);
   if (!Number.isInteger(n) || n <= 0 || n > MAX_COIN_AMOUNT) return null;
   return n;
+}
+
+export function isValidCoinRef(referenceId) {
+  return typeof referenceId === 'string' && /^[A-Za-z0-9._:-]{8,128}$/.test(referenceId);
 }
 
 async function lockProfile(tx, profileId) {
@@ -26,21 +33,32 @@ async function balanceOf(tx, profileId) {
 }
 
 async function priorByRef(tx, profileId, referenceId) {
-  if (!referenceId) return null;
   const rows = await tx`
-    SELECT id FROM coin_ledger
+    SELECT delta, type, counterparty_profile_id AS cpid FROM coin_ledger
     WHERE profile_id = ${Number(profileId)} AND reference_id = ${referenceId}
     LIMIT 1
   `;
   return rows.length ? rows[0] : null;
 }
 
-// Credit coins to a profile. Runs inside the caller's transaction `tx`.
-export async function creditWithinTx(tx, { profileId, amount, type = 'CREDIT', reason = null, referenceId = null, counterpartyProfileId = null }) {
+function fingerprintMatches(prior, { delta, type, counterpartyProfileId }) {
+  const priorCp = prior.cpid == null ? null : Number(prior.cpid);
+  const wantCp = counterpartyProfileId == null ? null : Number(counterpartyProfileId);
+  return Number(prior.delta) === delta && String(prior.type) === type && priorCp === wantCp;
+}
+
+// --- raw in-transaction helpers (module-private; require a real tx + a valid ref) ---
+
+async function _credit(tx, { profileId, amount, type = 'CREDIT', reason = null, referenceId, counterpartyProfileId = null }) {
   const amt = validateCoinAmount(amount);
   if (amt === null) return { ok: false, reason: 'invalid-amount' };
+  if (!isValidCoinRef(referenceId)) return { ok: false, reason: 'invalid-reference' };
   await lockProfile(tx, profileId);
-  if (await priorByRef(tx, profileId, referenceId)) {
+  const prior = await priorByRef(tx, profileId, referenceId);
+  if (prior) {
+    if (!fingerprintMatches(prior, { delta: amt, type, counterpartyProfileId })) {
+      return { ok: false, reason: 'idempotency-key-reused' };
+    }
     return { ok: true, replayed: true, balance: await balanceOf(tx, profileId) };
   }
   const rows = await tx`
@@ -55,17 +73,20 @@ export async function creditWithinTx(tx, { profileId, amount, type = 'CREDIT', r
   return { ok: true, replayed: false, balance: Number(rows[0].balance) };
 }
 
-// Debit coins from a profile. Returns { ok:false, reason:'insufficient-coins' } if short.
-export async function debitWithinTx(tx, { profileId, amount, type = 'DEBIT', reason = null, referenceId = null, counterpartyProfileId = null }) {
+async function _debit(tx, { profileId, amount, type = 'DEBIT', reason = null, referenceId, counterpartyProfileId = null }) {
   const amt = validateCoinAmount(amount);
   if (amt === null) return { ok: false, reason: 'invalid-amount' };
+  if (!isValidCoinRef(referenceId)) return { ok: false, reason: 'invalid-reference' };
   await lockProfile(tx, profileId);
-  if (await priorByRef(tx, profileId, referenceId)) {
+  const prior = await priorByRef(tx, profileId, referenceId);
+  if (prior) {
+    if (!fingerprintMatches(prior, { delta: -amt, type, counterpartyProfileId })) {
+      return { ok: false, reason: 'idempotency-key-reused' };
+    }
     return { ok: true, replayed: true, balance: await balanceOf(tx, profileId) };
   }
   const bal = await balanceOf(tx, profileId);
   if (bal < amt) return { ok: false, reason: 'insufficient-coins', balance: bal };
-  // Conditional UPDATE is the backstop even if the lock were ever absent.
   const rows = await tx`
     UPDATE coin_balances SET balance = balance - ${amt}, updated_at = NOW()
     WHERE profile_id = ${Number(profileId)} AND balance >= ${amt}
@@ -79,35 +100,54 @@ export async function debitWithinTx(tx, { profileId, amount, type = 'DEBIT', rea
   return { ok: true, replayed: false, balance: Number(rows[0].balance) };
 }
 
-// Atomic player-to-player transfer: debit `from`, credit `to`, in ONE transaction.
-// Locks both profiles in id order to avoid deadlock. Idempotent on `from`'s reference_id.
-export async function transferCoins(sql, { fromProfileId, toProfileId, amount, reason = null, referenceId = null }) {
+// Sentinel so a soft-fail mid-transfer (e.g. recipient ref collision) rolls the whole
+// transfer back instead of committing a half-applied debit.
+class CoinAbort extends Error {
+  constructor(result) { super('coin-abort'); this.result = result; }
+}
+
+// --- public API: always runs inside sql.begin ---
+
+// Atomic player-to-player transfer. Locks BOTH profiles in id order (deadlock-safe),
+// debits `from`, credits `to`. If either leg soft-fails, the whole transfer rolls back.
+export async function transferCoins(sql, { fromProfileId, toProfileId, amount, reason = null, referenceId }) {
   const from = Number(fromProfileId), to = Number(toProfileId);
   if (!Number.isInteger(from) || !Number.isInteger(to) || from < 1 || to < 1) return { ok: false, reason: 'invalid-profile' };
   if (from === to) return { ok: false, reason: 'self-transfer' };
-  const amt = validateCoinAmount(amount);
-  if (amt === null) return { ok: false, reason: 'invalid-amount' };
-
-  return sql.begin(async (tx) => {
-    // Deterministic lock order prevents deadlock between two opposing transfers.
-    const [lo, hi] = from < to ? [from, to] : [to, from];
-    await lockProfile(tx, lo);
-    await lockProfile(tx, hi);
-
-    if (await priorByRef(tx, from, referenceId)) {
-      return { ok: true, replayed: true, fromBalance: await balanceOf(tx, from), toBalance: await balanceOf(tx, to) };
-    }
-
-    const debit = await debitWithinTx(tx, { profileId: from, amount: amt, type: 'TRANSFER_OUT', reason, referenceId, counterpartyProfileId: to });
-    if (!debit.ok) return debit;
-    const credit = await creditWithinTx(tx, { profileId: to, amount: amt, type: 'TRANSFER_IN', reason, referenceId, counterpartyProfileId: from });
-    return { ok: true, replayed: false, fromBalance: debit.balance, toBalance: credit.balance };
-  });
+  if (validateCoinAmount(amount) === null) return { ok: false, reason: 'invalid-amount' };
+  if (!isValidCoinRef(referenceId)) return { ok: false, reason: 'invalid-reference' };
+  try {
+    return await sql.begin(async (tx) => {
+      const [lo, hi] = from < to ? [from, to] : [to, from];
+      await lockProfile(tx, lo);
+      await lockProfile(tx, hi);
+      const debit = await _debit(tx, { profileId: from, amount, type: 'TRANSFER_OUT', reason, referenceId, counterpartyProfileId: to });
+      if (!debit.ok) throw new CoinAbort(debit);
+      const credit = await _credit(tx, { profileId: to, amount, type: 'TRANSFER_IN', reason, referenceId, counterpartyProfileId: from });
+      if (!credit.ok) throw new CoinAbort(credit); // rolls back the debit
+      return { ok: true, replayed: debit.replayed || credit.replayed, fromBalance: debit.balance, toBalance: credit.balance };
+    });
+  } catch (e) {
+    if (e instanceof CoinAbort) return e.result;
+    throw e;
+  }
 }
 
-// Standalone wrappers (own transaction) for single credits/debits.
-export function creditCoins(sql, opts) { return sql.begin((tx) => creditWithinTx(tx, opts)); }
-export function debitCoins(sql, opts) { return sql.begin((tx) => debitWithinTx(tx, opts)); }
+// Single credit / debit, each in its own transaction.
+export function creditCoins(sql, opts) { return sql.begin((tx) => _credit(tx, opts)); }
+export function debitCoins(sql, opts) { return sql.begin((tx) => _debit(tx, opts)); }
+
+// Atomic multi-op composer for features that move coins alongside other writes
+// (e.g. template remix = debit buyer + credit author + duplicate world, all-or-nothing).
+// The callback receives in-transaction credit/debit bound to a real tx — callers can
+// never accidentally run a coin op outside a transaction.
+export function coinsTransaction(sql, fn) {
+  return sql.begin((tx) => fn({
+    credit: (opts) => _credit(tx, opts),
+    debit: (opts) => _debit(tx, opts),
+    tx,
+  }));
+}
 
 export function getCoinBalance(sql, profileId) {
   return sql`SELECT balance FROM coin_balances WHERE profile_id = ${Number(profileId)}`

--- a/netlify/functions/lib/coins.mjs
+++ b/netlify/functions/lib/coins.mjs
@@ -1,0 +1,115 @@
+// EC1 — Earned GOLD (Coins) primitive: atomic, idempotent, race-safe credit / debit /
+// transfer. The keystone every coin-moving feature (template sales, referral rewards,
+// paid-AI) builds on. Same discipline as the GOLD-spend path (E3):
+//   - a per-profile advisory lock SERIALIZES all coin ops for a profile inside the
+//     transaction, so balance read + check + write can't interleave (no overspend);
+//   - an idempotency key (reference_id) makes retries safe;
+//   - coin_balances.CHECK(balance >= 0) is the ultimate backstop.
+// The *WithinTx functions run inside a caller-provided transaction so a feature can
+// compose them atomically (e.g. remix = debit buyer + credit author + duplicate world).
+
+export const MAX_COIN_AMOUNT = 100_000_000;
+
+export function validateCoinAmount(amount) {
+  const n = Number(amount);
+  if (!Number.isInteger(n) || n <= 0 || n > MAX_COIN_AMOUNT) return null;
+  return n;
+}
+
+async function lockProfile(tx, profileId) {
+  await tx`SELECT pg_advisory_xact_lock(hashtext(${'coin:' + Number(profileId)})::bigint)`;
+}
+
+async function balanceOf(tx, profileId) {
+  const rows = await tx`SELECT balance FROM coin_balances WHERE profile_id = ${Number(profileId)}`;
+  return rows.length ? Number(rows[0].balance) : 0;
+}
+
+async function priorByRef(tx, profileId, referenceId) {
+  if (!referenceId) return null;
+  const rows = await tx`
+    SELECT id FROM coin_ledger
+    WHERE profile_id = ${Number(profileId)} AND reference_id = ${referenceId}
+    LIMIT 1
+  `;
+  return rows.length ? rows[0] : null;
+}
+
+// Credit coins to a profile. Runs inside the caller's transaction `tx`.
+export async function creditWithinTx(tx, { profileId, amount, type = 'CREDIT', reason = null, referenceId = null, counterpartyProfileId = null }) {
+  const amt = validateCoinAmount(amount);
+  if (amt === null) return { ok: false, reason: 'invalid-amount' };
+  await lockProfile(tx, profileId);
+  if (await priorByRef(tx, profileId, referenceId)) {
+    return { ok: true, replayed: true, balance: await balanceOf(tx, profileId) };
+  }
+  const rows = await tx`
+    INSERT INTO coin_balances (profile_id, balance) VALUES (${Number(profileId)}, ${amt})
+    ON CONFLICT (profile_id) DO UPDATE SET balance = coin_balances.balance + ${amt}, updated_at = NOW()
+    RETURNING balance
+  `;
+  await tx`
+    INSERT INTO coin_ledger (profile_id, delta, type, reason, reference_id, counterparty_profile_id)
+    VALUES (${Number(profileId)}, ${amt}, ${type}, ${reason}, ${referenceId}, ${counterpartyProfileId == null ? null : Number(counterpartyProfileId)})
+  `;
+  return { ok: true, replayed: false, balance: Number(rows[0].balance) };
+}
+
+// Debit coins from a profile. Returns { ok:false, reason:'insufficient-coins' } if short.
+export async function debitWithinTx(tx, { profileId, amount, type = 'DEBIT', reason = null, referenceId = null, counterpartyProfileId = null }) {
+  const amt = validateCoinAmount(amount);
+  if (amt === null) return { ok: false, reason: 'invalid-amount' };
+  await lockProfile(tx, profileId);
+  if (await priorByRef(tx, profileId, referenceId)) {
+    return { ok: true, replayed: true, balance: await balanceOf(tx, profileId) };
+  }
+  const bal = await balanceOf(tx, profileId);
+  if (bal < amt) return { ok: false, reason: 'insufficient-coins', balance: bal };
+  // Conditional UPDATE is the backstop even if the lock were ever absent.
+  const rows = await tx`
+    UPDATE coin_balances SET balance = balance - ${amt}, updated_at = NOW()
+    WHERE profile_id = ${Number(profileId)} AND balance >= ${amt}
+    RETURNING balance
+  `;
+  if (!rows.length) return { ok: false, reason: 'insufficient-coins', balance: bal };
+  await tx`
+    INSERT INTO coin_ledger (profile_id, delta, type, reason, reference_id, counterparty_profile_id)
+    VALUES (${Number(profileId)}, ${-amt}, ${type}, ${reason}, ${referenceId}, ${counterpartyProfileId == null ? null : Number(counterpartyProfileId)})
+  `;
+  return { ok: true, replayed: false, balance: Number(rows[0].balance) };
+}
+
+// Atomic player-to-player transfer: debit `from`, credit `to`, in ONE transaction.
+// Locks both profiles in id order to avoid deadlock. Idempotent on `from`'s reference_id.
+export async function transferCoins(sql, { fromProfileId, toProfileId, amount, reason = null, referenceId = null }) {
+  const from = Number(fromProfileId), to = Number(toProfileId);
+  if (!Number.isInteger(from) || !Number.isInteger(to) || from < 1 || to < 1) return { ok: false, reason: 'invalid-profile' };
+  if (from === to) return { ok: false, reason: 'self-transfer' };
+  const amt = validateCoinAmount(amount);
+  if (amt === null) return { ok: false, reason: 'invalid-amount' };
+
+  return sql.begin(async (tx) => {
+    // Deterministic lock order prevents deadlock between two opposing transfers.
+    const [lo, hi] = from < to ? [from, to] : [to, from];
+    await lockProfile(tx, lo);
+    await lockProfile(tx, hi);
+
+    if (await priorByRef(tx, from, referenceId)) {
+      return { ok: true, replayed: true, fromBalance: await balanceOf(tx, from), toBalance: await balanceOf(tx, to) };
+    }
+
+    const debit = await debitWithinTx(tx, { profileId: from, amount: amt, type: 'TRANSFER_OUT', reason, referenceId, counterpartyProfileId: to });
+    if (!debit.ok) return debit;
+    const credit = await creditWithinTx(tx, { profileId: to, amount: amt, type: 'TRANSFER_IN', reason, referenceId, counterpartyProfileId: from });
+    return { ok: true, replayed: false, fromBalance: debit.balance, toBalance: credit.balance };
+  });
+}
+
+// Standalone wrappers (own transaction) for single credits/debits.
+export function creditCoins(sql, opts) { return sql.begin((tx) => creditWithinTx(tx, opts)); }
+export function debitCoins(sql, opts) { return sql.begin((tx) => debitWithinTx(tx, opts)); }
+
+export function getCoinBalance(sql, profileId) {
+  return sql`SELECT balance FROM coin_balances WHERE profile_id = ${Number(profileId)}`
+    .then((rows) => (rows.length ? Number(rows[0].balance) : 0));
+}

--- a/netlify/functions/lib/referrals.mjs
+++ b/netlify/functions/lib/referrals.mjs
@@ -81,12 +81,25 @@ export async function maybeRewardReferral(sql, refereeId, now = new Date()) {
       const referralId = Number(rows[0].id);
       const referrer = Number(rows[0].referrer_profile_id);
 
-      // Per-referrer per-cycle cap (anti-farming).
-      const capRows = await tx`
-        SELECT count(*)::int AS n FROM referrals
-        WHERE referrer_profile_id = ${referrer} AND status = 'rewarded' AND cycle_id = ${cycleId}
+      // Anti-Sybil: the referee must have a VERIFIED wallet before the reward pays.
+      // Each fake referee would need a distinct real Solana keypair + the signature
+      // flow — far harder to farm than free accounts. If not yet, leave it pending
+      // (it pays on a later publish once they've linked + verified a wallet).
+      const w = await tx`SELECT 1 FROM wallet_accounts WHERE profile_id = ${ref} AND verified_at IS NOT NULL LIMIT 1`;
+      if (!w.length) return { rewarded: false, reason: 'referee-no-verified-wallet' };
+
+      // Race-free per-referrer per-cycle cap: atomic increment that only succeeds while
+      // under the cap. Empty RETURNING => cap reached. Increment rolls back with the tx
+      // if a later credit fails, so the counter only counts paid rewards.
+      const cap = await tx`
+        INSERT INTO referral_reward_counters (referrer_profile_id, cycle_id, count)
+        VALUES (${referrer}, ${cycleId}, 1)
+        ON CONFLICT (referrer_profile_id, cycle_id)
+        DO UPDATE SET count = referral_reward_counters.count + 1
+        WHERE referral_reward_counters.count < ${MAX_REWARDS_PER_CYCLE}
+        RETURNING count
       `;
-      if (Number(capRows[0].n) >= MAX_REWARDS_PER_CYCLE) {
+      if (!cap.length) {
         await tx`UPDATE referrals SET status = 'rejected', cycle_id = ${cycleId} WHERE id = ${referralId}`;
         return { rewarded: false, reason: 'cap-reached' };
       }

--- a/netlify/functions/lib/referrals.mjs
+++ b/netlify/functions/lib/referrals.mjs
@@ -1,0 +1,106 @@
+import { coinsTransaction } from './coins.mjs';
+import { currentCycleId } from '../../../packages/tinyworld-mmo-core/src/index.js';
+
+// G1 — referral rewards. Earned, not given: the referrer is paid Earned GOLD only after
+// the referee completes a verified action (publishing a world). Capped per cycle.
+export const REFERRER_REWARD = 50;
+export const REFEREE_REWARD = 25;
+export const MAX_REWARDS_PER_CYCLE = 10; // per referrer per weekly cycle
+
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no ambiguous 0/O/1/I
+
+export function isValidReferralCode(code) {
+  return typeof code === 'string' && /^[A-Za-z0-9]{6,16}$/.test(code.trim());
+}
+
+export function randomReferralCode(len = 8) {
+  let s = '';
+  for (let i = 0; i < len; i++) s += CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)];
+  return s;
+}
+
+// Return the profile's referral code, generating + persisting a unique one if absent.
+export async function ensureReferralCode(sql, profileId) {
+  const cur = await sql`SELECT referral_code FROM profiles WHERE id = ${Number(profileId)}`;
+  if (cur.length && cur[0].referral_code) return cur[0].referral_code;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const code = randomReferralCode();
+    try {
+      const upd = await sql`
+        UPDATE profiles SET referral_code = ${code}, updated_at = NOW()
+        WHERE id = ${Number(profileId)} AND referral_code IS NULL
+        RETURNING referral_code
+      `;
+      if (upd.length) return upd[0].referral_code;
+      // Already set concurrently — read it back.
+      const re = await sql`SELECT referral_code FROM profiles WHERE id = ${Number(profileId)}`;
+      if (re.length && re[0].referral_code) return re[0].referral_code;
+    } catch (e) { /* unique collision on the code — retry with a new one */ }
+  }
+  return null;
+}
+
+// Record that `refereeId` was referred by the owner of `code`. Idempotent (referee is
+// UNIQUE). Returns { ok, reason }. Validations: code exists, not self, referee not
+// already referred.
+export async function recordReferral(sql, { refereeId, code }) {
+  const ref = Number(refereeId);
+  if (!isValidReferralCode(code)) return { ok: false, reason: 'invalid-code' };
+  const owner = await sql`SELECT id FROM profiles WHERE referral_code = ${String(code).trim()} LIMIT 1`;
+  if (!owner.length) return { ok: false, reason: 'code-not-found' };
+  const referrer = Number(owner[0].id);
+  if (referrer === ref) return { ok: false, reason: 'self-referral' };
+  const ins = await sql`
+    INSERT INTO referrals (referrer_profile_id, referee_profile_id, code, status)
+    VALUES (${referrer}, ${ref}, ${String(code).trim()}, 'pending')
+    ON CONFLICT (referee_profile_id) DO NOTHING
+    RETURNING id
+  `;
+  if (!ins.length) return { ok: false, reason: 'already-referred' };
+  return { ok: true, referrerId: referrer };
+}
+
+// Called when a referee completes the VERIFIED action (publishes a world). Pays the
+// referrer + referee once, atomically, if a pending referral exists and the referrer is
+// under their per-cycle cap. Safe to call on every publish (idempotent: pending->rewarded
+// under a lock; never double-pays). Returns { rewarded:boolean, reason? }.
+export async function maybeRewardReferral(sql, refereeId, now = new Date()) {
+  const ref = Number(refereeId);
+  if (!Number.isInteger(ref) || ref < 1) return { rewarded: false, reason: 'invalid-referee' };
+  const cycleId = currentCycleId(now);
+  try {
+    return await coinsTransaction(sql, async ({ credit, tx }) => {
+      // Serialize on the referee so the pending->rewarded transition is exactly-once.
+      await tx`SELECT pg_advisory_xact_lock(hashtext(${'ref:' + ref})::bigint)`;
+      const rows = await tx`
+        SELECT id, referrer_profile_id FROM referrals
+        WHERE referee_profile_id = ${ref} AND status = 'pending'
+        FOR UPDATE
+      `;
+      if (!rows.length) return { rewarded: false, reason: 'no-pending' };
+      const referralId = Number(rows[0].id);
+      const referrer = Number(rows[0].referrer_profile_id);
+
+      // Per-referrer per-cycle cap (anti-farming).
+      const capRows = await tx`
+        SELECT count(*)::int AS n FROM referrals
+        WHERE referrer_profile_id = ${referrer} AND status = 'rewarded' AND cycle_id = ${cycleId}
+      `;
+      if (Number(capRows[0].n) >= MAX_REWARDS_PER_CYCLE) {
+        await tx`UPDATE referrals SET status = 'rejected', cycle_id = ${cycleId} WHERE id = ${referralId}`;
+        return { rewarded: false, reason: 'cap-reached' };
+      }
+
+      const rc = await credit({ profileId: referrer, amount: REFERRER_REWARD, type: 'CREDIT', reason: `referral:${ref}`, referenceId: `refrwd-${ref}`, counterpartyProfileId: ref });
+      if (!rc.ok) throw new Error('referrer-credit-failed:' + rc.reason);
+      const ec = await credit({ profileId: ref, amount: REFEREE_REWARD, type: 'CREDIT', reason: `referred-bonus:${referrer}`, referenceId: `refbns-${ref}`, counterpartyProfileId: referrer });
+      if (!ec.ok) throw new Error('referee-credit-failed:' + ec.reason);
+
+      await tx`UPDATE referrals SET status = 'rewarded', cycle_id = ${cycleId}, rewarded_at = NOW() WHERE id = ${referralId}`;
+      return { rewarded: true, referrer, referrerReward: REFERRER_REWARD, refereeReward: REFEREE_REWARD };
+    });
+  } catch (e) {
+    // A referral reward must NEVER break the action that triggered it (e.g. publish).
+    return { rewarded: false, reason: 'error:' + (e.message || e).slice(0, 60) };
+  }
+}

--- a/netlify/functions/referral.mjs
+++ b/netlify/functions/referral.mjs
@@ -1,0 +1,57 @@
+import { requireAuthUser } from './lib/auth.mjs';
+import { ensureProfile } from './lib/profiles.mjs';
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard, absoluteSiteUrl } from './lib/http.mjs';
+import { ensureReferralCode, recordReferral } from './lib/referrals.mjs';
+
+export const config = { path: '/api/me/referral' };
+
+// G1 — a player's referral code + stats (GET), and claiming a code as a referee (POST).
+const isMissingSchema = (err) => isMissingRelations(err, ['profiles', 'referrals']);
+
+export default async function referral(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'GET' && request.method !== 'POST') return errorResponse('Method not allowed', 405, origin);
+  if (request.method === 'POST' && !sameOriginWriteGuard(request)) return errorResponse('Forbidden', 403, origin);
+
+  const auth = await requireAuthUser(request, origin);
+  if (auth.response) return auth.response;
+
+  try {
+    const sql = getSql();
+    const profile = await ensureProfile(auth.user);
+
+    if (request.method === 'POST') {
+      let body; try { body = await readJson(request); } catch (_) { return errorResponse('invalid-json', 400, origin); }
+      const code = String((body && body.code) || '').trim();
+      const res = await recordReferral(sql, { refereeId: profile.id, code });
+      if (!res.ok) {
+        const status = res.reason === 'already-referred' ? 409 : 400;
+        return jsonResponse({ ok: false, reason: res.reason }, origin, status);
+      }
+      return jsonResponse({ ok: true, status: 'pending' }, origin);
+    }
+
+    // GET — your code + shareable link + stats.
+    const code = await ensureReferralCode(sql, profile.id);
+    let referred = 0, rewarded = 0;
+    try {
+      const stat = await sql`
+        SELECT
+          count(*)::int AS referred,
+          count(*) FILTER (WHERE status = 'rewarded')::int AS rewarded
+        FROM referrals WHERE referrer_profile_id = ${Number(profile.id)}
+      `;
+      referred = Number(stat[0].referred) || 0;
+      rewarded = Number(stat[0].rewarded) || 0;
+    } catch (_) {}
+    const link = code ? absoluteSiteUrl('/?ref=' + encodeURIComponent(code)) : null;
+    return jsonResponse({ code, link, referred, rewarded }, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingSchema(err)) {
+      return jsonResponse({ code: null, link: null, referred: 0, rewarded: 0 }, origin);
+    }
+    return errorResponse('referral-failed', 500, origin);
+  }
+}

--- a/netlify/functions/world-remix.mjs
+++ b/netlify/functions/world-remix.mjs
@@ -1,0 +1,96 @@
+import { requireAuthUser } from './lib/auth.mjs';
+import { ensureProfile } from './lib/profiles.mjs';
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
+import { coinsTransaction, isValidCoinRef } from './lib/coins.mjs';
+
+export const config = { path: '/api/worlds/remix' };
+
+// T2 — pay Earned GOLD to remix a template world into your own editable copy.
+// ATOMIC (one transaction via coinsTransaction): debit buyer -> credit author (price
+// minus treasury fee) -> duplicate the world's data into a new build owned by the
+// buyer -> bump remix_count. Either it all happens or none of it does. Idempotent on
+// a client key so a retry never double-charges or double-duplicates.
+
+const TREASURY_FEE_BPS = 500; // 5% — matches DEFAULT_ECONOMY_POLICY.officialMarketplaceFeeBps
+const MAX_BUILDS_PER_PROFILE = 500;
+const isMissingSchema = (err) => isMissingRelations(err, ['worlds', 'builds', 'coin_balances', 'coin_ledger']);
+
+export function templateFeeSplit(price) {
+  const p = Math.max(0, Math.floor(Number(price) || 0));
+  const fee = Math.floor((p * TREASURY_FEE_BPS) / 10000);
+  return { fee, authorAmount: p - fee };
+}
+
+export default async function worldRemix(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'POST') return errorResponse('Method not allowed', 405, origin);
+  if (!sameOriginWriteGuard(request)) return errorResponse('Forbidden', 403, origin);
+
+  const auth = await requireAuthUser(request, origin);
+  if (auth.response) return auth.response;
+
+  let body;
+  try { body = await readJson(request); } catch (_) { return errorResponse('invalid-json', 400, origin); }
+  body = body || {};
+  const worldId = Number(body.worldId);
+  const idempotencyKey = String(body.idempotencyKey || '').trim();
+  if (!Number.isInteger(worldId) || worldId < 1) return errorResponse('invalid-world', 400, origin);
+  if (!isValidCoinRef(idempotencyKey)) return errorResponse('invalid-idempotency-key', 400, origin);
+
+  try {
+    const sql = getSql();
+    const buyer = await ensureProfile(auth.user);
+
+    const rows = await sql`
+      SELECT id, owner_profile_id, name, is_template, template_price, data
+      FROM worlds WHERE id = ${worldId} LIMIT 1
+    `;
+    if (!rows.length) return errorResponse('world-not-found', 404, origin);
+    const world = rows[0];
+    if (!world.is_template || world.template_price == null) return errorResponse('not-a-template', 400, origin);
+    const author = Number(world.owner_profile_id);
+    if (author === Number(buyer.id)) return errorResponse('cannot-remix-own', 400, origin);
+
+    const price = Math.max(0, Math.floor(Number(world.template_price) || 0));
+    const { fee, authorAmount } = templateFeeSplit(price);
+
+    const result = await coinsTransaction(sql, async ({ debit, credit, tx }) => {
+      // Buyer's build cap (the duplicated world becomes a build they own).
+      const cnt = await tx`SELECT count(*)::int AS n FROM builds WHERE profile_id = ${Number(buyer.id)}`;
+      if (Number(cnt[0].n) >= MAX_BUILDS_PER_PROFILE) return { ok: false, reason: 'build-limit' };
+
+      // Free templates skip the coin movement entirely.
+      let debitBalance = null;
+      if (price > 0) {
+        const d = await debit({ profileId: buyer.id, amount: price, type: 'DEBIT', reason: `remix:${worldId}`, referenceId: idempotencyKey, counterpartyProfileId: author });
+        if (!d.ok) return d; // insufficient-coins / idempotency-key-reused (no writes)
+        if (d.replayed) return { ok: true, replayed: true, balance: d.balance }; // already remixed — don't double-build
+        debitBalance = d.balance;
+        if (authorAmount > 0) {
+          const c = await credit({ profileId: author, amount: authorAmount, type: 'CREDIT', reason: `remix-sale:${worldId}`, referenceId: idempotencyKey + ':author', counterpartyProfileId: Number(buyer.id) });
+          if (!c.ok) throw new Error('author-credit-failed:' + c.reason); // rolls back the debit
+        }
+      }
+
+      const name = ('Remix of ' + (world.name || 'world')).slice(0, 80);
+      const build = await tx`INSERT INTO builds (profile_id, name, data) VALUES (${Number(buyer.id)}, ${name}, ${world.data}) RETURNING id`;
+      await tx`UPDATE worlds SET remix_count = remix_count + 1 WHERE id = ${worldId}`;
+      return { ok: true, replayed: false, buildId: Number(build[0].id), spent: price, fee, authorReceived: authorAmount, balance: debitBalance };
+    });
+
+    if (!result.ok) {
+      const status = result.reason === 'insufficient-coins' ? 402
+        : result.reason === 'idempotency-key-reused' ? 409
+        : result.reason === 'build-limit' ? 409 : 400;
+      return jsonResponse(result, origin, status);
+    }
+    return jsonResponse(result, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingSchema(err)) {
+      return errorResponse('world-remix-unavailable: schema not ready', 503, origin);
+    }
+    return errorResponse('world-remix-failed: ' + (err.message || err), 500, origin);
+  }
+}

--- a/netlify/functions/world-remix.mjs
+++ b/netlify/functions/world-remix.mjs
@@ -14,7 +14,7 @@ export const config = { path: '/api/worlds/remix' };
 
 const TREASURY_FEE_BPS = 500; // 5% — matches DEFAULT_ECONOMY_POLICY.officialMarketplaceFeeBps
 const MAX_BUILDS_PER_PROFILE = 500;
-const isMissingSchema = (err) => isMissingRelations(err, ['worlds', 'builds', 'coin_balances', 'coin_ledger']);
+const isMissingSchema = (err) => isMissingRelations(err, ['worlds', 'builds', 'coin_balances', 'coin_ledger', 'world_remixes']);
 
 export function templateFeeSplit(price) {
   const p = Math.max(0, Math.floor(Number(price) || 0));
@@ -42,42 +42,65 @@ export default async function worldRemix(request) {
   try {
     const sql = getSql();
     const buyer = await ensureProfile(auth.user);
-
-    const rows = await sql`
-      SELECT id, owner_profile_id, name, is_template, template_price, data
-      FROM worlds WHERE id = ${worldId} LIMIT 1
-    `;
-    if (!rows.length) return errorResponse('world-not-found', 404, origin);
-    const world = rows[0];
-    if (!world.is_template || world.template_price == null) return errorResponse('not-a-template', 400, origin);
-    const author = Number(world.owner_profile_id);
-    if (author === Number(buyer.id)) return errorResponse('cannot-remix-own', 400, origin);
-
-    const price = Math.max(0, Math.floor(Number(world.template_price) || 0));
-    const { fee, authorAmount } = templateFeeSplit(price);
+    const buyerId = Number(buyer.id);
+    // Coin refs are bound to the world so a key reused across worlds can't false-replay
+    // a coin debit; the world_remixes table is the operation-level idempotency surface.
+    const coinRef = `rmx:${worldId}:${idempotencyKey}`.slice(0, 128);
 
     const result = await coinsTransaction(sql, async ({ debit, credit, tx }) => {
-      // Buyer's build cap (the duplicated world becomes a build they own).
-      const cnt = await tx`SELECT count(*)::int AS n FROM builds WHERE profile_id = ${Number(buyer.id)}`;
+      // Serialize ALL of this buyer's remix work (and coin ops — same lock key) so the
+      // idempotency pre-check + build-cap + writes can't interleave with a concurrent op.
+      await tx`SELECT pg_advisory_xact_lock(hashtext(${'coin:' + buyerId})::bigint)`;
+
+      // Operation-level idempotency (covers free AND paid). A reused key bound to a
+      // DIFFERENT world is rejected; bound to the same world, replays the original build.
+      const prior = await tx`
+        SELECT world_id, build_id FROM world_remixes
+        WHERE buyer_profile_id = ${buyerId} AND idempotency_key = ${idempotencyKey} LIMIT 1
+      `;
+      if (prior.length) {
+        if (Number(prior[0].world_id) !== worldId) return { ok: false, reason: 'idempotency-key-reused' };
+        return { ok: true, replayed: true, buildId: prior[0].build_id == null ? null : Number(prior[0].build_id) };
+      }
+
+      // Lock the template row and re-read price/data/author UNDER the lock so the author
+      // can't unlist / raise price / unpublish between our read and the charge (TOCTOU).
+      const rows = await tx`
+        SELECT id, owner_profile_id, name, template_price, data FROM worlds
+        WHERE id = ${worldId} AND is_template = TRUE AND template_price IS NOT NULL AND status = 'published'
+        FOR UPDATE
+      `;
+      if (!rows.length) return { ok: false, reason: 'not-a-template' };
+      const world = rows[0];
+      const author = Number(world.owner_profile_id);
+      if (author === buyerId) return { ok: false, reason: 'cannot-remix-own' };
+      const price = Math.max(0, Math.floor(Number(world.template_price) || 0));
+      const { fee, authorAmount } = templateFeeSplit(price);
+
+      const cnt = await tx`SELECT count(*)::int AS n FROM builds WHERE profile_id = ${buyerId}`;
       if (Number(cnt[0].n) >= MAX_BUILDS_PER_PROFILE) return { ok: false, reason: 'build-limit' };
 
-      // Free templates skip the coin movement entirely.
       let debitBalance = null;
       if (price > 0) {
-        const d = await debit({ profileId: buyer.id, amount: price, type: 'DEBIT', reason: `remix:${worldId}`, referenceId: idempotencyKey, counterpartyProfileId: author });
-        if (!d.ok) return d; // insufficient-coins / idempotency-key-reused (no writes)
-        if (d.replayed) return { ok: true, replayed: true, balance: d.balance }; // already remixed — don't double-build
+        const d = await debit({ profileId: buyerId, amount: price, type: 'DEBIT', reason: `remix:${worldId}`, referenceId: coinRef, counterpartyProfileId: author });
+        if (!d.ok) return d; // insufficient-coins (no writes)
         debitBalance = d.balance;
         if (authorAmount > 0) {
-          const c = await credit({ profileId: author, amount: authorAmount, type: 'CREDIT', reason: `remix-sale:${worldId}`, referenceId: idempotencyKey + ':author', counterpartyProfileId: Number(buyer.id) });
+          const c = await credit({ profileId: author, amount: authorAmount, type: 'CREDIT', reason: `remix-sale:${worldId}`, referenceId: coinRef + ':a', counterpartyProfileId: buyerId });
           if (!c.ok) throw new Error('author-credit-failed:' + c.reason); // rolls back the debit
         }
       }
 
       const name = ('Remix of ' + (world.name || 'world')).slice(0, 80);
-      const build = await tx`INSERT INTO builds (profile_id, name, data) VALUES (${Number(buyer.id)}, ${name}, ${world.data}) RETURNING id`;
+      const build = await tx`INSERT INTO builds (profile_id, name, data) VALUES (${buyerId}, ${name}, ${world.data}) RETURNING id`;
+      const buildId = Number(build[0].id);
       await tx`UPDATE worlds SET remix_count = remix_count + 1 WHERE id = ${worldId}`;
-      return { ok: true, replayed: false, buildId: Number(build[0].id), spent: price, fee, authorReceived: authorAmount, balance: debitBalance };
+      // Record the operation — the unique (buyer, key) index is the durable idempotency backstop.
+      await tx`
+        INSERT INTO world_remixes (buyer_profile_id, world_id, build_id, author_profile_id, price, idempotency_key)
+        VALUES (${buyerId}, ${worldId}, ${buildId}, ${author}, ${price}, ${idempotencyKey})
+      `;
+      return { ok: true, replayed: false, buildId, spent: price, fee, authorReceived: authorAmount, balance: debitBalance };
     });
 
     if (!result.ok) {

--- a/netlify/functions/world-template.mjs
+++ b/netlify/functions/world-template.mjs
@@ -1,0 +1,64 @@
+import { requireAuthUser } from './lib/auth.mjs';
+import { ensureProfile } from './lib/profiles.mjs';
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
+
+export const config = { path: '/api/worlds/template' };
+
+// T2 — list / unlist a world you OWN as a remixable template with an Earned GOLD price.
+// Owner-only; the buyer-facing paid remix is /api/worlds/remix.
+const MAX_TEMPLATE_PRICE = 1_000_000;
+const isMissingSchema = (err) => isMissingRelations(err, ['worlds']);
+
+export default async function worldTemplate(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'POST') return errorResponse('Method not allowed', 405, origin);
+  if (!sameOriginWriteGuard(request)) return errorResponse('Forbidden', 403, origin);
+
+  const auth = await requireAuthUser(request, origin);
+  if (auth.response) return auth.response;
+
+  let body;
+  try { body = await readJson(request); } catch (_) { return errorResponse('invalid-json', 400, origin); }
+  body = body || {};
+  const worldId = Number(body.worldId);
+  const action = String(body.action || '').trim(); // 'list' | 'unlist'
+  if (!Number.isInteger(worldId) || worldId < 1) return errorResponse('invalid-world', 400, origin);
+  if (action !== 'list' && action !== 'unlist') return errorResponse('invalid-action', 400, origin);
+
+  try {
+    const sql = getSql();
+    const profile = await ensureProfile(auth.user);
+
+    const rows = await sql`SELECT id, owner_profile_id, status FROM worlds WHERE id = ${worldId} LIMIT 1`;
+    if (!rows.length) return errorResponse('world-not-found', 404, origin);
+    const world = rows[0];
+    if (Number(world.owner_profile_id) !== Number(profile.id)) return errorResponse('not-your-world', 403, origin);
+    if (world.status !== 'published') return errorResponse('world-must-be-published', 400, origin);
+
+    if (action === 'unlist') {
+      const upd = await sql`
+        UPDATE worlds SET is_template = FALSE, updated_at = NOW()
+        WHERE id = ${worldId} RETURNING id, is_template, template_price, remix_count
+      `;
+      return jsonResponse({ ok: true, template: upd[0] }, origin);
+    }
+
+    // list
+    const price = Number(body.price);
+    if (!Number.isInteger(price) || price < 0 || price > MAX_TEMPLATE_PRICE) return errorResponse('invalid-price', 400, origin);
+    const upd = await sql`
+      UPDATE worlds
+      SET is_template = TRUE, template_price = ${price}, template_author_id = ${Number(profile.id)}, updated_at = NOW()
+      WHERE id = ${worldId}
+      RETURNING id, is_template, template_price, remix_count
+    `;
+    return jsonResponse({ ok: true, template: upd[0] }, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingSchema(err)) {
+      return errorResponse('world-template-unavailable: schema not ready', 503, origin);
+    }
+    return errorResponse('world-template-failed: ' + (err.message || err), 500, origin);
+  }
+}

--- a/netlify/functions/world-template.mjs
+++ b/netlify/functions/world-template.mjs
@@ -31,29 +31,34 @@ export default async function worldTemplate(request) {
     const sql = getSql();
     const profile = await ensureProfile(auth.user);
 
-    const rows = await sql`SELECT id, owner_profile_id, status FROM worlds WHERE id = ${worldId} LIMIT 1`;
+    // Existence/ownership are surfaced as a clear 404/403, but the authoritative
+    // ownership (+ published, for listing) check lives in the UPDATE predicate so a
+    // concurrent ownership/status change between read and write can't be exploited.
+    const rows = await sql`SELECT owner_profile_id FROM worlds WHERE id = ${worldId} LIMIT 1`;
     if (!rows.length) return errorResponse('world-not-found', 404, origin);
-    const world = rows[0];
-    if (Number(world.owner_profile_id) !== Number(profile.id)) return errorResponse('not-your-world', 403, origin);
-    if (world.status !== 'published') return errorResponse('world-must-be-published', 400, origin);
+    if (Number(rows[0].owner_profile_id) !== Number(profile.id)) return errorResponse('not-your-world', 403, origin);
 
     if (action === 'unlist') {
       const upd = await sql`
-        UPDATE worlds SET is_template = FALSE, updated_at = NOW()
-        WHERE id = ${worldId} RETURNING id, is_template, template_price, remix_count
+        UPDATE worlds
+        SET is_template = FALSE, template_price = NULL, template_author_id = NULL, updated_at = NOW()
+        WHERE id = ${worldId} AND owner_profile_id = ${Number(profile.id)}
+        RETURNING id, is_template, template_price, remix_count
       `;
+      if (!upd.length) return errorResponse('ownership-conflict', 409, origin);
       return jsonResponse({ ok: true, template: upd[0] }, origin);
     }
 
-    // list
+    // list — must own AND be published, enforced in the predicate.
     const price = Number(body.price);
     if (!Number.isInteger(price) || price < 0 || price > MAX_TEMPLATE_PRICE) return errorResponse('invalid-price', 400, origin);
     const upd = await sql`
       UPDATE worlds
       SET is_template = TRUE, template_price = ${price}, template_author_id = ${Number(profile.id)}, updated_at = NOW()
-      WHERE id = ${worldId}
+      WHERE id = ${worldId} AND owner_profile_id = ${Number(profile.id)} AND status = 'published'
       RETURNING id, is_template, template_price, remix_count
     `;
+    if (!upd.length) return errorResponse('not-owner-or-not-published', 409, origin);
     return jsonResponse({ ok: true, template: upd[0] }, origin);
   } catch (err) {
     if (isDatabaseUnavailable(err) || isMissingSchema(err)) {

--- a/netlify/functions/worlds.mjs
+++ b/netlify/functions/worlds.mjs
@@ -274,9 +274,11 @@ export default async function worldsFunction(request) {
       }
 
       if (action === 'unpublish') {
+        // Clear any template listing on unpublish so an unpublished world can't stay
+        // remixable (the remix path also re-checks status='published' under a row lock).
         const rows = await sql`
           UPDATE worlds
-          SET status = 'draft', updated_at = NOW()
+          SET status = 'draft', is_template = FALSE, template_price = NULL, template_author_id = NULL, updated_at = NOW()
           WHERE id = ${worldId} AND owner_profile_id = ${profile.id} AND status = 'published'
           RETURNING *
         `;

--- a/netlify/functions/worlds.mjs
+++ b/netlify/functions/worlds.mjs
@@ -274,7 +274,12 @@ export default async function worldsFunction(request) {
         // Publishing a world is the verified action that pays out a pending referral
         // (earned, not given). Best-effort: a referral-reward error must never fail the
         // publish. Idempotent — only the first eligible publish ever pays.
-        try { await maybeRewardReferral(sql, profile.id); } catch (_) {}
+        try {
+          const r = await maybeRewardReferral(sql, profile.id);
+          if (r && r.reason && String(r.reason).startsWith('error:')) {
+            console.warn('[referral] reward failed for profile', profile.id, r.reason);
+          }
+        } catch (e) { console.warn('[referral] reward threw for profile', profile.id, e && e.message); }
         return jsonResponse({ world: worldDto(rows[0], { includeData: true }) }, origin);
       }
 

--- a/netlify/functions/worlds.mjs
+++ b/netlify/functions/worlds.mjs
@@ -3,6 +3,7 @@ import { getAuthUser } from './lib/auth.mjs';
 import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
 import { corsResponse, errorResponse, jsonResponse, readJson, sameOriginWriteGuard } from './lib/http.mjs';
 import { ensureProfile, profileDto } from './lib/profiles.mjs';
+import { maybeRewardReferral } from './lib/referrals.mjs';
 import { activeSuspension } from './lib/community-moderation.mjs';
 import { isTinyverseAccessEmail } from './lib/tinyverse-access.mjs';
 import {
@@ -270,6 +271,10 @@ export default async function worldsFunction(request) {
           RETURNING *
         `;
         if (!rows.length) return errorResponse('Cannot publish (need a name, and it must be your draft)', 409, origin);
+        // Publishing a world is the verified action that pays out a pending referral
+        // (earned, not given). Best-effort: a referral-reward error must never fail the
+        // publish. Idempotent — only the first eligible publish ever pays.
+        try { await maybeRewardReferral(sql, profile.id); } catch (_) {}
         return jsonResponse({ world: worldDto(rows[0], { includeData: true }) }, origin);
       }
 

--- a/tests/coins-validate.test.mjs
+++ b/tests/coins-validate.test.mjs
@@ -4,7 +4,7 @@
 // live-DB rollback smoke test + integration plan, not unit tests.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateCoinAmount, MAX_COIN_AMOUNT } from '../netlify/functions/lib/coins.mjs';
+import { validateCoinAmount, MAX_COIN_AMOUNT, isValidCoinRef } from '../netlify/functions/lib/coins.mjs';
 
 test('accepts positive integers within range', () => {
   assert.equal(validateCoinAmount(1), 1);
@@ -26,4 +26,15 @@ test('rejects non-integers and junk', () => {
   assert.equal(validateCoinAmount(undefined), null);
   assert.equal(validateCoinAmount(NaN), null);
   assert.equal(validateCoinAmount(Infinity), null);
+});
+
+test('coin refs must be non-empty, bounded, server-key-shaped (idempotency requires one)', () => {
+  assert.equal(isValidCoinRef('remix:42:1718000000'), true);
+  assert.equal(isValidCoinRef('a1b2c3d4'), true); // 8 chars min
+  assert.equal(isValidCoinRef('short'), false);   // < 8
+  assert.equal(isValidCoinRef(''), false);
+  assert.equal(isValidCoinRef(null), false);
+  assert.equal(isValidCoinRef(undefined), false);
+  assert.equal(isValidCoinRef('has spaces!'), false);
+  assert.equal(isValidCoinRef('x'.repeat(129)), false); // > 128
 });

--- a/tests/coins-validate.test.mjs
+++ b/tests/coins-validate.test.mjs
@@ -1,0 +1,29 @@
+// tests/coins-validate.test.mjs
+// EC1: the pure amount-validation gate every coin credit/debit/transfer passes through.
+// The atomic DB behaviour (advisory lock, idempotency, balance >= 0) is covered by the
+// live-DB rollback smoke test + integration plan, not unit tests.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateCoinAmount, MAX_COIN_AMOUNT } from '../netlify/functions/lib/coins.mjs';
+
+test('accepts positive integers within range', () => {
+  assert.equal(validateCoinAmount(1), 1);
+  assert.equal(validateCoinAmount(500), 500);
+  assert.equal(validateCoinAmount(MAX_COIN_AMOUNT), MAX_COIN_AMOUNT);
+});
+
+test('rejects zero, negative, and over-cap amounts', () => {
+  assert.equal(validateCoinAmount(0), null);
+  assert.equal(validateCoinAmount(-5), null);
+  assert.equal(validateCoinAmount(MAX_COIN_AMOUNT + 1), null);
+});
+
+test('rejects non-integers and junk', () => {
+  assert.equal(validateCoinAmount(1.5), null);
+  assert.equal(validateCoinAmount('10'), 10); // numeric string coerces to a valid integer
+  assert.equal(validateCoinAmount('abc'), null);
+  assert.equal(validateCoinAmount(null), null);
+  assert.equal(validateCoinAmount(undefined), null);
+  assert.equal(validateCoinAmount(NaN), null);
+  assert.equal(validateCoinAmount(Infinity), null);
+});

--- a/tests/referrals.test.mjs
+++ b/tests/referrals.test.mjs
@@ -1,0 +1,34 @@
+// tests/referrals.test.mjs
+// G1: pure referral-code validation + generation. The reward/cap/idempotency behaviour
+// is integration-tested (needs profiles+referrals+coin schema).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isValidReferralCode, randomReferralCode,
+  REFERRER_REWARD, REFEREE_REWARD, MAX_REWARDS_PER_CYCLE,
+} from '../netlify/functions/lib/referrals.mjs';
+
+test('valid referral codes are 6-16 alphanumerics', () => {
+  assert.equal(isValidReferralCode('ABCDEF'), true);
+  assert.equal(isValidReferralCode('tw2k9xq'), true);
+  assert.equal(isValidReferralCode('short'), false); // 5
+  assert.equal(isValidReferralCode(''), false);
+  assert.equal(isValidReferralCode(null), false);
+  assert.equal(isValidReferralCode('has space'), false);
+  assert.equal(isValidReferralCode('toolongtoolongtoolong'), false); // >16
+});
+
+test('generated codes are the right length, valid, and avoid ambiguous chars', () => {
+  for (let i = 0; i < 50; i++) {
+    const c = randomReferralCode();
+    assert.equal(c.length, 8);
+    assert.equal(isValidReferralCode(c), true, `generated code ${c} should validate`);
+    assert.ok(!/[0O1I]/.test(c), `code ${c} must avoid ambiguous chars`);
+  }
+});
+
+test('reward economics match the decided defaults', () => {
+  assert.equal(REFERRER_REWARD, 50);
+  assert.equal(REFEREE_REWARD, 25);
+  assert.equal(MAX_REWARDS_PER_CYCLE, 10);
+});

--- a/tests/template-fee.test.mjs
+++ b/tests/template-fee.test.mjs
@@ -1,0 +1,37 @@
+// tests/template-fee.test.mjs
+// T2: the treasury-fee split applied when a template is remixed. The atomic
+// debit/credit/duplicate composition is integration-tested (it needs the full
+// worlds+builds+coin schema); this pins the money math.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { templateFeeSplit } from '../netlify/functions/world-remix.mjs';
+
+test('splits price into a 5% treasury fee and the author remainder', () => {
+  assert.deepEqual(templateFeeSplit(1000), { fee: 50, authorAmount: 950 });
+  assert.deepEqual(templateFeeSplit(100), { fee: 5, authorAmount: 95 });
+});
+
+test('fee floors (never over-charges the buyer or over-credits the treasury)', () => {
+  // 199 * 5% = 9.95 -> floor 9; author gets 190; fee + author == price (no leakage)
+  const { fee, authorAmount } = templateFeeSplit(199);
+  assert.equal(fee, 9);
+  assert.equal(authorAmount, 190);
+  assert.equal(fee + authorAmount, 199);
+});
+
+test('free templates split to nothing', () => {
+  assert.deepEqual(templateFeeSplit(0), { fee: 0, authorAmount: 0 });
+});
+
+test('garbage prices coerce to a zero split, never negative', () => {
+  assert.deepEqual(templateFeeSplit(-100), { fee: 0, authorAmount: 0 });
+  assert.deepEqual(templateFeeSplit('abc'), { fee: 0, authorAmount: 0 });
+  assert.deepEqual(templateFeeSplit(null), { fee: 0, authorAmount: 0 });
+});
+
+test('fee + author always reconstructs the price exactly (conservation)', () => {
+  for (const p of [1, 7, 33, 250, 999, 12345, 1000000]) {
+    const { fee, authorAmount } = templateFeeSplit(p);
+    assert.equal(fee + authorAmount, p, `price ${p} must be conserved`);
+  }
+});


### PR DESCRIPTION
**Do not merge.** Economy launch gate. Depends on #84 (EC1) and #85 (T2) — branched on T2.

Referral rewards — **earned, not given**: a referrer is paid Earned GOLD only after the referee completes a verified action (publishing a world).

## What
- **Migration**: `profiles.referral_code` (unique) + `referrals` table (referee UNIQUE = referred once; no-self CHECK; per-cycle cap surface).
- **`lib/referrals.mjs`**: `ensureReferralCode`, `recordReferral` (validates code/self/already-referred; idempotent), and **`maybeRewardReferral`** — atomic via `coinsTransaction`: referee-locked, pays **referrer +50 / referee +25** Earned GOLD once (`pending→rewarded` under `FOR UPDATE`), **capped at 10/referrer/cycle**, never double-pays, never breaks the triggering action.
- **`/api/me/referral`**: GET code + share link + stats; POST claim a code.
- **`worlds.mjs` publish** best-effort fires the reward (the verified action).

## Verification
- Pure unit tests + `npm run check` pass. Built on EC1's live-DB-verified coin primitive.
- **LIVE-DB smoke PASSED** (guarded, cleaned up): record→pending, dup→already-referred, self→blocked, reward→+50/+25, replay→no double-pay, status→rewarded.

## Defaults (your decision; adjustable)
+50 referrer / +25 referee, cap 10/referrer/week. Sybil-resistance beyond the cap (e.g. require the referee's wallet be funded / distinct device) is a tuning follow-up.

Codex adversarial pass running; verdict to follow.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK