### PR TITLE
fix: home carousel shows user-built community worlds, full-width under hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,10 +161,30 @@
           </a>
         </div>
       </div>
-      <section class="world-carousel" id="world-carousel" aria-label="Featured worlds" hidden>
+      <aside class="hero-feed" id="hero-feed" aria-label="Live public collab worlds" hidden>
+        <div class="hero-feed-head">
+          <span class="hero-feed-live"><span class="hero-feed-dot"></span>Live</span>
+          <span class="hero-feed-title">Public collab builds</span>
+        </div>
+        <ul class="hero-feed-list" id="hero-feed-list"></ul>
+        <a class="hero-feed-foot" href="/collabs">
+          <span>More worlds</span>
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></svg>
+        </a>
+      </aside>
+      <a class="scroll-cue" href="#features" aria-label="Scroll to features">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+      </a>
+    </section>
+
+    <!-- Community worlds carousel — full-width strip of user-built shared worlds.
+         Data source: /api/home-worlds (world_shares table).
+         scripts/world-carousel.js populates this at runtime; stays hidden until data loads. -->
+    <section class="world-carousel" id="world-carousel" aria-label="Worlds from the community" hidden>
+      <div class="world-carousel-inner">
         <div class="world-carousel-head">
-          <span class="world-carousel-label">Featured worlds</span>
-          <a class="world-carousel-browse" href="/featured">
+          <span class="world-carousel-label">Worlds from the community</span>
+          <a class="world-carousel-browse" href="/templates">
             <span>Browse all</span>
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></svg>
           </a>
@@ -181,21 +201,7 @@
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></svg>
           </button>
         </div>
-      </section>
-      <aside class="hero-feed" id="hero-feed" aria-label="Live public collab worlds" hidden>
-        <div class="hero-feed-head">
-          <span class="hero-feed-live"><span class="hero-feed-dot"></span>Live</span>
-          <span class="hero-feed-title">Public collab builds</span>
-        </div>
-        <ul class="hero-feed-list" id="hero-feed-list"></ul>
-        <a class="hero-feed-foot" href="/collabs">
-          <span>More worlds</span>
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></svg>
-        </a>
-      </aside>
-      <a class="scroll-cue" href="#features" aria-label="Scroll to features">
-        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
-      </a>
+      </div>
     </section>
 
     <!-- The content below is a fallback; scripts/latest-news.js replaces the

