### PR TITLE
Fix Stargate arrival walk-back, reseed rich demo world, animate animals, enlarge sword

### DIFF
--- a/engine/world/09b-voxel-build-factories.js
+++ b/engine/world/09b-voxel-build-factories.js
@@ -2410,21 +2410,37 @@
     const sheep = kind === 'sheep';
     const bodyMat = sheep ? M_ANIMAL.sheepWool : M_ANIMAL.cowWhite;
     const faceMat = sheep ? M_ANIMAL.sheepFace : M_ANIMAL.cowWhite;
-    vbox(g, sheep ? 0.34 : 0.42, sheep ? 0.24 : 0.26, sheep ? 0.22 : 0.24, 0, 0.22, 0, bodyMat);
-    vbox(g, sheep ? 0.14 : 0.18, sheep ? 0.14 : 0.16, sheep ? 0.12 : 0.16, 0.24, 0.30, 0, faceMat);
-    if (!sheep) {
-      vbox(g, 0.16, 0.04, 0.12, 0.02, 0.36, 0.05, M_ANIMAL.cowSpot);
-      vbox(g, 0.08, 0.08, 0.10, 0.36, 0.26, 0, M_ANIMAL.cowMuzzle);
-    } else {
-      for (const x of [-0.10, 0, 0.10]) vbox(g, 0.10, 0.06, 0.10, x, 0.36, 0.03, M_ANIMAL.sheepWool);
-    }
+    // Body on its own pivot so it can bob gently while ambling.
+    const body = new THREE.Group();
+    g.add(body);
+    vbox(body, sheep ? 0.34 : 0.42, sheep ? 0.24 : 0.26, sheep ? 0.22 : 0.24, 0, 0.22, 0, bodyMat);
+    if (!sheep) vbox(body, 0.16, 0.04, 0.12, 0.02, 0.36, 0.05, M_ANIMAL.cowSpot);
+    else for (const x of [-0.10, 0, 0.10]) vbox(body, 0.10, 0.06, 0.10, x, 0.36, 0.03, M_ANIMAL.sheepWool);
+    // Head pivots at the neck so it can dip down to nibble the grass while grazing.
+    const head = new THREE.Group();
+    head.position.set(0.24, 0.30, 0);
+    body.add(head);
+    vbox(head, sheep ? 0.14 : 0.18, sheep ? 0.14 : 0.16, sheep ? 0.12 : 0.16, 0, 0, 0, faceMat);
+    if (!sheep) vbox(head, 0.08, 0.08, 0.10, 0.12, -0.04, 0, M_ANIMAL.cowMuzzle);
+    // Legs hang from hip pivots so they swing fore/aft when walking. Order is
+    // front-left, front-right, back-left, back-right (consumed by 70-animal-anim).
+    const legs = [];
     [[0.13, -0.08], [0.13, 0.08], [-0.13, -0.08], [-0.13, 0.08]].forEach(([x, z]) => {
-      vbox(g, 0.06, 0.14, 0.06, x, 0.07, z, M_ANIMAL.hoof);
+      const hip = new THREE.Group();
+      hip.position.set(x, 0.14, z);
+      g.add(hip);
+      vbox(hip, 0.06, 0.14, 0.06, 0, -0.07, 0, M_ANIMAL.hoof);
+      legs.push(hip);
     });
-    g.userData = { kind };
+    // noVoxelBatch keeps the pivots separate (batching would flatten them and kill the
+    // animation); `anim` hands the moving parts to the per-frame grazer.
+    g.userData = { kind, animal: true, noVoxelBatch: true, anim: { body, head, legs } };
     castReceive(g);
     applyEditableObjectParts(g, opts);
     optimizeVoxelObjectGroup(g, { reason: 'voxel-animal' });
+    if (typeof window.__tinyworldRegisterAnimal === 'function') {
+      try { window.__tinyworldRegisterAnimal(g); } catch (_) {}
+    }
     return g;
   }
 

