### PR TITLE
Fix demo-world grid-size mismatch (island rendered bigger than the minimap)

### DIFF
--- a/engine/world/52-worlds-demo-seed.js
+++ b/engine/world/52-worlds-demo-seed.js
@@ -53,7 +53,20 @@
       const cells = data.cells;
       if (hasResources(cells)) return null;
 
-      const g = world.gridSize || 8;
+      // Pin the home-grid size so the rendered island can't diverge from the minimap.
+      // The builder sizes the 3D board via coerceGridSize(data.gridSize, GRID); when
+      // data.gridSize is missing it falls back to whatever GRID was left over from a
+      // previously-visited world (often a 20x20 one), so the island renders huge while
+      // the minimap still shows the world's real (e.g. 8x8) size — the recurring
+      // "8x8 vs 20x20" mismatch. Coerce ONE valid size and stamp it on both the data
+      // grid and the world hint, then keep every seeded cell inside it.
+      const coerce = (typeof coerceGridSize === 'function')
+        ? (v) => coerceGridSize(v, 8)
+        : (v) => { let g = 8; for (const n of [8, 10, 12, 16, 20]) if (v >= n) g = n; return g; };
+      const g = coerce(Number(world.gridSize) || Number(data.gridSize) || 8);
+      data.gridSize = g;
+      world.gridSize = g;
+
       const used = usedPositions(cells);
       const added = [];
       const cx = Math.floor(g / 2), cz = Math.floor(g / 2);


### PR DESCRIPTION
## The bug

In multiplayer Tinyverse the room minimap showed the world at its real size (e.g. 8×8) but the rendered 3D island was much bigger — the recurring "8×8 vs 20×20" grid-size mismatch.

## Root cause

The localhost demo seeder (`52-worlds-demo-seed.js`) runs only on **resource-less** worlds, and those frequently have **no `data.gridSize`**. The room builds the board with:

```
applyState(w.data)  →  GRID = coerceGridSize(w.data.gridSize, GRID)
```

When `data.gridSize` is missing, `coerceGridSize` falls back to the **leftover `GRID` from a previously-visited world** (often a 20×20 one). So the board rendered 20×20 while the minimap (`w.gridSize || w.data.gridSize || 8`) still showed 8×8. The seeder placed its cells in the 8×8 region, leaving the rest of the oversized board empty — an island visibly bigger than the map.

## Fix

Before seeding, coerce one valid home-grid size from `world.gridSize` / `data.gridSize` / `8` and stamp it on **both** `world.gridSize` (the minimap source) and `data.gridSize` (the `applyState` board source), then keep every seeded cell inside it. Now minimap size == board size == seeded area.

The pin runs **only after** the no-resources guard, so real published worlds — which may legitimately use non-option sizes like 18/22 — are never reshaped.

## Testing
- `node tools/check.js` ✓
- `node tools/smoke-static.js` ✓
- Unit tests for the changed areas (camera-walk, worlds-exit, party) — 71/71 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwDkAN78gZGUJQzEhRPCBx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwDkAN78gZGUJQzEhRPCBx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an inconsistency in the demo world’s grid sizing so the rendered view and minimap now stay in sync.
  * Seeded cells now use a single, consistent grid size, reducing cases where the display could appear as different sizes in different parts of the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->