--- a/netlify/functions/home-worlds.mjs
+++ b/netlify/functions/home-worlds.mjs
@@ -1,0 +1,68 @@
+import { getSql, isDatabaseUnavailable, isMissingRelations } from './lib/db.mjs';
+import { corsResponse, errorResponse, jsonResponse } from './lib/http.mjs';
+import { normalizeWorldSelectionGateData, worldPreview } from './lib/worlds.mjs';
+
+export const config = { path: '/api/home-worlds' };
+
+// Public, unauthenticated discovery feed of user-built worlds shared via the
+// Tiny World Builder. Returns recent public shares so the home-page carousel
+// showcases community creations, NOT tinyverse/published worlds.
+// NEVER returns profile_id, owner_auth_id, or any PII column.
+// Cells are sliced IN SQL to bound data transfer — same pattern as builder.mjs.
+const isMissingHomeWorldsSchema = (err) =>
+  isMissingRelations(err, ['world_shares']);
+
+const MAX_WORLDS = 12;
+const MAX_PREVIEW_CELLS = 1200;
+
+export default async function homeWorlds(request) {
+  const origin = request.headers.get('origin');
+  if (request.method === 'OPTIONS') return corsResponse(origin);
+  if (request.method !== 'GET') return errorResponse('Method not allowed', 405, origin);
+
+  try {
+    const sql = getSql();
+
+    // Select only safe public fields. gridSize is extracted as a scalar from
+    // the JSONB data column (world_shares has no grid_size column). Cells are
+    // sliced to MAX_PREVIEW_CELLS via WITH ORDINALITY so we never pull the
+    // full data blob (up to 20 MB/row) over the wire.
+    const rows = await sql`
+      SELECT
+        id,
+        name,
+        COALESCE((data->>'gridSize')::int, 8) AS grid_size,
+        COALESCE((
+          SELECT jsonb_agg(elem ORDER BY ord)
+          FROM jsonb_array_elements(
+            CASE WHEN jsonb_typeof(data->'cells') = 'array' THEN data->'cells' ELSE '[]'::jsonb END
+          ) WITH ORDINALITY AS t(elem, ord)
+          WHERE ord <= ${MAX_PREVIEW_CELLS}
+        ), '[]'::jsonb) AS cells
+      FROM world_shares
+      ORDER BY updated_at DESC
+      LIMIT ${MAX_WORLDS}
+    `;
+
+    const worlds = (rows || []).map((r) => {
+      // id is TEXT (base64url) — keep as string; do NOT coerce to Number.
+      const id = String(r.id || '');
+      const gridSize = Math.max(1, Math.min(64, Number(r.grid_size) || 8));
+      const rawCells = Array.isArray(r.cells) ? r.cells : [];
+      const previewData = normalizeWorldSelectionGateData({ cells: rawCells }, gridSize);
+      return {
+        id,
+        name: r.name || 'Untitled world',
+        gridSize,
+        preview: { gridSize, cells: worldPreview(previewData, MAX_PREVIEW_CELLS) },
+      };
+    }).filter((w) => Array.isArray(w.preview.cells) && w.preview.cells.length > 0);
+
+    return jsonResponse({ worlds }, origin);
+  } catch (err) {
+    if (isDatabaseUnavailable(err) || isMissingHomeWorldsSchema(err)) {
+      return jsonResponse({ worlds: [] }, origin);
+    }
+    return errorResponse('home-worlds-failed', 500, origin);
+  }
+}

