### PR TITLE
security: authorize Tinyverse on verified email only (privilege-escalation fix)

### DIFF
--- a/netlify/functions/admin-users.mjs
+++ b/netlify/functions/admin-users.mjs
@@ -49,10 +49,12 @@ function tinyverseAccessEmailsArray() {
   return Array.from(tinyverseAccessEmails()).map(e => String(e || '').trim().toLowerCase()).filter(Boolean);
 }
 
-export function canAccessTinyverse(user, profile) {
+export function canAccessTinyverse(user) {
   if (!user || !user.id) return false;
-  const email = cleanEmail(user.email || (profile && profile.email) || '');
-  return isTinyverseAccessEmail(email);
+  // Authorize on the VERIFIED auth-provider email ONLY — never the user-editable
+  // profiles.email (a wallet user can set that to anything via /api/profile, which
+  // would let them self-grant access). See plans/production-line/SECURITY-NOTES.md.
+  return isTinyverseAccessEmail(cleanEmail(user.email || ''));
 }
 
 function adminUserDto(row) {

--- a/netlify/functions/admin-users.mjs
+++ b/netlify/functions/admin-users.mjs
@@ -181,7 +181,7 @@ export default async function adminUsersFunction(request) {
     if (request.method === 'GET' && url.searchParams.get('action') === 'tinyverse-access') {
       try {
         const profile = await ensureProfile(user);
-        return jsonResponse({ allowed: canAccessTinyverse(user, profile), admin: isWorldAdminEmail(user && user.email) }, origin);
+        return jsonResponse({ allowed: canAccessTinyverse(user), admin: isWorldAdminEmail(user && user.email) }, origin);
       } catch (err) {
         if (isDatabaseUnavailable(err)) {
           const allowed = isTinyverseAccessEmail(user && user.email);

--- a/netlify/functions/worlds.mjs
+++ b/netlify/functions/worlds.mjs
@@ -68,12 +68,15 @@ function slugFromRequest(request) {
   return s;
 }
 
-function isTinyverseOwnerProfile(profile) {
-  return TINYVERSE_OWNER_EMAILS.has(String((profile && profile.email) || '').trim().toLowerCase());
+// Authorize on the VERIFIED auth-provider email only, NEVER the editable profiles.email
+// (a wallet user can set that to anything via /api/profile — using it for authorization
+// let them self-grant Tinyverse owner/access). See plans/production-line/SECURITY-NOTES.md.
+function isTinyverseOwnerEmail(verifiedEmail) {
+  return TINYVERSE_OWNER_EMAILS.has(String(verifiedEmail || '').trim().toLowerCase());
 }
 
-async function ensureTinyverseStarterOwnership(sql, profile) {
-  if (!profile || !isTinyverseOwnerProfile(profile)) return;
+async function ensureTinyverseStarterOwnership(sql, profile, verifiedEmail) {
+  if (!profile || !isTinyverseOwnerEmail(verifiedEmail)) return;
   await sql`
     UPDATE worlds
     SET owner_profile_id = ${profile.id}, updated_at = NOW()
@@ -106,12 +109,15 @@ export default async function worldsFunction(request) {
     // Browsing the universe is account-gated; writes require auth too.
     const user = await getAuthUser(request);
     const profile = (user && user.id) ? await ensureProfile(user) : null;
-    await ensureTinyverseStarterOwnership(sql, profile);
+    // The verified auth-provider email is the ONLY authorization input — never the
+    // user-editable profiles.email.
+    const verifiedEmail = (user && user.email) ? String(user.email).trim().toLowerCase() : '';
+    await ensureTinyverseStarterOwnership(sql, profile, verifiedEmail);
     const isWorldService = isWorldServiceRequest(request);
     // World admin: a small email allowlist may inspect/administer worlds beyond
     // ownership. Live room editing is intentionally not part of this path.
-    const isWorldAdmin = isWorldAdminEmail(user && user.email);
-    const canAccessTinyverse = isTinyverseAccessEmail(user && (user.email || (profile && profile.email)));
+    const isWorldAdmin = isWorldAdminEmail(verifiedEmail);
+    const canAccessTinyverse = isTinyverseAccessEmail(verifiedEmail);
     const worldId = worldIdFromRequest(request);
     const worldSlug = slugFromRequest(request);
 

--- a/tests/tinyverse-access.test.mjs
+++ b/tests/tinyverse-access.test.mjs
@@ -28,3 +28,13 @@ test('admin Tinyverse check ignores stale lobby flags for non-allowed users', ()
   assert.equal(canAccessTinyverse(user, profile), false);
   assert.equal(canAccessTinyverse({ id: 'user-456', email: 'jason.kneen@gmail.com' }, null), true);
 });
+
+test('Tinyverse access NEVER trusts the user-editable profiles.email (privilege escalation fix)', () => {
+  // A wallet user (empty verified email) cannot self-grant access by setting an
+  // allowlisted profiles.email, and an attacker with a non-allowlisted verified email
+  // cannot escalate via profiles.email either.
+  assert.equal(canAccessTinyverse({ id: 'w', email: '' }, { email: 'jason.kneen@gmail.com' }), false);
+  assert.equal(canAccessTinyverse({ id: 'w', email: 'attacker@example.com' }, { email: 'jason.kneen@gmail.com' }), false);
+  // The legitimate path still works: a verified allowlisted email grants access.
+  assert.equal(canAccessTinyverse({ id: 'w', email: 'jason.kneen@gmail.com' }, { email: 'unrelated@example.com' }), true);
+});

--- a/tests/worlds-exit-ui.test.mjs
+++ b/tests/worlds-exit-ui.test.mjs
@@ -137,7 +137,7 @@ test('world picker is a carousel overlay with search and filter controls', () =>
 
 test('world picker cards display owner-backed resource readiness stats', () => {
   assert.match(worldsFunctionJs, /p\.email AS owner_email/);
-  assert.match(worldsFunctionJs, /function ensureTinyverseStarterOwnership\(sql, profile\)/);
+  assert.match(worldsFunctionJs, /function ensureTinyverseStarterOwnership\(sql, profile, verifiedEmail\)/);
   assert.match(universeJs, /function resourceStatsText\(stats\)/);
   assert.match(universeJs, /w\.resourceStats/);
   assert.match(universeJs, /class: 'tw-worlds-resources'/);


### PR DESCRIPTION
Pre-existing CRITICAL surfaced by the G1 adversarial review and fixed.

## The bug
`/api/profile` lets a wallet user set `profiles.email` to anything; `worlds.mjs` + `admin-users.mjs` used that EDITABLE email (as a fallback) for Tinyverse access/admin/owner decisions → a wallet user could self-grant access by setting an allowlisted email.

## The fix
Authorize ONLY on the verified auth-provider `user.email`, never `profiles.email`.
- `worlds.mjs`: access / admin / starter-ownership now use one `verifiedEmail = user.email`.
- `admin-users.mjs` `canAccessTinyverse`: `user.email` only.
- Regression test pins it (editable email never grants; verified allowlisted email still works). 194 tests pass.

**Codex adversarial review: SHIP** — fix complete, legit path intact, `user.email` is from the verified token, starter-ownership gated correctly.

Non-economy security fix → ships to prod, removes a launch blocker for the economy. See `plans/production-line/SECURITY-NOTES.md`.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened Tinyverse access checks to rely on the authenticated, verified email only.
  * Prevented profile-edited email fields from being used to gain or change access.
  * Updated Tinyverse ownership handling so admin and access status are determined from verified account details.

* **Tests**
  * Added coverage to confirm profile email changes cannot bypass access restrictions.
  * Updated existing checks to match the revised verification flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->