--- a/engine/world/25-animation-loop-schema.js
+++ b/engine/world/25-animation-loop-schema.js
@@ -40,6 +40,9 @@
     if (window.__tinyworldWatcherLayer && typeof window.__tinyworldWatcherLayer.tick === 'function') {
       try { window.__tinyworldWatcherLayer.tick(t, dt); } catch (_) {}
     }
+    if (typeof window.__tinyworldAnimalTick === 'function') {
+      try { window.__tinyworldAnimalTick(t, dt); } catch (_) {}
+    }
     repaintProfileEnd('tick.anim', tickStart);
 
     tickStart = repaintProfileBegin();

--- a/engine/world/47-worlds-room.js
+++ b/engine/world/47-worlds-room.js
@@ -857,6 +857,43 @@ function computeTaxCooldown(lastTaxChangeAt) {
         else if (typeof WS.leaveRoom === 'function') WS.leaveRoom();
       } catch (_) {}
     }
+    // The emerge animation (56's arriveFromGate) walks the VISUAL avatar a couple of feet
+    // out the gate's front, but the logical grid cell stays on the stargate tile. The moment
+    // travel ends, animVoxel tweens the avatar back toward that cell — so the player appears
+    // to arrive, turn around, and walk straight back into the portal. Fix: when arrival
+    // completes, settle the player's grid cell to a standable tile in the SAME direction they
+    // emerged (the gate's local +z), so the avatar drifts forward off the gate and stops
+    // there. Stepping off the gate cell also avoids instantly re-triggering its travel.
+    function settleAfterGateArrival(gateCell, gate) {
+      if (!selfEnt || !gateCell) return;
+      const gx = cellXOf(gateCell), gz = cellZOf(gateCell);
+      if (gx == null || gz == null) return;
+      // Emerge direction in world space = the gate opening's +z. worldRoomTilePos maps grid
+      // axes 1:1 onto world x/z, so snap that vector to the dominant cardinal to get the row
+      // or column the avatar walks out along.
+      let dx = 0, dz = 1;
+      try {
+        if (gate && gate.group && typeof THREE !== 'undefined') {
+          gate.group.updateWorldMatrix(true, false);
+          const fwd = new THREE.Vector3(0, 0, 1).transformDirection(gate.group.matrixWorld);
+          if (Math.abs(fwd.x) >= Math.abs(fwd.z)) { dx = Math.sign(fwd.x) || 1; dz = 0; }
+          else { dz = Math.sign(fwd.z) || 1; dx = 0; }
+        }
+      } catch (_) {}
+      // Prefer 2 cells out (≈ where the emerge animation ends) so the avatar steps FORWARD;
+      // fall back to 1 cell, then leave them on the gate if both are blocked.
+      let nx = gx, nz = gz;
+      for (const d of [2, 1]) {
+        const cx = gx + dx * d, cz = gz + dz * d;
+        if (standable(cx, cz)) { nx = cx; nz = cz; break; }
+      }
+      if (nx === gx && nz === gz) return;
+      you.x = nx; you.z = nz;
+      moveEntity(selfEnt, nx, nz);
+      try { send({ type: 'move', x: nx, z: nz }); } catch (_) {}
+      emit('you', you);
+      if (typeof drawMinimap === 'function') drawMinimap();
+    }
     function scheduleSelectionGateArrival() {
       if (!selectionGateArrivalPending || selectionGateArrivalTimer) return;
       let tries = 0;
@@ -874,7 +911,10 @@ function computeTaxCooldown(lastTaxChangeAt) {
         selectionGateArrivalPending = false;
         selfEnt._traveling = true;
         const ok = GT.arriveFromGate(gate, selfEnt.voxel, {
-          onArrive: () => { if (selfEnt) selfEnt._traveling = false; },
+          onArrive: () => {
+            settleAfterGateArrival(gateCell, gate);
+            if (selfEnt) selfEnt._traveling = false;
+          },
         });
         if (!ok && selfEnt) selfEnt._traveling = false;
       };

--- a/engine/world/52-worlds-demo-seed.js
+++ b/engine/world/52-worlds-demo-seed.js
@@ -1,9 +1,17 @@
-  // Tinyverse — demo resource seeder for local development.
-  // When entering a world on localhost that has no harvestable cells, injects a
-  // compact set of resource cells (water, stone, plant, animal) so foraging works
-  // out-of-the-box without the owner having to manually add terrain.
-  // Mutates world.data.cells BEFORE the WebSocket opens, so the augmented cells
-  // are sent in world.join and the server derives nodes from them.
+  // Tinyverse — demo world seeder for local development.
+  // When entering a world on localhost that has no harvestable cells, lays out a
+  // RICH scene so the demo feels alive out of the box: clustered voxel-stamp trees
+  // (oak grove / pine cluster / cherry), bushes and flowers as undergrowth, a piled
+  // rock highland on raised terrain, a low water pond beside it, a crop patch, and a
+  // central meadow of grazing animals (which amble + swing their legs via 70-animal-anim).
+  // Harvest still works: water = fish, stone = ore, crops = plants, animals = hunt.
+  //
+  // Layout keeps all BLOCKING props (trees/rocks/voxel-builds) in the four corners and
+  // off the central cross, so the cells the player emerges onto from the selection gate
+  // (see 47's settleAfterGateArrival) stay walkable.
+  //
+  // Mutates world.data.cells BEFORE the WebSocket opens, so the augmented cells are sent
+  // in world.join and the server derives nodes from them.
   // Guard: ONLY runs on localhost / 127.0.0.1. Never runs in production.
   (function wireWorldsDemoSeed() {
     'use strict';
@@ -37,37 +45,6 @@
       return used;
     }
 
-    // Place `count` cells of given terrain/kind in a corner area, skipping used cells.
-    function placeInCorner(existing, g, ox, oz, dx, dz, terrain, kind, count) {
-      const added = [];
-      let placed = 0;
-      for (let step = 0; step < g && placed < count; step++) {
-        const x = ox + dx * step;
-        const z = oz + dz * step;
-        if (x < 0 || x >= g || z < 0 || z >= g) continue;
-        if (!existing.has(x + ',' + z)) {
-          added.push(kind ? [x, z, terrain, kind] : [x, z, terrain]);
-          existing.add(x + ',' + z);
-          placed++;
-        }
-      }
-      return added;
-    }
-
-    // Build a small water body (3 cells in an L-shape) at given origin.
-    function placeWater(existing, g, ox, oz) {
-      const added = [];
-      const candidates = [[ox, oz], [ox + 1, oz], [ox, oz + 1]];
-      for (const [x, z] of candidates) {
-        if (x < 0 || x >= g || z < 0 || z >= g) continue;
-        if (!existing.has(x + ',' + z)) {
-          added.push([x, z, 'water']);
-          existing.add(x + ',' + z);
-        }
-      }
-      return added;
-    }
-
     function seedResources(world) {
       if (!world) return null;
       if (!world.data || typeof world.data !== 'object') world.data = { v: 4, gridSize: world.gridSize || 8, cells: [] };
@@ -79,30 +56,98 @@
       const g = world.gridSize || 8;
       const used = usedPositions(cells);
       const added = [];
+      const cx = Math.floor(g / 2), cz = Math.floor(g / 2);
 
-      // Water body in top-left corner (fish node).
-      added.push(...placeWater(used, g, 0, 0));
+      const inBounds = (x, z) => x >= 0 && z >= 0 && x < g && z < g;
+      // Place one cell. opts: { terrainFloors, floors, build } where `build` is a
+      // voxel-build stamp id. Emits the most compact tuple the schema allows.
+      function put(x, z, terrain, kind, opts) {
+        x = Math.round(x); z = Math.round(z);
+        if (!inBounds(x, z)) return false;
+        const key = x + ',' + z;
+        if (used.has(key)) return false;
+        used.add(key);
+        const tf = (opts && opts.terrainFloors) || 1;
+        const floors = (opts && opts.floors) || 1;
+        const build = opts && opts.build;
+        if (build) {
+          added.push([x, z, terrain, 'voxel-build', floors, null, tf, null, null, null, { voxelBuildId: build }]);
+        } else if (tf > 1 || floors > 1) {
+          added.push([x, z, terrain, kind || null, floors, null, tf]);
+        } else if (kind) {
+          added.push([x, z, terrain, kind]);
+        } else {
+          added.push([x, z, terrain]);
+        }
+        return true;
+      }
+      // Scatter a kind across a list of [x,z] offsets from an anchor.
+      function scatter(ax, az, offsets, terrain, kind, opts) {
+        for (const [dx, dz] of offsets) put(ax + dx, az + dz, terrain, kind, opts);
+      }
 
-      // Stone cells along the bottom edge (ore nodes).
-      added.push(...placeInCorner(used, g, 0, g - 1, 1, 0, 'stone', null, 3));
+      // ---------- TOP-LEFT: forest grove (voxel-stamp trees + undergrowth) ----------
+      // The "nice" multi-tree voxel stamps, spaced so each reads as its own clump.
+      put(1, 1, 'grass', null, { build: 'oak-grove-build' });
+      put(Math.min(cx - 1, 3), 1, 'grass', null, { build: 'pine-cluster-build' });
+      put(1, Math.min(cz - 1, 3), 'grass', null, { build: 'cherry-tree-build' });
+      // Single voxel trees filling the canopy (taller via floors), then low cover.
+      scatter(0, 0, [[2, 0], [0, 2], [2, 2]], 'grass', 'tree', { floors: 2 });
+      scatter(0, 0, [[3, 0], [0, 3]], 'grass', 'tree');
+      scatter(0, 0, [[1, 2], [2, 1], [3, 2], [2, 3]], 'grass', 'bush');
+      scatter(0, 0, [[0, 1], [1, 0], [3, 3]], 'grass', 'flower');
 
-      // Crop cells in the top-right corner (plant nodes).
-      added.push(...placeInCorner(used, g, g - 1, 0, 0, 1, 'grass', 'crop', 2));
-      added.push(...placeInCorner(used, g, g - 2, 0, 0, 1, 'grass', 'wheat', 1));
+      // ---------- TOP-RIGHT: crop patch (plant harvest) ----------
+      const rx = g - 2;
+      put(rx, 1, 'grass', null, { build: 'crop-patch-build' });
+      scatter(rx, 0, [[0, 2], [1, 2]], 'grass', 'wheat');
+      scatter(rx, 0, [[-1, 1], [0, 3]], 'grass', 'corn');
+      put(rx, Math.min(cz - 1, 3), 'grass', 'pumpkin');
+      put(rx - 1, 2, 'grass', 'sunflower');
+      put(rx + 1 < g ? rx + 1 : rx, 0, 'grass', 'carrot');
+      scatter(rx, 0, [[0, 0], [-1, 3]], 'grass', 'tuft');
 
-      // Animals near center-right (hunt node).
-      const cx = Math.max(0, g - 3), cz = Math.floor(g / 2);
-      const animalSpots = [[cx, cz], [cx + 1, cz]];
-      const animalKinds = ['cow', 'sheep'];
-      animalSpots.forEach(([x, z], i) => {
-        if (x >= g || z >= g || used.has(x + ',' + z)) return;
-        added.push([x, z, 'grass', animalKinds[i % animalKinds.length]]);
-        used.add(x + ',' + z);
-      });
+      // ---------- BOTTOM-LEFT: rock highland (piled rock on RAISED terrain) ----------
+      const bz = g - 2;
+      // A small plateau of raised stone (water sits lower beside it for contrast).
+      put(1, bz, 'stone', null, { terrainFloors: 3 });
+      put(2, bz, 'stone', null, { terrainFloors: 3 });
+      put(1, bz - 1, 'stone', null, { terrainFloors: 2 });
+      put(2, bz - 1, 'stone', null, { terrainFloors: 2 });
+      // Heaped rocks on top of / around the plateau — adjacency merges them into a pile.
+      put(1, bz, 'stone', 'rock', { terrainFloors: 3 });
+      put(2, bz, 'stone', 'rock', { terrainFloors: 3 });
+      put(1, bz - 1, 'stone', 'rock', { terrainFloors: 2 });
+      put(0, bz, 'grass', 'rock');
+      put(0, bz - 1, 'grass', null, { build: 'rock-outcrop-build' });
+      if (cx - 1 >= 3) put(3, bz, 'grass', 'rock');
+
+      // ---------- BOTTOM-RIGHT: low water pond (fish) ----------
+      const wx = cx + 1;
+      for (const [dx, dz] of [[0, 0], [1, 0], [0, 1], [1, 1], [2, 1]]) {
+        put(wx + dx, bz - 1 + dz, 'water', null);
+      }
+      // A few rocks at the waterline.
+      put(wx - 1, bz, 'grass', 'rock');
+      put(wx, bz - 2, 'grass', 'bush');
+
+      // ---------- CENTRE: grazing meadow (animals + standable ground cover) ----------
+      // Animals + tufts/flowers only here — all standable, so the spawn cross stays clear.
+      const meadow = [
+        [cx - 1, cz - 1, 'cow'], [cx + 1, cz, 'cow'],
+        [cx, cz + 1, 'sheep'], [cx + 1, cz + 1, 'sheep'], [cx - 1, cz + 1, 'sheep'],
+      ];
+      for (const [x, z, kind] of meadow) {
+        // never drop an animal on the centre gate cell itself
+        if (x === cx && z === cz) continue;
+        put(x, z, 'grass', kind);
+      }
+      scatter(cx, cz, [[-1, 0], [0, -1], [1, -1], [2, 0], [-2, 0]], 'grass', 'tuft');
+      scatter(cx, cz, [[1, -1], [-1, -1], [0, 2]], 'grass', 'flower');
 
       if (added.length > 0) {
         data.cells = [...cells, ...added];
-        console.log('[demo-seed] Seeded', added.length, 'resource cells into world', world.slug);
+        console.log('[demo-seed] Seeded rich demo world (' + added.length + ' cells) into', world.slug);
       }
       return added;
     }

--- a/engine/world/53-voxel-avatar.js
+++ b/engine/world/53-voxel-avatar.js
@@ -665,15 +665,17 @@
       }
 
       function addSwordGear(parent) {
+        // Sword scaled up ~1.5x (dimensions AND offsets together) so it reads clearly in the
+        // hand — the old slim 0.36-wide blade was barely visible at avatar scale.
         const g = grp(parent, 0, -0.7, 1.35); g.name = 'avatar-gear-sword';
-        const grip = gearBox(0.34, 1.15, 0.34, 'avatarGearLeather', 0x5c3a26);
-        grip.position.y = -0.15; g.add(grip);
-        const guard = gearBox(1.75, 0.24, 0.28, 'avatarGearGold', 0xd9a441);
-        guard.position.y = -0.82; g.add(guard);
-        const blade = gearBox(0.36, 4.5, 0.16, 'avatarGearSteel', 0xcfd8e6);
-        blade.position.y = -3.15; g.add(blade);
-        const tip = gearCone(0.34, 0.7, 4, 'avatarGearSteel', 0xcfd8e6);
-        tip.position.y = -5.75; tip.rotation.z = Math.PI; g.add(tip);
+        const grip = gearBox(0.51, 1.72, 0.51, 'avatarGearLeather', 0x5c3a26);
+        grip.position.y = -0.22; g.add(grip);
+        const guard = gearBox(2.62, 0.36, 0.42, 'avatarGearGold', 0xd9a441);
+        guard.position.y = -1.23; g.add(guard);
+        const blade = gearBox(0.54, 6.75, 0.24, 'avatarGearSteel', 0xcfd8e6);
+        blade.position.y = -4.72; g.add(blade);
+        const tip = gearCone(0.51, 1.05, 4, 'avatarGearSteel', 0xcfd8e6);
+        tip.position.y = -8.62; tip.rotation.z = Math.PI; g.add(tip);
       }
       function addStaffGear(parent) {
         const g = grp(parent, 0, -1.25, 1.1); g.name = 'avatar-gear-staff';

--- a/engine/world/70-animal-anim.js
+++ b/engine/world/70-animal-anim.js
@@ -1,0 +1,93 @@
+  // -------- grazing animal animation --------
+  // Cow/sheep meshes built by makeVoxelAnimal (09b) register here. Each frame the grazer
+  // swings their legs, bobs the body and dips the head, and lets them amble a short
+  // distance within their home tile before stopping to graze again — so a meadow of
+  // animals feels alive. Movement is purely cosmetic (a small wander around the tile the
+  // animal was placed on); the grid/harvest model is untouched.
+  //
+  // Driven from the main loop in 25-animation-loop-schema.js via window.__tinyworldAnimalTick.
+  (function wireAnimalAnimation() {
+    'use strict';
+    if (typeof window === 'undefined') return;
+
+    const herd = new Set();
+
+    function register(group) {
+      const st = group && group.userData && group.userData.anim;
+      if (!st) return;
+      st.homeSet = false;            // home captured lazily, after the tile renderer positions it
+      st.phase = 'graze';
+      st.timer = 0.4 + Math.random() * 1.8;
+      st.walkPhase = Math.random() * Math.PI * 2;
+      st.heading = group.rotation.y || 0;
+      st.targetHeading = st.heading;
+      st.tx = 0; st.tz = 0;
+      st.dip = 0;
+      herd.add(group);
+    }
+
+    const R = 0.26;       // wander radius in world units — keeps the animal inside its 1-unit tile
+    const SPEED = 0.3;    // amble speed (units/sec)
+
+    function tick(t, dt) {
+      if (!dt || !herd.size) return;
+      for (const g of herd) {
+        const st = g && g.userData && g.userData.anim;
+        if (!g.parent || !st) { herd.delete(g); continue; }   // mesh removed / re-rendered → drop it
+        if (!st.homeSet) {
+          st.homeX = g.position.x; st.homeZ = g.position.z;
+          st.tx = g.position.x; st.tz = g.position.z;
+          st.homeSet = true;
+        }
+
+        st.timer -= dt;
+        if (st.phase === 'graze') {
+          st.dip += (1 - st.dip) * Math.min(1, dt * 4);       // ease the head down to nibble
+          if (st.timer <= 0) {                                 // pick a new spot to amble to
+            const a = Math.random() * Math.PI * 2;
+            const r = R * (0.35 + Math.random() * 0.65);
+            st.tx = st.homeX + Math.cos(a) * r;
+            st.tz = st.homeZ + Math.sin(a) * r;
+            st.targetHeading = Math.atan2(st.tx - g.position.x, st.tz - g.position.z);
+            st.phase = 'walk';
+            st.timer = 1.0 + Math.random() * 1.6;
+          }
+        } else {                                               // walking
+          st.dip += (0 - st.dip) * Math.min(1, dt * 6);        // lift the head back up
+          const dx = st.tx - g.position.x, dz = st.tz - g.position.z;
+          const dist = Math.hypot(dx, dz);
+          if (dist > 0.01) {
+            const stepLen = Math.min(dist, SPEED * dt);
+            g.position.x += (dx / dist) * stepLen;
+            g.position.z += (dz / dist) * stepLen;
+            st.walkPhase += dt * 9;
+          }
+          if (dist <= 0.02 || st.timer <= 0) {                 // arrived / gave up → graze
+            st.phase = 'graze';
+            st.timer = 1.6 + Math.random() * 2.6;
+          }
+        }
+
+        // ease the facing toward the walk direction
+        let dh = st.targetHeading - st.heading;
+        while (dh > Math.PI) dh -= Math.PI * 2;
+        while (dh < -Math.PI) dh += Math.PI * 2;
+        st.heading += dh * Math.min(1, dt * 5);
+        g.rotation.y = st.heading;
+
+        // pose the moving parts
+        const walking = st.phase === 'walk';
+        const swing = walking ? Math.sin(st.walkPhase) * 0.5 : 0;
+        const legs = st.legs || [];
+        for (let i = 0; i < legs.length; i++) {
+          const diag = (i === 0 || i === 3) ? 1 : -1;          // diagonal gait
+          legs[i].rotation.x = swing * diag;
+        }
+        if (st.body) st.body.position.y = walking ? Math.abs(Math.sin(st.walkPhase)) * 0.02 : 0;
+        if (st.head) st.head.rotation.z = -st.dip * 0.7;
+      }
+    }
+
+    window.__tinyworldRegisterAnimal = register;
+    window.__tinyworldAnimalTick = tick;
+  })();

--- a/tiny-world-builder.html
+++ b/tiny-world-builder.html
@@ -1832,6 +1832,7 @@
   <script defer src="engine/world/67-cctv-view.js"></script>
   <script defer src="engine/world/68-notifications.js"></script>
   <script defer src="engine/world/69-watcher-layer.js"></script>
+  <script defer src="engine/world/70-animal-anim.js"></script>
   <script defer src="engine/world/99-late-boot.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## What & why

Three gameplay fixes for multiplayer Tinyverse mode.

### 1. Stargate arrival walk-back (bug)
Arriving through the selection-gate portal, you'd emerge and then immediately turn around and walk back into the gate.

**Cause:** `arriveFromGate` (56) walks the *visual* avatar a couple of feet out of the gate's opening, but the player's logical grid cell stays on the stargate tile. The instant travel ends, `animVoxel` tweens the avatar back toward that cell — straight into the portal.

**Fix:** new `settleAfterGateArrival` in `47-worlds-room.js` steps the player's grid cell to a standable tile in the *same direction they emerged* (the gate's local `+z`, snapped to the dominant grid axis). The avatar drifts forward off the gate and stops. Stepping off the gate cell also stops it instantly re-triggering travel. Prefers 2 cells out (≈ where the emerge animation ends), falls back to 1.

### 2. Richer demo world (`52-worlds-demo-seed.js`)
Replaced the minimal resource injector with a laid-out scene:
- **Forest grove** (top-left): clustered voxel-stamp trees — oak grove, pine cluster, cherry — plus single trees, bushes, flowers.
- **Rock highland** (bottom-left): heaped `rock` on raised (`terrainFloors`) stone terrain + a rock-outcrop stamp.
- **Low water pond** (bottom-right) beside the highland.
- **Crop patch** (top-right) with a crop-patch stamp + wheat/corn/pumpkin/sunflower/carrot.
- **Grazing meadow** (centre): cows + sheep among ground cover.

All *blocking* props (trees/rocks/voxel-builds) stay in the corners and off the central cross, so the cells the player emerges onto from the gate stay walkable. Harvest resources (fish/ore/plants/hunt) preserved. Still localhost-only.

### 3. Animated grazing animals
`makeVoxelAnimal` (09b) now builds the head and legs as pivot groups (kept unbatched). A new per-frame grazer (`70-animal-anim.js`, driven from the animation loop in 25) swings the legs in a diagonal gait, bobs the body, dips the head to nibble, and lets each animal amble a short distance within its home tile before grazing again. Purely cosmetic — the grid/harvest model is untouched.

### 4. Held sword size
Scaled the held sword ~1.5× (dimensions and offsets together so it stays anchored in the hand) — the old `0.36`-wide blade was barely visible at avatar scale.

## Testing
- `node tools/check.js` ✓
- `node tools/smoke-static.js` ✓
- Unit tests covering changed areas (camera-walk, worlds-exit, party) — 71/71 ✓
- (8 unrelated failures in account/community/db/wallet suites are pre-existing in this container: missing `@netlify/identity` dependency.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwDkAN78gZGUJQzEhRPCBx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwDkAN78gZGUJQzEhRPCBx)_