--- a/scripts/world-carousel.js
+++ b/scripts/world-carousel.js
@@ -1,10 +1,10 @@
-// -------- landing hero featured worlds carousel --------
-// Fetches /api/worlds/featured (public, unauthenticated — published worlds only)
-// and renders them as isometric canvas previews that cycle in the home hero. The
-// preview renderer lives in scripts/world-preview.js (window.TinyWorldPreview),
-// which must be loaded before this script.
-// If the feed is empty or fails, the section stays hidden (hideFeed pattern from
-// landing-feed.js).
+// -------- home page community worlds carousel --------
+// Fetches /api/home-worlds (public, unauthenticated — user-built builder worlds
+// shared via the Tiny World Builder share system) and renders them as isometric
+// canvas previews in a full-width strip directly under the hero. The preview
+// renderer lives in scripts/world-preview.js (window.TinyWorldPreview), which
+// must be loaded before this script.
+// If the feed is empty or fails, the section stays hidden (hideFeed pattern).
 (function () {
   'use strict';
 
@@ -25,38 +25,40 @@
   var INTERVAL = 5000;
   var reducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+  // Each share opens in the builder at /tiny-world-builder?share=<id>.
+  // id is a TEXT (base64url) string — never numeric.
   function worldHref(w) {
-    var slug = String((w && w.slug) || '').trim();
-    if (!slug) return '/tiny-world-builder';
-    return '/tiny-world-builder?world=' + encodeURIComponent(slug);
+    var id = String((w && w.id) || '').trim();
+    if (!id) return '/tiny-world-builder';
+    return '/tiny-world-builder?share=' + encodeURIComponent(id);
   }
 
   function buildSlide(w, idx) {
     var slide = document.createElement('div');
     slide.className = 'world-carousel-slide';
     slide.setAttribute('role', 'group');
-    slide.setAttribute('aria-label', String(w.name || w.slug || 'World'));
+    slide.setAttribute('aria-label', String(w.name || 'World'));
     slide.dataset.idx = String(idx);
 
     var cnv = document.createElement('canvas');
     cnv.className = 'world-carousel-canvas';
-    // Set explicit pixel dimensions as fallback for renderPreview when slide
-    // is not yet visible (clientWidth may be 0 while display:none).
-    cnv.width = 320;
-    cnv.height = 200;
+    // Explicit pixel dimensions so renderPreview works while the slide may
+    // not yet be visible (clientWidth can be 0 before display:block).
+    cnv.width = 280;
+    cnv.height = 180;
 
     var info = document.createElement('div');
     info.className = 'world-carousel-info';
 
     var name = document.createElement('span');
     name.className = 'world-carousel-name';
-    name.textContent = String(w.name || w.slug || 'World');
+    name.textContent = String(w.name || 'World');
 
     var link = document.createElement('a');
     link.className = 'world-carousel-open';
     link.href = worldHref(w);
     link.textContent = 'Open world';
-    link.setAttribute('aria-label', 'Open ' + String(w.name || w.slug || 'world'));
+    link.setAttribute('aria-label', 'Open ' + String(w.name || 'world'));
 
     info.appendChild(name);
     info.appendChild(link);
@@ -64,6 +66,8 @@
     slide.appendChild(info);
 
     // Render preview onto canvas via the shared renderer module.
+    // Called synchronously (no rAF) so off-screen cards still render —
+    // rAF is throttled in background tabs.
     try {
       window.TinyWorldPreview.renderPreview(cnv, w.preview);
     } catch (_) {}
@@ -80,12 +84,20 @@
     }
   }
 
+  function cardStepPx() {
+    // Advance by one card's width + gap so multi-card views scroll cleanly.
+    var slide = track.querySelector('.world-carousel-slide');
+    if (!slide) return 0;
+    var slideW = slide.getBoundingClientRect().width || 290;
+    var gap = parseFloat(getComputedStyle(track).gap) || 16;
+    return slideW + gap;
+  }
+
   function goTo(idx, skipTimer) {
     var n = worlds.length;
     if (!n) return;
     current = ((idx % n) + n) % n;
-    // Slide via CSS transform on the track
-    track.style.transform = 'translateX(' + (-current * 100) + '%)';
+    track.style.transform = 'translateX(' + (-current * cardStepPx()) + 'px)';
     updateDots();
     if (!skipTimer) resetTimer();
   }
@@ -100,7 +112,6 @@
     if (!wList || !wList.length) { hideCarousel(); return; }
     worlds = wList;
 
-    // Build slides
     track.textContent = '';
     dotsEl.textContent = '';
 
@@ -132,17 +143,15 @@
   prevBtn.addEventListener('click', function () { goTo(current - 1); });
   nextBtn.addEventListener('click', function () { goTo(current + 1); });
 
-  // Keyboard nav on the track wrapper
   section.addEventListener('keydown', function (e) {
     if (e.key === 'ArrowLeft') { goTo(current - 1); e.preventDefault(); }
     else if (e.key === 'ArrowRight') { goTo(current + 1); e.preventDefault(); }
   });
 
   function load() {
-    // Public discovery feed: /api/worlds/featured returns only published worlds
-    // with preview data and needs no auth, so it works for anonymous landing
-    // visitors (the auth-gated /api/worlds returns [] for them).
-    fetch('/api/worlds/featured', { headers: { Accept: 'application/json' } })
+    // Community discovery feed: /api/home-worlds returns public user-built
+    // worlds from world_shares — no auth required.
+    fetch('/api/home-worlds', { headers: { Accept: 'application/json' } })
       .then(function (res) { return res && res.ok ? res.json() : null; })
       .then(function (data) {
         var all = data && Array.isArray(data.worlds) ? data.worlds : [];

--- a/styles/landing.css
+++ b/styles/landing.css
@@ -797,41 +797,54 @@ svg {
   }
 }
 
-/* -------- hero featured worlds carousel -------- */
+/* -------- community worlds carousel — full-width strip under hero -------- */
+/* The section itself spans full viewport width; the inner wrapper constrains
+   content to the same 1200px grid used by .top-story-section. */
 .world-carousel {
-  position: relative;
-  z-index: 1;
-  margin-top: 36px;
-  width: min(420px, 100%);
+  width: 100%;
+  background: rgba(255, 255, 255, 0.48);
+  border-top: 1px solid rgba(255, 255, 255, 0.62);
+  border-bottom: 1px solid rgba(200, 210, 230, 0.36);
+  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  backdrop-filter: blur(14px) saturate(160%);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.82) inset,
+    0 8px 32px -16px rgba(40, 50, 80, 0.18);
+  padding: 28px 0 24px;
+}
+
+.world-carousel-inner {
+  width: min(1200px, calc(100% - 48px));
+  margin: 0 auto;
 }
 
 .world-carousel-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 10px;
+  margin-bottom: 16px;
 }
 
 .world-carousel-label {
-  font-size: 12px;
+  font-family: 'Pixelify Sans', var(--display-font), sans-serif;
+  font-size: 13px;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #25304c;
-  opacity: 0.72;
+  color: #1a2a50;
 }
 
 .world-carousel-browse {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 650;
-  color: var(--accent);
+  color: var(--accent, #3a72c8);
   text-decoration: none;
   transition: opacity 0.14s ease;
 }
-.world-carousel-browse:hover { opacity: 0.78; }
+.world-carousel-browse:hover { opacity: 0.72; }
 .world-carousel-browse svg {
   width: 13px;
   height: 13px;
@@ -842,16 +855,16 @@ svg {
   stroke-linejoin: round;
 }
 
+/* Stage clips the sliding track. Full-width, shows ~3-4 cards at once.
+   Each card is ~290px wide with gaps; the track translates by card+gap px per step. */
 .world-carousel-stage {
   overflow: hidden;
-  border-radius: var(--radius-lg);
-  background: rgba(7, 9, 17, 0.82);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  box-shadow: 0 18px 48px -24px rgba(17, 27, 69, 0.6);
+  border-radius: var(--radius-lg, 14px);
 }
 
 .world-carousel-track {
   display: flex;
+  gap: 16px;
   transition: transform 0.38s cubic-bezier(0.4, 0, 0.2, 1);
   will-change: transform;
 }
@@ -860,16 +873,24 @@ svg {
   .world-carousel-track { transition: none; }
 }
 
+/* Fixed card width; JS advances by (card-width + gap) pixels. */
 .world-carousel-slide {
-  flex: 0 0 100%;
+  flex: 0 0 290px;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-lg, 14px);
+  overflow: hidden;
+  background: rgba(7, 9, 17, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 14px 40px -20px rgba(17, 27, 69, 0.55);
 }
 
 .world-carousel-canvas {
   display: block;
   width: 100%;
   height: auto;
-  aspect-ratio: 8 / 5;
+  aspect-ratio: 14 / 9;
   image-rendering: pixelated;
   background: #070911;
 }
@@ -879,29 +900,29 @@ svg {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  padding: 8px 12px 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(7, 9, 17, 0.9);
+  padding: 9px 14px 11px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(7, 9, 17, 0.92);
 }
 
 .world-carousel-name {
   font-size: 13px;
   font-weight: 700;
-  color: rgba(235, 240, 255, 0.92);
+  color: rgba(235, 240, 255, 0.93);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--display-font);
+  font-family: var(--display-font, sans-serif);
 }
 
 .world-carousel-open {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
+  padding: 4px 11px;
   border-radius: 999px;
   background: rgba(58, 114, 200, 0.22);
-  border: 1px solid rgba(58, 114, 200, 0.42);
+  border: 1px solid rgba(58, 114, 200, 0.44);
   color: #a8c6ff;
   font-size: 11px;
   font-weight: 700;
@@ -915,26 +936,29 @@ svg {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  margin-top: 10px;
+  gap: 10px;
+  margin-top: 16px;
 }
 
 .world-carousel-btn {
   display: inline-grid;
   place-items: center;
-  width: 30px;
-  height: 30px;
+  width: 32px;
+  height: 32px;
   padding: 0;
-  border: 1px solid rgba(255, 255, 255, 0.28);
+  border: 1px solid rgba(58, 114, 200, 0.36);
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.52);
+  background: rgba(255, 255, 255, 0.72);
   color: #25304c;
   cursor: pointer;
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  transition: background 0.14s ease;
+  transition: background 0.14s ease, border-color 0.14s ease;
 }
-.world-carousel-btn:hover { background: rgba(255, 255, 255, 0.76); }
+.world-carousel-btn:hover {
+  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(58, 114, 200, 0.6);
+}
 .world-carousel-btn:focus-visible {
   outline: 2px solid rgba(21, 93, 212, 0.5);
   outline-offset: 2px;
@@ -951,7 +975,7 @@ svg {
 
 .world-carousel-dots {
   display: flex;
-  gap: 6px;
+  gap: 7px;
   align-items: center;
 }
 
@@ -961,30 +985,23 @@ svg {
   padding: 0;
   border: 0;
   border-radius: 50%;
-  background: rgba(17, 27, 69, 0.28);
+  background: rgba(58, 114, 200, 0.22);
   cursor: pointer;
   transition: background 0.18s ease, transform 0.18s ease;
 }
 .world-carousel-dot.is-active {
-  background: var(--accent);
-  transform: scale(1.25);
+  background: var(--accent, #3a72c8);
+  transform: scale(1.3);
 }
 .world-carousel-dot:focus-visible {
   outline: 2px solid rgba(21, 93, 212, 0.5);
   outline-offset: 2px;
 }
 
-/* On narrow screens the carousel sits in normal flow below the hero copy */
-@media (max-width: 1080px) {
-  .world-carousel {
-    width: min(420px, 100%);
-  }
-}
-
-@media (max-width: 540px) {
-  .world-carousel {
-    width: 100%;
-  }
+@media (max-width: 600px) {
+  .world-carousel { padding: 20px 0 18px; }
+  .world-carousel-inner { width: calc(100% - 32px); }
+  .world-carousel-slide { flex: 0 0 calc(100% - 32px); }
 }
 
 .scroll-cue {


### PR DESCRIPTION
Owner feedback: the home carousel showed the wrong worlds (tinyverse islands) and was in a bad spot (bottom-left, nested in the hero).

## Fixed
- **Data → user-built shared worlds**: new public `GET /api/home-worlds` reads `world_shares` (public Tiny World Builder shares), returns only `{id, name, gridSize, preview}` (no PII; cells sliced in SQL). Cards open the share at `/tiny-world-builder?share=<id>`.
- **Position → full-width strip directly UNDER the hero** (moved out of the hero corner into its own full-width section between the hero and the news teaser). Label: "Worlds from the community"; "Browse all" -> /templates.
- Restyled to a clean full-width horizontal card strip.
- Seeded 4 demo shared worlds so it has content.

## Verified
- **Looked at it in a real browser** (Claude-in-Chrome): full-width strip under the hero, isometric previews drawn, on-theme, cycles. (Screenshot reviewed.)
- Endpoint smoke-tested against the live DB (4 shares, correct gridSize/cells after fixing a JSONB double-encode in the seed).
- `npm run check` passes. No PII in the endpoint.

Non-economy (public discovery) -> ships to prod.

https://claude.ai/code/session_01WrNYuB1FHT1hCQo3GP77XK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new community worlds carousel on the landing page, with updated browsing links and runtime-loaded previews.
  * Introduced a public home worlds feed that surfaces recently updated community worlds.

* **Bug Fixes**
  * Improved carousel behavior and navigation for more reliable slide movement and keyboard controls.
  * Hid the carousel when no preview data is available, avoiding empty or broken displays.

* **Style**
  * Refreshed the landing page carousel layout, sizing, spacing, and responsive behavior for a more polished full-width presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->