### PR TITLE
Sync local random island builder config

### DIFF
--- a/.codex/skills/tinyworld-lowpoly-world-prompt/SKILL.md
+++ b/.codex/skills/tinyworld-lowpoly-world-prompt/SKILL.md
@@ -99,12 +99,21 @@ Offline random island generation:
   must update that manifest and its source digest in the same patch.
 - Keep emitted cells complete v4 object cells: `x`, `z`, `terrain`, `kind`,
   `floors`, `terrainFloors`, `buildingType`, and `fenceSide`.
+- Offline random islands currently emit a flat terrain surface:
+  `terrainFloors: 1` for every generated cell. Keep island identity in terrain
+  material, roads, water composition, object grouping, traits, and economy
+  profile rather than generated height variation.
 - Map lab-only tokens explicitly to real renderer support. Examples:
   watchtower/castle -> `kind:"house"` with `buildingType:"tower"`,
   manor -> `kind:"house"` with `buildingType:"manor"`, lamp -> `lamp-post`,
   berries -> `bush`, ore -> `crystal`, water-bridge -> `bridge` on water.
   Do not invent unsupported `kind` values just because the lab catalogue has
   a matching label.
+- Generated random islands suppress props that have no generation economy
+  effect before save output. `spotlight` is explicitly generation-suppressed
+  even though legacy mapping/scoring still understands it for compatibility.
+- Generated random islands may keep `lamp-post` as Commerce/Charm punctuation,
+  but final output is capped at two lamps and lamps must not be adjacent.
 - Generated placed objects should set `appearance.objectStyle = "voxel"` so
   the in-app test exercises the existing voxel asset factories instead of the
   standalone lab's flat preview tokens.
@@ -121,6 +130,10 @@ Offline random island generation:
   polish runs after the identity grammar, and final validation repairs any
   displaced floors. Residual scatter is for small accents only, not the primary
   source of meaningful resources.
+- Food areas should read as deliberate farm plots, not random sprinkles:
+  generated crops prefer a compact square-ish region and avoid the immediate
+  one-cell ring around main `house` / `manor` habitation when space allows.
+  Tower houses are landmarks and do not count as the main-house food buffer.
 - Towers are owned by the corner landmark pass, not by archetype scatter:
   generated `watchtower`/`castle` tokens should resolve to corner-adjacent
   `kind:"house", buildingType:"tower"` cells with the count profile

--- a/.codex/skills/tinyworld-render-performance/SKILL.md
+++ b/.codex/skills/tinyworld-render-performance/SKILL.md
@@ -90,11 +90,19 @@ GPU caches (introduced for low-end GPU + visible-distance scaling):
   `findFenceRenderSpan()` / `makeVoxelFenceSpan()` while keeping per-cell
   `world` intent and tile picking unchanged. Refresh the full connected fence
   component after edits so old anchors/non-anchors do not linger.
+- Fence edge posts belong on the true tile edge/corner coordinates (`±0.50`),
+  not inset inside the cell. This lets perpendicular sides and neighboring
+  cells visually share one corner post while preserving the same adjacency
+  intent.
 - Waterfall froth/foam should drift slowly. Keep `WATERFALL_FROTH_SPEED`
   conservative (currently `0.30`) so the white puff layer reads as moving foam,
   not flashing particles.
 - The object/stamp voxel bevel is a persisted render setting (`tinyworld:render:voxelBevel`) applied inside `vbox()` through cached centered voxel box geometry. It is intentionally fine-grained (0.001 steps) so tiny voxels can keep only a slight softened edge. Keep it subtle and global; do not hand-bevel individual stamps unless they need a genuinely different silhouette.
-- Voxel terrain top panels need a small width/depth overlap. Exact edge-to-edge panels produce sub-pixel cracks in the pixelated render path, especially on dark soil. Do not add a full top underlay to hide seams: terrain tile fade materials are transparent/depthWrite-off, so broad underlays can sort over the voxel panels and make the surface read flat.
+- Terrain tile geometry must stay inside the logical cell footprint. Do not use
+  x/z overhangs on tile tops, risers, voxel top panels, riser panels, or cheap
+  ghost terrain; every terrain tile should share the same `TILE` bounds in x/z.
+  If cracks appear, solve them with material/shader treatment or camera/post
+  tuning, not by overlapping neighbouring terrain vertices or faces.
 - Terrain leak blockers belong under the dirt/riser body as bottom caps, not beneath the visible top surface. Mark those caps `userData.noShadow = true` and keep `castReceive()` respecting that flag so they block sky/background misses without adding shadow cost or flattening voxel tops.
 - Terrain/island side and riser meshes must not receive projected shadows. Tag side-only risers/kerbs/rims with `userData.noReceiveShadow = true` and keep `groundReceiveOnly()` respecting it; otherwise sun shadows from top content draw large diagonal bands on vertical side materials that appear to rotate while orbiting the camera.
 - Far zoom/VOD also disables terrain shadow receivers via `updateTerrainShadowReceiversForCamera()` so cap/top meshes that necessarily combine top + vertical side faces cannot show distant diagonal shadow bands. Preserve the near/far cutoff as a zoom-aware terrain-only shadow LOD; object shadows can read close-up, but distant terrain sides should stay clean.
@@ -127,6 +135,10 @@ GPU caches (introduced for low-end GPU + visible-distance scaling):
   Three may reuse a stock/local-UV program and side textures appear to rotate
   when the camera orbits.
 - Generated/imported world application supports sliced progressive rendering. In sliced mode, `applyState(..., { sliced: true })` sorts terrain and object/detail passes by distance from `opts.renderOrigin` or the current camera `target`, so visible/nearby cells appear before farther cells. Preserve that distance-ranked ordering when changing generation rendering. Demo/stress routes may pass `skipGhostBoards: true` to keep a large home board from also preloading preview boards; in that mode `applyState` should zero the in-memory preview distance, sync the ghost budget, and clear ghost boards without persisting render settings.
+- Generated random islands request a one-shot terrain bake through
+  `window.__tinyworldRequestTerrainBake()` after the sliced apply pass finishes.
+  This keeps merged terrain a render optimization: picking resolves baked cells
+  from hit coordinates, and terrain edits unbake back to live per-cell tiles.
 - Stamps panel card thumbnails share the toolbar thumbnail renderer/cache but should not synchronously build every 3D thumbnail during open/search/category renders. Keep fallback thumbs immediate, cancel stale card-thumb queues on panel re-render, and drain expensive card thumbs in small `requestAnimationFrame` batches.
 - Home grids above the windowing threshold are **intent-full / render-windowed**: `world[][]` may hold the full 512×512 board, but `cellMeshes` must only hold the camera-centred home render window. Keep large-grid bulk load/clear paths on intent writes plus `requestHomeRenderWindowSync()`, not `GRID²` mesh rebuilds. Keep `world[][]` sparse: virtual default grass comes from `getWorldCell()`/`ensureWorldCell()`, not from preallocating `HOME_GRID_MAX²` cells. Any direct `world[x][z]` read on an editing/API path must either guard the row or use `getWorldCell()` so untouched large-grid rows still behave as default terrain.
 - Duplicate editable islands follow the same sparse-intent rule: a new island gets one pickable default grass surface and only edited cells get materialized through `setCell()`. Do not restore per-island `GRID²` grass seeding; 50 islands must stay mostly proxies/sparse cells until edited.
@@ -185,6 +197,10 @@ GPU caches (introduced for low-end GPU + visible-distance scaling):
   lighting conservative now that there is no post pass; time-of-day
   hemisphere scaling should normalize against the day anchor (`0.90`), not
   the raw constructor value, or midday blows out.
+- The non-shadowing environment/fill stack is currently lifted by
+  `ENVIRONMENT_LIGHT_MULTIPLIER = 2.0` in `02-cameras-lighting.js`; this
+  brightens ambient/hemi/fill/model-stamp safety lights without increasing the
+  shadow-casting sun.
 - Imported GLB/model stamps also have named non-shadowing safety lights:
   `model-stamp-import-ambient-fill` and
   `model-stamp-import-directional-fill`. They are adapted from the

--- a/.codex/skills/tinyworld-shader-fx/SKILL.md
+++ b/.codex/skills/tinyworld-shader-fx/SKILL.md
@@ -51,8 +51,10 @@ the landscape ocean. A Settings toggle upgrades water everywhere:
 - Voxel water: injected in **`applyFlowingWaterUVs`** (`04-textures.js`) — the single
   `onBeforeCompile` chokepoint for every water material (base + flow clones). Stays
   Lambert; projects each water vertex into the shared planar reflection texture, then adds
-  ripple-normal bend, light caustics, Blinn-Phong glint, and foam, masked by `vTwWaterNrm.y`
-  so sides stay calm. Shared `waterShaderTimeUniform` advanced in `tickWaterTextureFlow`.
+  refractive bend, ripple-normal sheen, Blinn-Phong glint, and crest foam, masked by
+  `vTwWaterNrm.y` so sides stay calm. The refractive sampler must use the derived
+  world-flow UV (`vTwWaterSurfaceUv` / the same coordinates assigned to `vMapUv`), not
+  raw mesh `vUv`. Shared `waterShaderTimeUniform` advanced in `tickWaterTextureFlow`.
   **`customProgramCacheKey` is mandatory** here — without it three.js would reuse the wrong
   program when the toggle flips (onBeforeCompile output isn't in the default cache key).
   Include the shader-variant string in both the program key and flow-material cache key
@@ -66,6 +68,9 @@ the landscape ocean. A Settings toggle upgrades water everywhere:
 - On toggle: `refreshWaterShaderMaterials()` (clears `waterFlowMaterialCache`, resets the
   base materials) then `rebuildTerrainRender()`; the handler also sets the live landscape
   `uEnhance`. Waterfalls are untouched (separate shaders).
+- The water albedo texture named `ripples` is intentionally neutral/no-stripe.
+  Do not re-add baked horizontal/wavy line decals there; visible motion should
+  come from the reflective/refractive shader and shoreline/waterfall edge foam.
 
 ## TinyShaderFX library (engine/world/45-shader-fx.js)
 

--- a/.codex/skills/tinyworld-single-file/SKILL.md
+++ b/.codex/skills/tinyworld-single-file/SKILL.md
@@ -11,6 +11,7 @@ Core rules:
 
 - Keep the builder app single-file at runtime: inline CSS, inline JS, no bundler, no npm runtime packages.
 - Root `index.html` is a static landing page entry point; the builder remains available at `/tiny-world-builder` and `/tiny-world-builder.html`.
+- `random-island-preview.html` is a standalone local-dev control shell for random-island reveal/card iteration. It embeds `/tiny-world-builder?randomIslandPreview=1` so the visible island is the real Three.js game renderer, then talks to the app by `postMessage` to generate, load, and export reveal/game JSON. Production Netlify shares it through the private `netlify/functions/random-island-preview.mjs` route instead of copying the HTML as a public static file.
 - Do not touch `tiny-world-builder BACKUP.html` if present.
 - Preserve style: 2-space indent, semicolons, single-quoted strings, section comments like `// -------- tools --------`.
 - Mutate board state through `setCell(x, z, opts)`, not direct `world[x][z]` writes outside initialization.

--- a/docs/SHADERS.md
+++ b/docs/SHADERS.md
@@ -1,8 +1,10 @@
 # Shaders & GPU FX
 
 Tiny World Builder is stylized low-poly, so its shaders favour cheap,
-fully-procedural effects (hash-noise / fbm, no texture fetches, no extra render
-targets) over physically-based realism. The techniques are lifted and adapted
+fully-procedural effects (hash-noise / fbm) over physically-based realism. The
+enhanced water reflection pass is the explicit exception: it uses one shared
+planar render target so water can sample the real scene instead of a fake
+highlight. The techniques are lifted and adapted
 from [lettier/3d-game-shaders-for-beginners](https://github.com/lettier/3d-game-shaders-for-beginners)
 (lighting, fog, normal mapping, posterization, dithering, outlining) and tuned to
 sit next to the cel-shaded terrain.
@@ -12,7 +14,7 @@ sit next to the cel-shaded terrain.
 | System | File | Notes |
 | --- | --- | --- |
 | Terrain (sand / cel low-poly) | `engine/landscape/shaders.js` | `SAND_FS`, `LOWPOLY_FS`; ripple normals, sparkle, rim, hemi, fog/haze |
-| Ocean water plane | `engine/landscape/water.js` | flowing ripples, foam, fresnel, Blinn-Phong glint, depth tint |
+| Ocean water plane | `engine/landscape/water.js` | planar scene reflection, refractive bend, flowing ripples, foam, fresnel, Blinn-Phong glint, depth tint |
 | Voxel-world waterfalls / water flow | `engine/world/05-tile-factory.js` | curtain + surface shader sheets, batched foam puffs |
 | Reusable FX library | `engine/world/45-shader-fx.js` | `window.TinyShaderFX` — water, waterfall, foam, smoke, explosion, wear |
 | Island side strata, propeller blur disc, shield | various `engine/world/*` | bespoke ShaderMaterials |
@@ -33,6 +35,10 @@ upgrades, at roughly the same GPU cost as the old single-layer ripple:
   feeding both lighting and reflection.
 - **Blinn-Phong sun glint** (`specPower`) plus a soft broad sheen.
 - **Fresnel sky reflection** mixing `skyBottom`→`skyTop`.
+- **Planar scene reflection** from `tw-water-planar-reflection`, sampled through
+  `reflectionMatrix`.
+- **Refractive bend** using `refract(-viewDir, norm, 0.7502)` to steer local
+  colour/caustic variation.
 - **Foam** (`foamColor`, `foamAmount`) on animated wave crests and as a shoreline
   ring at the island runway edge.
 - **Depth tint** with a hint of subsurface back-glow on the shallow colour.
@@ -50,11 +56,13 @@ persisted as `tinyworld:render:enhancedWater`) that works in **every** environme
   enhancement is injected at the one chokepoint every water material flows
   through — `applyFlowingWaterUVs` in `engine/world/04-textures.js`. It keeps the
   material a `MeshLambertMaterial` (so colour shades, flow direction, and the
-  wear slider keep working) and, via `onBeforeCompile`, adds an animated ripple
-  normal → moving light/dark bands, fresnel sky sheen, sharp Blinn-Phong sun
-  glints and foam — masked to upward-facing faces so the tile sides stay calm. A
-  shared `uWaterTime` uniform (advanced in `tickWaterTextureFlow`) drives them
-  all, and a `customProgramCacheKey` makes the toggle recompile cleanly at runtime.
+  wear slider keep working) and, via `onBeforeCompile`, projects each water
+  vertex into the shared planar reflection texture, then layers refractive bend,
+  ripple-normal sheen, sharp Blinn-Phong sun glints, and crest foam — masked to
+  upward-facing faces so the tile sides stay calm. The refractive map sample uses
+  the same world-flow UV assigned to `vMapUv`, not raw mesh `vUv`. A shared
+  `uWaterTime` uniform (advanced in `tickWaterTextureFlow`) drives the motion, and
+  a `customProgramCacheKey` makes the toggle recompile cleanly at runtime.
 - **LandscapeEngine ocean** (`engine/landscape/water.js`): the same toggle drives a
   `uEnhance` uniform that scales the foam / sheen / subsurface terms, so turning it
   off falls back toward the simpler original look.

--- a/docs/random-island-generation-assets.md
+++ b/docs/random-island-generation-assets.md
@@ -1,10 +1,10 @@
 # Random Island Generation Asset Manifest
 
-Manifest version: `2026-06-27.1`
+Manifest version: `2026-06-27.4`
 
 Source: `engine/world/26-ai-generation.js`
 
-Source digest: `sha256-b264f7982d0c6321`
+Source digest: `sha256-5bbd562822d1abe2`
 
 Canonical path: `docs/random-island-generation-assets.md`
 
@@ -25,6 +25,40 @@ island generator currently knows about. Shipped GLB/texture/runtime assets stay
 in `models/`, `textures/`, `assets/`, or `engine/world/assets/`; generated sample
 and stats output stays ignored under `random-island-runs/` and
 `stats-runs/random-island/`.
+
+## Generation Selection Pipeline
+
+Random island generation uses a narrower final selection than the full catalog
+below. The catalog records every lab token the generator can recognize, map, or
+keep compatible with older output, but final generated islands use this order:
+
+1. Choose an archetype from prompt/settings mix and seed.
+2. Select terrain from the archetype terrain weights, deterministic terrain
+   motifs, road/path carving, validation passes, and a final minimum of five
+   saved `water` terrain cells.
+3. Select object candidates from economy viability floors, archetype object
+   weights, motif ownership passes, water-bridge validation, and residual
+   scatter. Food crops prefer a compact square-ish plot and keep at least one
+   empty cell of separation from main houses/manors when space allows.
+4. Apply generation-only suppression before save output. Suppressed props stay
+   documented for compatibility, but new random islands should not emit them.
+5. Map surviving lab tokens to native TinyWorld cells and score economy from
+   the mapped, rendered output.
+6. Cap generated lamp output to at most two `lamp-post` cells, and never place
+   those lamps adjacent to each other.
+7. Render generated island terrain as a flat, constant-height surface
+   (`terrainFloors: 1`) so terrain identity comes from material, coastline,
+   roads, and object composition rather than height variation.
+8. Request the terrain mesh bake after generated islands finish applying so
+   static terrain surfaces can be merged by material while per-cell picking
+   remains coordinate-derived.
+
+Use the status column to tell whether a token is part of the final generated
+selection. `Active` means the token can be emitted by new random islands.
+`Generation-suppressed` means the token may still be catalogued, weighted, or
+mapped for older data, but should not survive final generation. `Dormant`,
+`hidden`, and `map-supported` tokens are compatibility or planned semantics, not
+ordinary generated choices.
 
 ## Terrain Tokens
 
@@ -48,6 +82,9 @@ Final TinyWorld terrain mapping:
 | cliff | stone |
 
 The generator does not currently emit `lava` or `snow`.
+
+Generated random-island cells currently emit `terrainFloors: 1` for every
+terrain token.
 
 ## Lab Object Catalog
 
@@ -77,8 +114,8 @@ The generator does not currently emit `lava` or `snow`.
 | berries | grass, prairie, dirt | Active food/charm token; maps to bush. |
 | cow | grass, prairie | Active food token. |
 | sheep | grass, prairie | Active food/charm token. |
-| lamp | path, grass | Active commerce/charm token; maps to lamp-post. |
-| spotlight | path, stone, cliff | Active defense token. |
+| lamp | path, grass | Active commerce/charm token; maps to lamp-post. Final output is capped at two non-adjacent lamps. |
+| spotlight | path, stone, cliff | Generation-suppressed non-functional prop; legacy/pre-filter defense candidate only. |
 | ruins | grass, stone, cliff, dirt | Active relic/charm token. |
 | crystal | stone, cliff, grass | Active materials/charm token. |
 | totem | grass, prairie, stone | Active relic/charm token. |
@@ -113,7 +150,7 @@ All generated placed objects request voxel styling with
 | cow | `kind: "cow"`, floors 1 |
 | sheep | `kind: "sheep"`, floors 1 |
 | lamp | `kind: "lamp-post"`, floors 1 |
-| spotlight | `kind: "spotlight"`, floors 1 |
+| spotlight | Legacy/manual mapping only: `kind: "spotlight"`, floors 1; suppressed from new generated islands |
 | ruins | `kind: "ruins"`, floors 1-3 |
 | totem | `kind: "totem"`, floors 1-3 |
 
@@ -154,10 +191,19 @@ Current enclosure conventions:
 Crop and animal components are fenced separately. If a crop and animal touch,
 the shared boundary gets a fence edge instead of becoming a gate.
 
+Generated food areas prefer compact square-ish crop plots over loose single
+cells. Crop placement also avoids the immediate one-cell ring around main
+habitation (`house` / `manor`) so the farm reads as its own clear area instead
+of being glued to the front door. Towers are excluded from this house buffer.
+
 ## Archetype Weights
 
-These weights are selection weights, not exact counts. Motif passes and
-validation rules can also place assets directly.
+These weights are pre-filter selection weights, not exact counts. Motif passes
+and validation rules can also place assets directly. Tokens marked
+generation-suppressed in the catalog are legacy candidates only and should not
+survive the final emitted selection. Any mapped object that contributes to no
+Food / Materials / Commerce / Defense / Charm bucket is also skipped before
+save output.
 
 ```js
 pastoral.terrain = { grass: 5, prairie: 5, dirt: 1, path: 1, stone: 0.5, sand: 0.7 }
@@ -167,6 +213,7 @@ forest.terrain = { grass: 6, prairie: 1, dirt: 2, stone: 0.8, cliff: 0.4, path: 
 forest.objects = { tree: 6, berries: 2, flower: 1.5, stone: 1, ore: 0.4, crystal: 0.4, house: 0.6, garden: 0.8 }
 
 quarry.terrain = { stone: 5, cliff: 3, dirt: 2, grass: 1.5, path: 1, sand: 0.3 }
+// spotlight is a legacy/pre-filter candidate and is generation-suppressed.
 quarry.objects = { stone: 4, ore: 3, crystal: 1.3, watchtower: 1, ruins: 0.8, spotlight: 0.8, tree: 0.5 }
 
 river.terrain = { grass: 3, prairie: 2, sand: 2, path: 1.2, dirt: 1, stone: 0.8 }
@@ -176,6 +223,7 @@ village.terrain = { grass: 3, path: 3, prairie: 1.2, dirt: 1.4, stone: 0.8, sand
 village.objects = { house: 4, manor: 1.6, lamp: 2, garden: 1.8, crop: 1.5, tree: 1.2, flower: 1.2, watchtower: 0.8 }
 
 fortress.terrain = { cliff: 3, stone: 3, path: 2, grass: 1.5, dirt: 1 }
+// spotlight is a legacy/pre-filter candidate and is generation-suppressed.
 fortress.objects = { watchtower: 4, castle: 2.5, spotlight: 2, stone: 1.5, lamp: 1, house: 0.8 }
 
 ruins.terrain = { grass: 2.5, stone: 2.5, dirt: 2, cliff: 1, path: 0.8, prairie: 0.5 }
@@ -209,7 +257,7 @@ Resource bucket membership:
 | food | crop, corn, wheat, pumpkin, carrot, sunflower, cow, sheep, berries |
 | materials | tree, stone, ore, crystal, logs |
 | commerce | house, manor, lamp, bridge, water-bridge |
-| defense | watchtower, spotlight, castle |
+| defense | watchtower, castle, totem; spotlight is legacy/pre-filter only |
 | charm | flower, berries, tree, crystal, ruins, totem |
 
 ## Economy System Alignment
@@ -254,6 +302,9 @@ Gaps to keep visible:
   native cells. It relies on live derivation from terrain/kind. That is fine for
   water, stone, crops, and animals, but custom or non-obvious resource assets
   should use explicit metadata.
+- Random island generation suppresses props with no generation economy effect
+  before save output; `spotlight` is explicitly suppressed even though older
+  preview scoring treated it as a Defense candidate.
 - World-card purchase pricing uses live `fish`, `ore`, `plants`, and `meat`
   readiness. It does not use reveal `potential`, rarity, Commerce, Defense, or
   Charm yet.
@@ -276,19 +327,19 @@ economic output from visual material names, colors, or model shape.
 | Road/path carving | path |
 | Economy food floor | house anchor plus crop, wheat, corn, pumpkin, carrot, sunflower, flower, fence edge extras |
 | Economy materials floor | tree, berries, stone, ore, crystal |
-| Economy commerce floor | lamp, house |
-| Economy defense floor | spotlight |
+| Economy commerce floor | lamp, house; final lamp output is capped at two non-adjacent lamps |
+| Economy defense floor | totem; spotlight is legacy/pre-filter only |
 | Economy charm floor | flower, berries, tree, crystal, totem |
 | Corner tower motif | watchtower |
 | Crop plot motif | crop, wheat, corn, sunflower, pumpkin, carrot, fence edge extras |
 | Animal pen motif | cow, sheep, fence edge extras |
-| Settlement block motif | house, manor, lamp |
+| Settlement block motif | house, manor, lamp, with final lamp cap |
 | Pathside home motif | house |
 | Grove motif | tree, berries, flower |
 | Quarry seam motif | stone, ore, crystal |
 | Relic site motif | totem, ruins, crystal |
 | Water bridge validation | water-bridge |
-| Residual scatter | tree, garden, stone, berries, flower, lamp, spotlight |
+| Residual scatter | tree, garden, stone, berries, flower, lamp, with final lamp cap; spotlight is legacy/pre-filter only |
 
 Notes:
 
@@ -298,3 +349,6 @@ Notes:
   version markers for planned or partially ported lab semantics.
 - If a new token is added to `objectDefs`, it should also get a status here:
   active, hidden, map-supported, or dormant.
+- Generated island terrain requests the home terrain bake after the chunked
+  apply pass. Edits can unbake the affected cells and rebuild live tiles, so the
+  merged mesh stays a render optimization rather than a save-format feature.

--- a/engine/world/01-render-core.js
+++ b/engine/world/01-render-core.js
@@ -164,6 +164,7 @@
     uiTheme: 'tinyworld:uiTheme',
     shadow: 'tinyworld:render:shadow',
     lighting: 'tinyworld:render:lighting',
+    directionalSun: 'tinyworld:render:directionalSun',
     ambientFill: 'tinyworld:render:ambientFill',
     frontFill: 'tinyworld:render:frontFill',
     sideFill: 'tinyworld:render:sideFill',
@@ -242,6 +243,7 @@
     uiTheme: 'auto',
     shadow: 'balanced',
     lighting: '0.78',
+    directionalSun: '1',
     ambientFill: '1.00',
     frontFill: '0.48',
     sideFill: '0.40',
@@ -388,6 +390,7 @@
   let renderContrast = storedNumber(RENDER_LS.contrast, parseFloat(RENDER_DEFAULTS.contrast), 0.85, 1.25);
   let renderShadowQuality = localStorage.getItem(RENDER_LS.shadow) || 'balanced';
   let renderLighting = storedNumber(RENDER_LS.lighting, parseFloat(RENDER_DEFAULTS.lighting), 0.5, 1.45);
+  let renderDirectionalSun = storedNumber(RENDER_LS.directionalSun, parseFloat(RENDER_DEFAULTS.directionalSun), 0, 10);
   let renderAmbientFill = storedNumber(RENDER_LS.ambientFill, parseFloat(RENDER_DEFAULTS.ambientFill), 0, 1);
   let renderFrontFill = storedNumber(RENDER_LS.frontFill, parseFloat(RENDER_DEFAULTS.frontFill), 0, 1);
   let renderSideFill = storedNumber(RENDER_LS.sideFill, parseFloat(RENDER_DEFAULTS.sideFill), 0, 1);

--- a/engine/world/02-cameras-lighting.js
+++ b/engine/world/02-cameras-lighting.js
@@ -173,6 +173,11 @@
   //      its position and shadow camera follow `target` every frame so
   //      shadows render correctly anywhere on the world, not just near
   //      the home board origin.
+  // Environment multiplier lifts all non-shadowing scene light without making
+  // the sun harsher or increasing shadow-map cost.
+  const ENVIRONMENT_LIGHT_MULTIPLIER = 2.0;
+  const DIRECTIONAL_SUN_INTENSITY_MULTIPLIER = 1.4;
+
   // Low ambient floor — just enough so shadowed sides aren't pitch black.
   const ambient = new THREE.AmbientLight(0xffffff, 0.06);
   scene.add(ambient);
@@ -283,15 +288,15 @@
     // Sun controls shadow direction and contrast. Fill lights are non-shadowing
     // so dark faces can be lifted without flattening the diorama into CSS
     // brightness.
-    sun.intensity = 0.62 + renderLighting * 0.58;
-    hemi.intensity = 0.08 + renderAmbientFill * 0.20;
-    ambient.intensity = 0.025 + renderAmbientFill * 0.105;
-    frontFill.intensity = renderFrontFill * 0.28;
-    sideFillA.intensity = renderSideFill * 0.13;
-    sideFillB.intensity = renderSideFill * 0.13;
-    backFill.intensity = renderBackFill * 0.20;
-    modelStampImportAmbientFill.intensity = MODEL_STAMP_IMPORT_AMBIENT_BASE * renderAmbientFill;
-    modelStampImportDirFill.intensity = MODEL_STAMP_IMPORT_DIRECTIONAL_BASE * renderLighting;
+    sun.intensity = (0.62 + renderLighting * 0.58) * DIRECTIONAL_SUN_INTENSITY_MULTIPLIER * renderDirectionalSun;
+    hemi.intensity = (0.08 + renderAmbientFill * 0.20) * ENVIRONMENT_LIGHT_MULTIPLIER;
+    ambient.intensity = (0.025 + renderAmbientFill * 0.105) * ENVIRONMENT_LIGHT_MULTIPLIER;
+    frontFill.intensity = renderFrontFill * 0.28 * ENVIRONMENT_LIGHT_MULTIPLIER;
+    sideFillA.intensity = renderSideFill * 0.13 * ENVIRONMENT_LIGHT_MULTIPLIER;
+    sideFillB.intensity = renderSideFill * 0.13 * ENVIRONMENT_LIGHT_MULTIPLIER;
+    backFill.intensity = renderBackFill * 0.20 * ENVIRONMENT_LIGHT_MULTIPLIER;
+    modelStampImportAmbientFill.intensity = MODEL_STAMP_IMPORT_AMBIENT_BASE * renderAmbientFill * ENVIRONMENT_LIGHT_MULTIPLIER;
+    modelStampImportDirFill.intensity = MODEL_STAMP_IMPORT_DIRECTIONAL_BASE * renderLighting * ENVIRONMENT_LIGHT_MULTIPLIER;
   }
 
   function setShadowQuality(value) {

--- a/engine/world/04-textures.js
+++ b/engine/world/04-textures.js
@@ -140,12 +140,17 @@
     } else if (type === 'ripples') {
       ctx.fillStyle = '#ffffff';
       ctx.fillRect(0, 0, scale, scale);
-      ctx.fillStyle = '#e8e8e8';
-      ctx.fillRect(0, 3, scale, 1);
-      ctx.fillRect(0, 11, scale, 1);
-      ctx.fillStyle = '#cccccc';
-      ctx.fillRect(scale / 4, 4, scale / 2, 1);
-      ctx.fillRect(scale * 0.75, 12, scale / 4, 1);
+      // Neutral water albedo. The true motion/refraction/reflection comes from
+      // the enhanced water shader; do not bake fake wave stripes into the map.
+      for (let i = 0; i < scale * scale * 0.10; i++) {
+        const x = Math.floor(rand() * scale);
+        const y = Math.floor(rand() * scale);
+        const a = 0.025 + rand() * 0.040;
+        ctx.fillStyle = rand() > 0.5
+          ? 'rgba(255,255,255,' + a.toFixed(3) + ')'
+          : 'rgba(190,220,232,' + a.toFixed(3) + ')';
+        ctx.fillRect(x, y, 1, 1);
+      }
     } else if (type === 'leaves') {
       ctx.fillStyle = '#ffffff';
       ctx.fillRect(0, 0, scale, scale);
@@ -1092,9 +1097,9 @@
   }
 
   // Shared clock + procedural noise for the enhanced water surface shader
-  // (animated refraction / sun glints / foam). Advanced by tickWaterTextureFlow
+  // (planar reflection, refractive bend, sun glints, crest foam). Advanced by tickWaterTextureFlow
   // and shared across every water material so one update drives them all.
-  const WATER_SURFACE_SHADER_VARIANT = 'planar-reflect-v1';
+  const WATER_SURFACE_SHADER_VARIANT = 'planar-reflect-v3';
   const waterShaderTimeUniform = { value: 0 };
   const WATER_SHADER_NOISE_GLSL = `
     float twWaterHash(vec2 p){ return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123); }
@@ -1128,7 +1133,7 @@
         `
         #include <common>
         uniform vec2 waterFlowOffset;
-        ${enhanced ? 'uniform mat4 twReflectionMatrix; varying vec3 vTwWaterWorld; varying vec3 vTwWaterView; varying vec3 vTwWaterNrm; varying vec4 vTwReflectCoord;' : ''}
+        ${enhanced ? 'uniform mat4 twReflectionMatrix; varying vec2 vTwWaterSurfaceUv; varying vec3 vTwWaterWorld; varying vec3 vTwWaterView; varying vec3 vTwWaterNrm; varying vec4 vTwReflectCoord;' : ''}
         `
       );
       shader.vertexShader = shader.vertexShader.replace(
@@ -1148,14 +1153,17 @@
         vec3 worldNormal = normalize((modelMatrix * localNormal).xyz);
         ${enhanced ? 'vTwWaterWorld = worldPos.xyz; vTwWaterView = cameraPosition - worldPos.xyz; vTwWaterNrm = worldNormal; vTwReflectCoord = twReflectionMatrix * worldPos;' : ''}
 
+        vec2 twWaterFlowUv;
+        if (abs(worldNormal.y) > 0.5) {
+          twWaterFlowUv = worldPos.xz * ${textureScale.toFixed(4)} + waterFlowOffset;
+        } else if (abs(worldNormal.x) > 0.5) {
+          twWaterFlowUv = worldPos.zy * ${textureScale.toFixed(4)} + waterFlowOffset.yx;
+        } else {
+          twWaterFlowUv = worldPos.xy * ${textureScale.toFixed(4)} + waterFlowOffset;
+        }
+        ${enhanced ? 'vTwWaterSurfaceUv = twWaterFlowUv;' : ''}
         #ifdef USE_MAP
-          if (abs(worldNormal.y) > 0.5) {
-            vMapUv = worldPos.xz * ${textureScale.toFixed(4)} + waterFlowOffset;
-          } else if (abs(worldNormal.x) > 0.5) {
-            vMapUv = worldPos.zy * ${textureScale.toFixed(4)} + waterFlowOffset.yx;
-          } else {
-            vMapUv = worldPos.xy * ${textureScale.toFixed(4)} + waterFlowOffset;
-          }
+          vMapUv = twWaterFlowUv;
         #endif
         `
       );
@@ -1173,6 +1181,7 @@
         uniform float uWaterTime;
         uniform sampler2D twReflectionMap;
         uniform float twReflectionStrength;
+        varying vec2 vTwWaterSurfaceUv;
         varying vec3 vTwWaterWorld;
         varying vec3 vTwWaterView;
         varying vec3 vTwWaterNrm;
@@ -1220,7 +1229,7 @@
             #endif
             float refrDepth = clamp(refrLum * 0.65 + h0 * 0.35, 0.0, 1.0);
             vec3 refrCol = mix(vec3(0.015, 0.25, 0.42), vec3(0.46, 0.96, 1.0), refrDepth);
-            float refrMask = clamp(0.18 + refrLean * 0.20, 0.0, 0.38) * twTop;
+            float refrMask = clamp(0.26 + refrLean * 0.30, 0.0, 0.58) * twTop;
             gl_FragColor.rgb = mix(gl_FragColor.rgb, refrCol, refrMask);
             vec2 reflUv = vTwReflectCoord.xy / max(vTwReflectCoord.w, 0.0001);
             vec2 reflBend = refrBend * 0.46 + rn.xz * 0.018;
@@ -1232,24 +1241,19 @@
             float reflectedLuma = dot(reflectedScene, vec3(0.299, 0.587, 0.114));
             vec3 reflectedWaterScene = mix(reflectedScene, reflectedScene * vec3(0.72, 0.90, 1.08) + vec3(0.01, 0.03, 0.05), 0.18);
             reflectedWaterScene += vec3(0.16, 0.42, 0.62) * smoothstep(0.08, 0.34, reflectedLuma) * 0.04;
-            float reflectMask = clamp(0.74 + fres * 0.28 + refrLean * 0.12, 0.0, 0.96) *
+            float reflectMask = clamp(0.88 + fres * 0.32 + refrLean * 0.18, 0.0, 1.0) *
               twReflectionStrength * twTop * reflInside;
             gl_FragColor.rgb = mix(gl_FragColor.rgb, reflectedWaterScene, reflectMask);
-            // bright thin caustic veins where the wave field crosses mid-height
-            float veins = pow(max(1.0 - abs(h0 - 0.5) * 2.0, 0.0), 4.0);
             float refrCaustic = pow(max(1.0 - abs(twWaterNoise(wp * 4.40 + refr.xz * 5.2 + vec2(t * 0.20, -t * 0.14)) - 0.52) * 2.25, 0.0), 4.0);
             float refrCausticFine = pow(max(1.0 - abs(twWaterNoise(wp * 9.20 - refr.xz * 8.0 + vec2(-t * 0.24, t * 0.19)) - 0.50) * 2.15, 0.0), 6.0);
-            float refrRibbon = pow(0.5 + 0.5 * sin((wp.x * 2.9 + wp.y * 1.7) + refrLean * 3.2 + t * 1.55), 8.0);
             float foam = smoothstep(0.62, 0.84, h0);
-            // Visible moving light/dark wave bands (troughs darker, crests brighter).
-            gl_FragColor.rgb *= mix(0.72, 1.18, h0) * twTop + (1.0 - twTop);
-            // Cyan refractive caustics + white sun sparkles + foam crests on top.
-            vec3 addCol = vec3(0.55, 0.90, 1.0) * veins * 0.10
-                        + vec3(0.42, 0.92, 1.0) * refrCaustic * 0.12
+            float broadSheen = smoothstep(0.46, 0.88, h0);
+            gl_FragColor.rgb *= mix(0.94, 1.08, broadSheen) * twTop + (1.0 - twTop);
+            vec3 addCol = vec3(0.42, 0.92, 1.0) * refrCaustic * 0.12
                         + vec3(0.80, 1.0, 1.0) * refrCausticFine * 0.08
-                        + vec3(0.72, 0.96, 1.0) * refrRibbon * 0.06
-                        + vec3(1.0, 1.0, 0.98) * glint * 1.15
-                        + vec3(0.95, 0.99, 1.0) * foam * 0.22;
+                        + vec3(1.0, 1.0, 0.98) * glint * 1.25
+                        + vec3(0.50, 0.88, 1.0) * refrLean * 0.08
+                        + vec3(0.95, 0.99, 1.0) * foam * 0.18;
             gl_FragColor.rgb += addCol * twTop;
           }
         }

--- a/engine/world/05-tile-factory.js
+++ b/engine/world/05-tile-factory.js
@@ -202,8 +202,9 @@
     const mats = terrainVoxelMaterials(terrain, x, z, terrainN);
     const cells = terrainVoxelCellCount(terrain);
     const cellSize = topSize / cells;
-    const panelOverlap = Math.min(0.014, Math.max(0.006, cellSize * 0.06));
-    const panelSize = cellSize + panelOverlap;
+    // Terrain panels must stay inside their logical cell footprint. Do not
+    // overlap neighbouring panels or adjacent tiles in x/z.
+    const panelSize = cellSize;
     const half = topSize * 0.5;
     const y = rise + topHeight * 0.5;
     const buckets = new Map();
@@ -442,8 +443,8 @@
     const cells = terrainVoxelCellCount(terrain);
     const cellSize = riserSize / cells;
     const verticalCells = Math.max(2, Math.min(8, Math.ceil(riserHeight / cellSize)));
-    const panelW = cellSize + Math.min(0.012, cellSize * 0.05);
-    const panelH = riserHeight / verticalCells + Math.min(0.008, (riserHeight / verticalCells) * 0.04);
+    const panelW = cellSize;
+    const panelH = riserHeight / verticalCells;
     const sideDepth = Math.min(0.028, Math.max(0.016, cellSize * 0.12));
     const half = riserSize * 0.5;
     const buckets = new Map();
@@ -474,8 +475,8 @@
       const alongX = dir === 'n' || dir === 's';
       for (let i = 0; i < cells; i++) {
         for (let j = 0; j < verticalCells; j++) {
-          const px = alongX ? -half + cellSize * (i + 0.5) : (dir === 'w' ? -half : half);
-          const pz = alongX ? (dir === 'n' ? -half : half) : -half + cellSize * (i + 0.5);
+          const px = alongX ? -half + cellSize * (i + 0.5) : (dir === 'w' ? -half + sideDepth * 0.5 : half - sideDepth * 0.5);
+          const pz = alongX ? (dir === 'n' ? -half + sideDepth * 0.5 : half - sideDepth * 0.5) : -half + cellSize * (i + 0.5);
           const py = -DIRT_H + panelH * 0.5 + (riserHeight / verticalCells) * j;
           queuePanel(geo, pickMat(i, j, dir), px, py, pz);
         }
@@ -846,9 +847,9 @@
         for (let i = 0; i < count; i++) {
           const r = cellRand(x * 13 + i + dir.gx, z * 17 - i + dir.gz, 1820);
           const along = (r - 0.5) * topSize * 0.72;
-          const inset = 0.018 + cellRand(x - i, z + i, 1830) * 0.030;
           const h = 0.10 + cellRand(x + i, z - i, 1840) * 0.16;
           const w = 0.018 + cellRand(x - i * 2, z + i * 3, 1850) * 0.020;
+          const inset = Math.max(w * 0.5, 0.018 + cellRand(x - i, z + i, 1830) * 0.030);
           let px = 0, pz = 0;
           if (dir.key === 'n') { px = along; pz = -topSize * 0.5 + inset; }
           if (dir.key === 's') { px = along; pz =  topSize * 0.5 - inset; }
@@ -871,9 +872,9 @@
       for (let i = 0; i < count; i++) {
         const r = cellRand(x * 17 + i + dir.gx, z * 19 - i + dir.gz, 1870);
         const along = (r - 0.5) * topSize * 0.76;
-        const inset = 0.035 + cellRand(x - i, z + i, 1880) * 0.075;
         const h = 0.055 + cellRand(x + i, z - i, 1890) * 0.090;
         const w = 0.025 + cellRand(x - i * 2, z + i * 3, 1900) * 0.026;
+        const inset = Math.max(w * 0.5, 0.035 + cellRand(x - i, z + i, 1880) * 0.075);
         let px = 0, pz = 0;
         if (dir.key === 'n') { px = along; pz = -topSize * 0.5 + inset; }
         if (dir.key === 's') { px = along; pz =  topSize * 0.5 - inset; }
@@ -960,6 +961,7 @@
     function placeCurtainSheet(dir, h) {
       const mesh = new THREE.Mesh(getWaterfallPlaneGeometry(), getWaterfallCurtainMaterial());
       mesh.userData.noShadow = true;
+      mesh.userData.twWaterReflective = true;
       mesh.userData.waterfall = { kind: 'shaderSheet' };
       mesh.renderOrder = 6;
       orientCurtainSheet(mesh, dir, topY - h * 0.5, h);
@@ -970,6 +972,7 @@
       const length = 0.36 + cellRand(x + salt, z - salt, 712) * 0.16;
       const mesh = new THREE.Mesh(getWaterfallPlaneGeometry(), getWaterfallSurfaceMaterial());
       mesh.userData.noShadow = true;
+      mesh.userData.twWaterReflective = true;
       mesh.userData.waterfall = { kind: 'shaderSheet' };
       mesh.renderOrder = 7;
       orientSurfaceSheet(mesh, dir, length);
@@ -1021,6 +1024,7 @@
       const mesh = new THREE.InstancedMesh(getWaterfallFoamGeometry(), M.waterfallFoamPuff, specs.length);
       mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
       mesh.userData.noShadow = true;
+      mesh.userData.twWaterReflective = true;
       mesh.userData.waterfall = { kind: 'foamBatch', specs };
       mesh.renderOrder = 8;
       for (let i = 0; i < specs.length; i++) setWaterfallFoamInstanceMatrix(mesh, specs[i], 0, i);
@@ -1034,6 +1038,7 @@
       const mesh = new THREE.InstancedMesh(getWaterfallCubeGeometry(), M.waterfallCube, specs.length);
       mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
       mesh.userData.noShadow = true;
+      mesh.userData.twWaterReflective = true;
       mesh.userData.waterfall = { kind: 'cubeBatch', specs };
       mesh.renderOrder = 6;
       for (let i = 0; i < specs.length; i++) setWaterfallCubeInstanceMatrix(mesh, specs[i], 0, i);

--- a/engine/world/06-history-object-factories.js
+++ b/engine/world/06-history-object-factories.js
@@ -185,27 +185,25 @@
     const skipSurfaceDetails = !!(opts && opts.skipSurfaceDetails);
     const useVoxelTerrainForTile = renderVoxelTerrain && !(opts && opts.simpleTerrain);
 
-    // Dirt / riser block (sides + bottom of tile).
-    // For grass we *always* use a simple vertical brown dirt wall (BoxGeometry
-    // with no top face) + a larger grass top that overhangs it. This keeps the
-    // classic dirt edges visible on every grass cliff, bank, or drop-off while
-    // completely hiding the brown from above ("if it's grass it's grass").
+    // Dirt / riser block (sides + bottom of tile). Terrain tile geometry must
+    // stay inside its logical cell footprint: no x/z overhang into neighbours,
+    // and every terrain top/body uses the same TILE bounds.
     //
     // Hidden faces are stripped at geometry-build time: risers drop top/bottom
     // faces, caps/panels drop bottoms, and same-or-higher neighbours hide shared
     // side faces. FrontSide materials handle normal back-face culling on the
     // remaining visible faces.
     if (!skipTerrain) {
-      let riserSize = TILE * 1.04;
-      let topSize   = TILE * 0.98;
+      let riserSize = TILE;
+      let topSize   = TILE;
       let riserBevel = 0.04;
       let topBevel   = 0.06;
 
       if (terrain === 'grass' || terrain === 'path' || terrain === 'stone' || terrain === 'water') {
-        // Restore the physical tile look: the cap overhangs the body, so grass
-        // edges read as green first with dirt underneath.
-        riserSize  = TILE * 1.04;
-        topSize    = TILE * 1.04;
+        // Keep the physical tile look through materials/details, not by
+        // expanding the cap/body beyond the cell.
+        riserSize  = TILE;
+        topSize    = TILE;
         riserBevel = 0.02;
         topBevel   = 0.04;
       }
@@ -258,7 +256,7 @@
       // One whole logical tile panel: no artificial gaps inside a cell. The
       // voxel resolution belongs to objects/stamps; terrain/path cells must
       // still read as full panels aligned to the board grid.
-      const seamOverlap = 0.006;
+      const seamOverlap = 0;
       const topHeight = TOP_H + seamOverlap;
       if (useVoxelTerrainForTile) {
         addVoxelTerrainTop(g, terrain, x, z, visualRise - seamOverlap * 0.5, topSize, topHeight, pathN, terrainN, {

--- a/engine/world/07-house-primitives.js
+++ b/engine/world/07-house-primitives.js
@@ -1093,8 +1093,8 @@
     const normalized = FENCE_SIDES.has(side) ? side : 'n';
     const fenceStyle = typeof normalizeFenceStyle === 'function' ? normalizeFenceStyle(style) : 'wood';
     const alongX = normalized === 'n' || normalized === 's' || normalized === 'center-x';
-    const offsetX = normalized === 'w' ? -0.43 : normalized === 'e' ? 0.43 : 0;
-    const offsetZ = normalized === 'n' ? -0.43 : normalized === 's' ? 0.43 : 0;
+    const offsetX = normalized === 'w' ? -0.50 : normalized === 'e' ? 0.50 : 0;
+    const offsetZ = normalized === 'n' ? -0.50 : normalized === 's' ? 0.50 : 0;
 
     function endpointOffsets() {
       return alongX
@@ -1123,41 +1123,41 @@
         return mesh;
       }
       for (const [px, pz] of endpointOffsets()) {
-        gateBox(0.14, postH, 0.14, px, postH / 2, pz, postMat);
-        gateBox(0.18, 0.055, 0.18, px, postH + 0.03, pz, railMat);
+        gateBox(0.08, postH, 0.08, px, postH / 2, pz, postMat);
+        gateBox(0.11, 0.045, 0.11, px, postH + 0.025, pz, railMat);
       }
       if (alongX) {
-        const inward = normalized === 'n' ? 1 : -1;
+        const outward = normalized === 'n' ? -1 : 1;
         const leaves = [
-          { hingeX: -hingeInset, dir: 1, ry: -inward * leafAngle },
-          { hingeX: hingeInset, dir: -1, ry: inward * leafAngle },
+          { hingeX: -hingeInset, dir: 1, ry: -outward * leafAngle },
+          { hingeX: hingeInset, dir: -1, ry: outward * leafAngle },
         ];
         leaves.forEach(leaf => {
           const leafX = leaf.hingeX + leaf.dir * Math.cos(leaf.ry) * leafHalf;
           const leafZ = offsetZ + leaf.dir * -Math.sin(leaf.ry) * leafHalf;
-          for (const y of [0.13 * fenceScale, gateH * 0.82]) gateBox(leafLen, 0.05, 0.05, leafX, y, leafZ, railMat, { ry: leaf.ry });
+          for (const y of [0.13 * fenceScale, gateH * 0.82]) gateBox(leafLen, 0.035, 0.035, leafX, y, leafZ, railMat, { ry: leaf.ry });
           for (const dx of [-0.13, 0.13]) {
-            gateBox(0.05, gateH * 0.66, 0.05, leafX + dx * Math.cos(leaf.ry), gateH * 0.43, leafZ - dx * Math.sin(leaf.ry), panelMat, { ry: leaf.ry });
+            gateBox(0.034, gateH * 0.66, 0.034, leafX + dx * Math.cos(leaf.ry), gateH * 0.43, leafZ - dx * Math.sin(leaf.ry), panelMat, { ry: leaf.ry });
           }
         });
-        gateBox(0.22, 0.11, 0.045, 0, postH + 0.13, offsetZ, markerMat);
-        gateBox(0.075, 0.075, 0.075, 0.12, gateH * 0.55, offsetZ + inward * 0.03, latchMat);
+        gateBox(0.18, 0.09, 0.035, 0, postH + 0.13, offsetZ, markerMat);
+        gateBox(0.055, 0.055, 0.055, 0.12, gateH * 0.55, offsetZ + outward * 0.025, latchMat);
       } else {
-        const inward = normalized === 'w' ? 1 : -1;
+        const outward = normalized === 'w' ? -1 : 1;
         const leaves = [
-          { hingeZ: -hingeInset, dir: 1, ry: inward * leafAngle },
-          { hingeZ: hingeInset, dir: -1, ry: -inward * leafAngle },
+          { hingeZ: -hingeInset, dir: 1, ry: outward * leafAngle },
+          { hingeZ: hingeInset, dir: -1, ry: -outward * leafAngle },
         ];
         leaves.forEach(leaf => {
           const leafX = offsetX + leaf.dir * Math.sin(leaf.ry) * leafHalf;
           const leafZ = leaf.hingeZ + leaf.dir * Math.cos(leaf.ry) * leafHalf;
-          for (const y of [0.13 * fenceScale, gateH * 0.82]) gateBox(0.05, 0.05, leafLen, leafX, y, leafZ, railMat, { ry: leaf.ry });
+          for (const y of [0.13 * fenceScale, gateH * 0.82]) gateBox(0.035, 0.035, leafLen, leafX, y, leafZ, railMat, { ry: leaf.ry });
           for (const dz of [-0.13, 0.13]) {
-            gateBox(0.05, gateH * 0.66, 0.05, leafX + dz * Math.sin(leaf.ry), gateH * 0.43, leafZ + dz * Math.cos(leaf.ry), panelMat, { ry: leaf.ry });
+            gateBox(0.034, gateH * 0.66, 0.034, leafX + dz * Math.sin(leaf.ry), gateH * 0.43, leafZ + dz * Math.cos(leaf.ry), panelMat, { ry: leaf.ry });
           }
         });
-        gateBox(0.045, 0.11, 0.22, offsetX, postH + 0.13, 0, markerMat);
-        gateBox(0.075, 0.075, 0.075, offsetX + inward * 0.03, gateH * 0.55, 0.12, latchMat);
+        gateBox(0.035, 0.09, 0.18, offsetX, postH + 0.13, 0, markerMat);
+        gateBox(0.055, 0.055, 0.055, offsetX + outward * 0.025, gateH * 0.55, 0.12, latchMat);
       }
     } else if (fenceStyle === 'garden' && level < 4) {
       const fenceScale = level === 1 ? 1 : (level === 2 ? 1.18 : 1.32);
@@ -1166,25 +1166,25 @@
       const railMat = M.fenceGardenD || M.fence;
       const vineMat = M.fenceVine || M.cropStem || postMat;
       const fruitMat = M.fenceFruit || M.pumpkin || railMat;
-      const postGeo = getBoxGeometry(0.10, postH, 0.10);
+      const postGeo = getBoxGeometry(0.064, postH, 0.064);
       for (const [px, pz] of endpointOffsets()) {
         const post = new THREE.Mesh(postGeo, postMat);
         post.position.set(px, postH / 2, pz);
         g.add(post);
-        const cap = new THREE.Mesh(getBoxGeometry(0.14, 0.045, 0.14), railMat);
+        const cap = new THREE.Mesh(getBoxGeometry(0.09, 0.04, 0.09), railMat);
         cap.position.set(px, postH + 0.025, pz);
         g.add(cap);
       }
       for (const y of [0.12 * fenceScale, 0.28 * fenceScale, ...(level >= 3 ? [0.42 * fenceScale] : [])]) {
-        const rail = new THREE.Mesh(getBoxGeometry(alongX ? 1.08 : 0.05, 0.05, alongX ? 0.05 : 1.08), railMat);
+        const rail = new THREE.Mesh(getBoxGeometry(alongX ? 1.00 : 0.034, 0.034, alongX ? 0.034 : 1.00), railMat);
         rail.position.set(offsetX, y, offsetZ);
         g.add(rail);
       }
-      const vine = new THREE.Mesh(getBoxGeometry(alongX ? 0.82 : 0.035, 0.035, alongX ? 0.035 : 0.82), vineMat);
+      const vine = new THREE.Mesh(getBoxGeometry(alongX ? 0.82 : 0.026, 0.026, alongX ? 0.026 : 0.82), vineMat);
       vine.position.set(offsetX, postH * 0.82, offsetZ);
       g.add(vine);
       for (const a of [-0.30, 0.18]) {
-        const fruit = new THREE.Mesh(getBoxGeometry(0.055, 0.055, 0.055), fruitMat);
+        const fruit = new THREE.Mesh(getBoxGeometry(0.045, 0.045, 0.045), fruitMat);
         fruit.position.set(alongX ? a : offsetX, postH * 0.90, alongX ? offsetZ : a);
         fruit.castShadow = false;
         fruit.receiveShadow = false;
@@ -1194,21 +1194,21 @@
       const stone = level >= 5 ? M.fenceSteel : M.castleStone;
       const capMat = level >= 5 ? M.skyFrame : M.castleStoneD;
       const wallH = level >= 5 ? 0.58 : 0.46;
-      const wallT = level >= 5 ? 0.14 : 0.18;
+      const wallT = level >= 5 ? 0.10 : 0.13;
       const wall = new THREE.Mesh(
-        getBoxGeometryPrecise(alongX ? 1.08 : wallT, wallH, alongX ? wallT : 1.08),
+        getBoxGeometryPrecise(alongX ? 1.00 : wallT, wallH, alongX ? wallT : 1.00),
         stone
       );
       wall.position.set(offsetX, wallH / 2, offsetZ);
       g.add(wall);
       const cap = new THREE.Mesh(
-        getBoxGeometryPrecise(alongX ? 1.12 : wallT + 0.04, 0.055, alongX ? wallT + 0.04 : 1.12),
+        getBoxGeometryPrecise(alongX ? 1.04 : wallT + 0.035, 0.05, alongX ? wallT + 0.035 : 1.04),
         capMat
       );
       cap.position.set(offsetX, wallH + 0.027, offsetZ);
       g.add(cap);
     } else if (level === 3) {
-      const postGeo = getBoxGeometry(0.07, 0.52, 0.07);
+      const postGeo = getBoxGeometry(0.045, 0.52, 0.045);
       for (const [px, pz] of endpointOffsets()) {
         const post = new THREE.Mesh(postGeo, M.fenceSteel);
         post.position.set(px, 0.26, pz);
@@ -1216,7 +1216,7 @@
       }
       for (const y of [0.15, 0.29, 0.43]) {
         const wire = new THREE.Mesh(
-          getBoxGeometry(alongX ? 1.08 : 0.025, 0.025, alongX ? 0.025 : 1.08),
+          getBoxGeometry(alongX ? 1.00 : 0.018, 0.018, alongX ? 0.018 : 1.00),
           M.fenceWire
         );
         wire.position.set(offsetX, y, offsetZ);
@@ -1225,14 +1225,14 @@
     } else {
       const fenceScale = level === 2 ? 1.28 : 1;
       const postH = 0.32 * fenceScale;
-      const postGeo = getBoxGeometry(0.09, postH, 0.09);
+      const postGeo = getBoxGeometry(0.055, postH, 0.055);
       for (const [px, pz] of endpointOffsets()) {
         const post = new THREE.Mesh(postGeo, M.fence);
         post.position.set(px, 0.16 * fenceScale, pz);
         g.add(post);
       }
-      const railH = 0.06;
-      const railGeo = getBoxGeometry(alongX ? 1.08 : railH, railH, alongX ? railH : 1.08);
+      const railH = 0.038;
+      const railGeo = getBoxGeometry(alongX ? 1.00 : railH, railH, alongX ? railH : 1.00);
       for (const y of [0.08 * fenceScale, 0.24 * fenceScale]) {
         const rail = new THREE.Mesh(railGeo, M.fence);
         rail.position.set(offsetX, y, offsetZ);

--- a/engine/world/09b-voxel-build-factories.js
+++ b/engine/world/09b-voxel-build-factories.js
@@ -2217,8 +2217,8 @@
     const normalized = FENCE_SIDES.has(side) ? side : 'n';
     const fenceStyle = typeof normalizeFenceStyle === 'function' ? normalizeFenceStyle(style) : 'wood';
     const alongX = roadGate ? pathOrientation === 'x' : (normalized === 'n' || normalized === 's' || normalized === 'center-x');
-    const offsetX = normalized === 'w' ? -0.43 : normalized === 'e' ? 0.43 : 0;
-    const offsetZ = normalized === 'n' ? -0.43 : normalized === 's' ? 0.43 : 0;
+    const offsetX = normalized === 'w' ? -0.50 : normalized === 'e' ? 0.50 : 0;
+    const offsetZ = normalized === 'n' ? -0.50 : normalized === 's' ? 0.50 : 0;
     const mat = castle || lv >= 4 ? M.castleStone : (lv >= 3 ? M.fenceSteel : M.fence);
     const dark = castle || lv >= 4 ? M.castleStoneD : (lv >= 3 ? M.fenceWire : M.fence);
 
@@ -2240,41 +2240,41 @@
       const hingeInset = 0.43;
       const ends = alongX ? [[-0.50, offsetZ], [0.50, offsetZ]] : [[offsetX, -0.50], [offsetX, 0.50]];
       ends.forEach(([x, z]) => {
-        vbox(g, 0.14, postH, 0.14, x, postH / 2, z, postMat);
-        vbox(g, 0.18, 0.06, 0.18, x, postH + 0.03, z, railMat);
+        vbox(g, 0.08, postH, 0.08, x, postH / 2, z, postMat);
+        vbox(g, 0.11, 0.045, 0.11, x, postH + 0.025, z, railMat);
       });
       if (alongX) {
-        const inward = normalized === 'n' ? 1 : -1;
+        const outward = normalized === 'n' ? -1 : 1;
         const leaves = [
-          { hingeX: -hingeInset, dir: 1, ry: -inward * leafAngle },
-          { hingeX: hingeInset, dir: -1, ry: inward * leafAngle },
+          { hingeX: -hingeInset, dir: 1, ry: -outward * leafAngle },
+          { hingeX: hingeInset, dir: -1, ry: outward * leafAngle },
         ];
         leaves.forEach(leaf => {
           const leafX = leaf.hingeX + leaf.dir * Math.cos(leaf.ry) * leafHalf;
           const leafZ = offsetZ + leaf.dir * -Math.sin(leaf.ry) * leafHalf;
-          for (const y of [0.13, gateH * 0.82]) vbox(g, leafLen, 0.055, 0.055, leafX, y, leafZ, railMat, { ry: leaf.ry, noBevel: true });
+          for (const y of [0.13, gateH * 0.82]) vbox(g, leafLen, 0.035, 0.035, leafX, y, leafZ, railMat, { ry: leaf.ry, noBevel: true });
           for (const dx of [-0.13, 0.13]) {
-            vbox(g, 0.05, gateH * 0.66, 0.05, leafX + dx * Math.cos(leaf.ry), gateH * 0.43, leafZ - dx * Math.sin(leaf.ry), panelMat, { ry: leaf.ry });
+            vbox(g, 0.034, gateH * 0.66, 0.034, leafX + dx * Math.cos(leaf.ry), gateH * 0.43, leafZ - dx * Math.sin(leaf.ry), panelMat, { ry: leaf.ry });
           }
         });
-        vbox(g, 0.22, 0.11, 0.045, 0, postH + 0.13, offsetZ, markerMat, { noShadow: true });
-        vbox(g, 0.075, 0.075, 0.075, 0.12, gateH * 0.55, offsetZ + inward * 0.03, latchMat, { noShadow: true });
+        vbox(g, 0.18, 0.09, 0.035, 0, postH + 0.13, offsetZ, markerMat, { noShadow: true });
+        vbox(g, 0.055, 0.055, 0.055, 0.12, gateH * 0.55, offsetZ + outward * 0.025, latchMat, { noShadow: true });
       } else {
-        const inward = normalized === 'w' ? 1 : -1;
+        const outward = normalized === 'w' ? -1 : 1;
         const leaves = [
-          { hingeZ: -hingeInset, dir: 1, ry: inward * leafAngle },
-          { hingeZ: hingeInset, dir: -1, ry: -inward * leafAngle },
+          { hingeZ: -hingeInset, dir: 1, ry: outward * leafAngle },
+          { hingeZ: hingeInset, dir: -1, ry: -outward * leafAngle },
         ];
         leaves.forEach(leaf => {
           const leafX = offsetX + leaf.dir * Math.sin(leaf.ry) * leafHalf;
           const leafZ = leaf.hingeZ + leaf.dir * Math.cos(leaf.ry) * leafHalf;
-          for (const y of [0.13, gateH * 0.82]) vbox(g, 0.055, 0.055, leafLen, leafX, y, leafZ, railMat, { ry: leaf.ry, noBevel: true });
+          for (const y of [0.13, gateH * 0.82]) vbox(g, 0.035, 0.035, leafLen, leafX, y, leafZ, railMat, { ry: leaf.ry, noBevel: true });
           for (const dz of [-0.13, 0.13]) {
-            vbox(g, 0.05, gateH * 0.66, 0.05, leafX + dz * Math.sin(leaf.ry), gateH * 0.43, leafZ + dz * Math.cos(leaf.ry), panelMat, { ry: leaf.ry });
+            vbox(g, 0.034, gateH * 0.66, 0.034, leafX + dz * Math.sin(leaf.ry), gateH * 0.43, leafZ + dz * Math.cos(leaf.ry), panelMat, { ry: leaf.ry });
           }
         });
-        vbox(g, 0.045, 0.11, 0.22, offsetX, postH + 0.13, 0, markerMat, { noShadow: true });
-        vbox(g, 0.075, 0.075, 0.075, offsetX + inward * 0.03, gateH * 0.55, 0.12, latchMat, { noShadow: true });
+        vbox(g, 0.035, 0.09, 0.18, offsetX, postH + 0.13, 0, markerMat, { noShadow: true });
+        vbox(g, 0.055, 0.055, 0.055, offsetX + outward * 0.025, gateH * 0.55, 0.12, latchMat, { noShadow: true });
       }
     } else if (fenceStyle === 'garden' && !castle && !roadGate && lv < 4) {
       const postH = lv === 1 ? 0.42 : (lv === 2 ? 0.50 : 0.56);
@@ -2284,18 +2284,18 @@
       const fruitMat = M.fenceFruit || M.pumpkin || railMat;
       const ends = alongX ? [[-0.50, offsetZ], [0.50, offsetZ]] : [[offsetX, -0.50], [offsetX, 0.50]];
       ends.forEach(([x, z]) => {
-        vbox(g, 0.11, postH, 0.11, x, postH / 2, z, postMat);
-        vbox(g, 0.14, 0.045, 0.14, x, postH + 0.025, z, railMat);
+        vbox(g, 0.064, postH, 0.064, x, postH / 2, z, postMat);
+        vbox(g, 0.09, 0.04, 0.09, x, postH + 0.025, z, railMat);
       });
       for (const y of [0.14, 0.31, ...(lv >= 3 ? [0.46] : [])]) {
-        vbox(g, alongX ? 1.08 : 0.052, 0.052, alongX ? 0.052 : 1.08, offsetX, y, offsetZ, railMat);
+        vbox(g, alongX ? 1.00 : 0.034, 0.034, alongX ? 0.034 : 1.00, offsetX, y, offsetZ, railMat);
       }
       for (const a of [-0.25, 0, 0.25]) {
-        vbox(g, 0.045, postH * 0.70, 0.045, alongX ? a : offsetX, postH * 0.38, alongX ? offsetZ : a, postMat);
+        vbox(g, 0.028, postH * 0.70, 0.028, alongX ? a : offsetX, postH * 0.38, alongX ? offsetZ : a, postMat);
       }
-      vbox(g, alongX ? 0.82 : 0.038, 0.035, alongX ? 0.038 : 0.82, offsetX, postH * 0.84, offsetZ, vineMat);
+      vbox(g, alongX ? 0.82 : 0.026, 0.026, alongX ? 0.026 : 0.82, offsetX, postH * 0.84, offsetZ, vineMat);
       for (const a of [-0.32, 0.18]) {
-        vbox(g, 0.055, 0.055, 0.055, alongX ? a : offsetX, postH * 0.90, alongX ? offsetZ : a, fruitMat, { noShadow: true });
+        vbox(g, 0.045, 0.045, 0.045, alongX ? a : offsetX, postH * 0.90, alongX ? offsetZ : a, fruitMat, { noShadow: true });
       }
     } else if (castle || lv >= 4 || roadGate) {
       const h = roadGate ? 0.62 + Math.max(0, lv - 3) * 0.05 : (castle ? 0.56 : 0.46);
@@ -2303,18 +2303,18 @@
         for (const s of [-1, 1]) vbox(g, 0.14, h, 0.14, alongX ? s * 0.42 : 0, h / 2, alongX ? 0 : s * 0.42, mat);
         vbox(g, alongX ? 1.02 : 0.16, 0.12, alongX ? 0.16 : 1.02, 0, h + 0.06, 0, dark);
       } else {
-        vbox(g, alongX ? 1.08 : 0.18, h, alongX ? 0.18 : 1.08, offsetX, h / 2, offsetZ, mat);
-        vbox(g, alongX ? 1.12 : 0.22, 0.06, alongX ? 0.22 : 1.12, offsetX, h + 0.03, offsetZ, dark);
+        vbox(g, alongX ? 1.00 : 0.13, h, alongX ? 0.13 : 1.00, offsetX, h / 2, offsetZ, mat);
+        vbox(g, alongX ? 1.04 : 0.165, 0.05, alongX ? 0.165 : 1.04, offsetX, h + 0.025, offsetZ, dark);
         for (const a of [-0.35, 0, 0.35]) {
-          vbox(g, 0.11, 0.12, 0.11, alongX ? a : offsetX, h + 0.12, alongX ? offsetZ : a, mat);
+          vbox(g, 0.08, 0.10, 0.08, alongX ? a : offsetX, h + 0.10, alongX ? offsetZ : a, mat);
         }
       }
     } else {
       const postH = lv === 2 ? 0.40 : 0.32;
       const ends = alongX ? [[-0.50, offsetZ], [0.50, offsetZ]] : [[offsetX, -0.50], [offsetX, 0.50]];
-      ends.forEach(([x, z]) => vbox(g, 0.09, postH, 0.09, x, postH / 2, z, mat));
+      ends.forEach(([x, z]) => vbox(g, 0.055, postH, 0.055, x, postH / 2, z, mat));
       for (const y of [0.12, 0.26, ...(lv >= 3 ? [0.40] : [])]) {
-        vbox(g, alongX ? 1.08 : 0.045, 0.055, alongX ? 0.045 : 1.08, offsetX, y, offsetZ, dark);
+        vbox(g, alongX ? 1.00 : 0.032, 0.038, alongX ? 0.032 : 1.00, offsetX, y, offsetZ, dark);
       }
     }
     g.userData = { kind: 'fence', level: lv, side: normalized, fenceStyle };
@@ -2332,8 +2332,8 @@
     const normalized = FENCE_SIDES.has(side) ? side : 'n';
     const fenceStyle = typeof normalizeFenceStyle === 'function' ? normalizeFenceStyle(style) : 'wood';
     const alongX = normalized === 'n' || normalized === 's' || normalized === 'center-x';
-    const offsetX = normalized === 'w' ? -0.43 : normalized === 'e' ? 0.43 : 0;
-    const offsetZ = normalized === 'n' ? -0.43 : normalized === 's' ? 0.43 : 0;
+    const offsetX = normalized === 'w' ? -0.50 : normalized === 'e' ? 0.50 : 0;
+    const offsetZ = normalized === 'n' ? -0.50 : normalized === 's' ? 0.50 : 0;
     const spanLen = spanCells * TILE;
     const mat = lv >= 4 ? M.castleStone : (lv >= 3 ? M.fenceSteel : M.fence);
     const dark = lv >= 4 ? M.castleStoneD : (lv >= 3 ? M.fenceWire : M.fence);
@@ -2347,38 +2347,38 @@
       const fruitMat = M.fenceFruit || M.pumpkin || railMat;
       for (let i = 0; i <= spanCells; i++) {
         const p = alongPos(i);
-        vbox(g, 0.11, postH, 0.11, alongX ? p : offsetX, postH / 2, alongX ? offsetZ : p, postMat);
-        vbox(g, 0.14, 0.045, 0.14, alongX ? p : offsetX, postH + 0.025, alongX ? offsetZ : p, railMat);
+        vbox(g, 0.064, postH, 0.064, alongX ? p : offsetX, postH / 2, alongX ? offsetZ : p, postMat);
+        vbox(g, 0.09, 0.04, 0.09, alongX ? p : offsetX, postH + 0.025, alongX ? offsetZ : p, railMat);
       }
       for (const y of [0.14, 0.31, ...(lv >= 3 ? [0.46] : [])]) {
-        vbox(g, alongX ? spanLen + 0.08 : 0.052, 0.052, alongX ? 0.052 : spanLen + 0.08, offsetX, y, offsetZ, railMat);
+        vbox(g, alongX ? spanLen : 0.034, 0.034, alongX ? 0.034 : spanLen, offsetX, y, offsetZ, railMat);
       }
       for (let cell = 0; cell < spanCells; cell++) {
         const base = -spanLen / 2 + cell * TILE + TILE * 0.5;
         for (const delta of [-0.24, 0.05, 0.30]) {
           const p = base + delta;
-          vbox(g, 0.045, postH * 0.70, 0.045, alongX ? p : offsetX, postH * 0.38, alongX ? offsetZ : p, postMat);
+          vbox(g, 0.028, postH * 0.70, 0.028, alongX ? p : offsetX, postH * 0.38, alongX ? offsetZ : p, postMat);
         }
         const fruitP = base + (cell % 2 ? 0.18 : -0.26);
-        vbox(g, 0.055, 0.055, 0.055, alongX ? fruitP : offsetX, postH * 0.90, alongX ? offsetZ : fruitP, fruitMat, { noShadow: true });
+        vbox(g, 0.045, 0.045, 0.045, alongX ? fruitP : offsetX, postH * 0.90, alongX ? offsetZ : fruitP, fruitMat, { noShadow: true });
       }
-      vbox(g, alongX ? spanLen - 0.18 : 0.038, 0.035, alongX ? 0.038 : spanLen - 0.18, offsetX, postH * 0.84, offsetZ, vineMat);
+      vbox(g, alongX ? spanLen - 0.18 : 0.026, 0.026, alongX ? 0.026 : spanLen - 0.18, offsetX, postH * 0.84, offsetZ, vineMat);
     } else if (lv >= 4) {
       const h = 0.46;
-      vbox(g, alongX ? spanLen + 0.08 : 0.18, h, alongX ? 0.18 : spanLen + 0.08, offsetX, h / 2, offsetZ, mat);
-      vbox(g, alongX ? spanLen + 0.12 : 0.22, 0.06, alongX ? 0.22 : spanLen + 0.12, offsetX, h + 0.03, offsetZ, dark);
+      vbox(g, alongX ? spanLen : 0.13, h, alongX ? 0.13 : spanLen, offsetX, h / 2, offsetZ, mat);
+      vbox(g, alongX ? spanLen + 0.04 : 0.165, 0.05, alongX ? 0.165 : spanLen + 0.04, offsetX, h + 0.025, offsetZ, dark);
       for (let i = 0; i <= spanCells; i++) {
         const p = alongPos(i);
-        vbox(g, 0.11, 0.12, 0.11, alongX ? p : offsetX, h + 0.12, alongX ? offsetZ : p, mat);
+        vbox(g, 0.08, 0.10, 0.08, alongX ? p : offsetX, h + 0.10, alongX ? offsetZ : p, mat);
       }
     } else {
       const postH = lv === 2 ? 0.40 : 0.32;
       for (let i = 0; i <= spanCells; i++) {
         const p = alongPos(i);
-        vbox(g, 0.09, postH, 0.09, alongX ? p : offsetX, postH / 2, alongX ? offsetZ : p, mat);
+        vbox(g, 0.055, postH, 0.055, alongX ? p : offsetX, postH / 2, alongX ? offsetZ : p, mat);
       }
       for (const y of [0.12, 0.26, ...(lv >= 3 ? [0.40] : [])]) {
-        vbox(g, alongX ? spanLen + 0.08 : 0.045, 0.055, alongX ? 0.045 : spanLen + 0.08, offsetX, y, offsetZ, dark);
+        vbox(g, alongX ? spanLen : 0.032, 0.038, alongX ? 0.032 : spanLen, offsetX, y, offsetZ, dark);
       }
     }
     g.userData = { kind: 'fence', level: lv, side: normalized, fenceStyle, batchedSpan: true, spanCells };

--- a/engine/world/15-ghost-generation-fade.js
+++ b/engine/world/15-ghost-generation-fade.js
@@ -582,7 +582,7 @@
   // -------- cheap ghost instancing helpers --------
   function ensureCheapGhostGeoms() {
     if (cheapGhostGeomDirt) return;
-    const size = TILE * 1.04;
+    const size = TILE;
     cheapGhostGeomDirt = new THREE.BoxGeometry(size, DIRT_H, size);
     cheapGhostGeomDirt.translate(0, DIRT_H / 2, 0);
     cheapGhostGeomTop = new THREE.BoxGeometry(size, TOP_H, size);
@@ -747,7 +747,7 @@
     if (terrain === 'snow')  mat = M.snow;
 
     const height = DIRT_H + rise + TOP_H;
-    const slab = new THREE.Mesh(getBoxGeometry(TILE * 1.04, height, TILE * 1.04), mat);
+    const slab = new THREE.Mesh(getBoxGeometry(TILE, height, TILE), mat);
     slab.position.y = -DIRT_H + height * 0.5;
 
     slab.userData = {

--- a/engine/world/17-tile-renderers.js
+++ b/engine/world/17-tile-renderers.js
@@ -930,7 +930,8 @@
   // edited, then re-bake after the world settles.
   //
   // Feature flag: ON iff localStorage 'tinyworld:renderTerrainBake' === '1'
-  // OR URL param ?meshbake=1. Default OFF for safe rollout.
+  // OR URL param ?meshbake=1. Procedural islands can request the same bake at
+  // runtime after generation without persisting the setting.
 
   const terrainBakeEnabled = (function () {
     try {
@@ -947,6 +948,7 @@
   // Runtime opt-in for non-home contexts (static lobby/demo world rooms) without
   // the global flag. Toggled by window.__tinyworldSetTerrainBakeForced.
   let terrainBakeForced = false;
+  let terrainBakeRequested = false;
   const _terrainBakeBox = new THREE.Box3();
 
   function terrainCellBakeEligible(x, z, entry) {
@@ -988,7 +990,7 @@
   }
 
   function bakeHomeTerrainNow() {
-    if (!terrainBakeEnabled && !terrainBakeForced) return;
+    if (!terrainBakeEnabled && !terrainBakeForced && !terrainBakeRequested) return;
     if (bakedTerrainCells.size > 0) return; // already baked
     if (typeof isLandscapeMeshActive === 'function' && isLandscapeMeshActive()) return;
     // Suppress during applyState bulk load (suppressSave flag from 29-persistence-api.js)
@@ -1060,6 +1062,7 @@
     const ms = Math.round(performance.now() - t0);
     console.log('[terrain-bake] baked', bakedTerrainCells.size, 'cells in', ms + 'ms');
     if (ms > 50) console.warn('[terrain-bake] bake took', ms + 'ms (>50ms threshold; consider chunked v2)');
+    terrainBakeRequested = false;
   }
 
   function unbakeAllTerrain() {
@@ -1098,7 +1101,7 @@
   }
 
   function scheduleTerrainBakeOnSettle() {
-    if (!terrainBakeEnabled && !terrainBakeForced) return;
+    if (!terrainBakeEnabled && !terrainBakeForced && !terrainBakeRequested) return;
     if (terrainBakeSettleTimer !== null) clearTimeout(terrainBakeSettleTimer);
     terrainBakeSettleTimer = setTimeout(function () {
       terrainBakeSettleTimer = null;
@@ -1112,5 +1115,9 @@
   window.__tinyworldSetTerrainBakeForced = function (on) {
     terrainBakeForced = !!on;
     if (terrainBakeForced) scheduleTerrainBakeOnSettle();
+  };
+  window.__tinyworldRequestTerrainBake = function () {
+    terrainBakeRequested = true;
+    scheduleTerrainBakeOnSettle();
   };
   window.__tinyworldUnbakeTerrain = function () { try { unbakeAllTerrain(); } catch (_) {} };

--- a/engine/world/19-tools-toolbar.js
+++ b/engine/world/19-tools-toolbar.js
@@ -52,7 +52,6 @@
   const TOOL_GROUPS = [
     { id: 'terrain', label: 'Terrain', toolIds: ['grass', 'path', 'dirt', 'water', 'stone', 'lava', 'sand', 'snow', 'rock', 'mesh-terrain'], iconTool: 'grass' },
     { id: 'plants', label: 'Plants', toolIds: ['tree', 'tuft', 'flower', 'bush'], iconTool: 'tree' },
-    { id: 'build', label: 'Build', toolIds: ['house', 'new-island'], iconTool: 'house' },
     { id: 'infra', label: 'Infra', toolIds: ['fence', 'bridge', 'lamp-post', 'spotlight', 'mooring'], iconTool: 'fence' },
     { id: 'farm', label: 'Farm', toolIds: ['crop', 'corn', 'wheat', 'pumpkin', 'carrot', 'sunflower'], iconTool: 'wheat' },
     { id: 'life', label: 'Life', toolIds: ['cow', 'sheep'], iconTool: 'cow' },

--- a/engine/world/26-ai-generation.js
+++ b/engine/world/26-ai-generation.js
@@ -1257,6 +1257,36 @@
       }
       pruneWaterToBudget(cells, protectedWater);
     }
+    function ensureMinimumWaterTiles(cells, minWaterTiles = 5) {
+      let waterCount = terrainCells(cells, 'water').length;
+      if (waterCount >= minWaterTiles) return;
+      const waterIndexes = terrainCells(cells, 'water');
+      function nearestWaterDistance(index) {
+        if (!waterIndexes.length) return isEdgeIndex(index) ? 0 : size;
+        return waterIndexes.reduce((best, waterIndex) => Math.min(best, distanceBetweenIndexes(index, waterIndex)), size * 2);
+      }
+      const candidates = cells
+        .map((cell, index) => ({ cell, index }))
+        .filter(({ cell }) => {
+          if (!cell || cell.terrain === 'water') return false;
+          if (isProtectedEconomyCell(cell)) return false;
+          if (cell.footprint || cell.footprintParent) return false;
+          if (isBuildingObjectId(cell.object) || cell.object === 'bridge' || cell.object === 'water-bridge') return false;
+          return true;
+        })
+        .map(entry => ({
+          index: entry.index,
+          score: nearestWaterDistance(entry.index)
+            + (isEdgeIndex(entry.index) ? -0.65 : 0)
+            + (entry.cell.object ? 1.25 : 0)
+            + cellRand(entry.index, 'minimum-water') * 0.35,
+        }))
+        .sort((a, b) => a.score - b.score);
+      for (const { index } of candidates) {
+        if (waterCount >= minWaterTiles) break;
+        if (clearMotifCell(cells, index, 'water')) waterCount++;
+      }
+    }
     function applyTerrainMotifs(cells) {
       const waterChance = pct(biomeMix, 'water', 10) / 100;
       const mountainChance = (pct(elevMix, 'mountains', 15) + pct(elevMix, 'hills', 30) * 0.45) / 100;
@@ -1383,9 +1413,29 @@
       if (resourceId === 'food') return isCropObjectId(objectId) || isAnimalObjectId(objectId) || objectId === 'berries';
       if (resourceId === 'materials') return objectId === 'tree' || objectId === 'stone' || objectId === 'ore' || objectId === 'crystal' || objectId === 'logs';
       if (resourceId === 'commerce') return objectId === 'house' || objectId === 'manor' || objectId === 'lamp' || objectId === 'bridge' || objectId === 'water-bridge';
-      if (resourceId === 'defense') return isTowerObjectId(objectId) || objectId === 'spotlight' || objectId === 'castle';
+      if (resourceId === 'defense') return isTowerObjectId(objectId) || objectId === 'totem' || objectId === 'spotlight' || objectId === 'castle';
       if (resourceId === 'charm') return objectId === 'flower' || objectId === 'berries' || objectId === 'tree' || objectId === 'crystal' || objectId === 'ruins' || objectId === 'totem';
       return false;
+    }
+    const generationSuppressedObjectIds = new Set(['spotlight']);
+    function generationEconomyObjectIdForMapped(mapped) {
+      if (!mapped || !mapped.kind) return null;
+      if (mapped.kind === 'house') {
+        if (mapped.buildingType === 'manor') return 'manor';
+        if (mapped.buildingType === 'tower' || mapped.buildingType === 'turret') return 'watchtower';
+        return 'house';
+      }
+      if (mapped.kind === 'lamp-post') return 'lamp';
+      if (mapped.kind === 'rock' || mapped.kind === 'stone' || mapped.kind === 'pebble') return 'stone';
+      if (mapped.kind === 'bush' || mapped.kind === 'shrub') return 'berries';
+      if (mapped.kind === 'crystal') return 'crystal';
+      if (mapped.kind === 'bridge') return 'bridge';
+      return mapped.kind;
+    }
+    function mappedObjectContributesToGenerationEconomy(mapped) {
+      const id = generationEconomyObjectIdForMapped(mapped);
+      if (!id || generationSuppressedObjectIds.has(id)) return false;
+      return economyResourceIds.some(resourceId => objectContributesToResource(id, resourceId));
     }
     function economyResourceCount(cells, resourceId) {
       return cells.reduce((count, cell) => count + (objectContributesToResource(cell && cell.object, resourceId) ? 1 : 0), 0);
@@ -1801,18 +1851,161 @@
       const targetY = archetypeKey === 'pastoral' ? size * 0.58 : size * 0.62;
       return nearestFeatureIndex(cells, cell => cell && cell.terrain !== 'water', targetX, targetY);
     }
-    function applyCropPlotMotif(cells) {
-      clearObjectsWhere(cells, objectId => isCropObjectId(objectId) || objectId === 'garden');
-      const anchor = cropPlotAnchor(cells);
-      if (anchor < 0) return false;
-      const cropIds = archetypeKey === 'pastoral'
+    function chebyshevDistanceBetweenIndexes(a, b) {
+      const pa = xyFor(a);
+      const pb = xyFor(b);
+      return Math.max(Math.abs(pa.x - pb.x), Math.abs(pa.y - pb.y));
+    }
+    function isMainHabitationObject(objectId) {
+      return objectId === 'house' || objectId === 'manor';
+    }
+    function hasMainHabitationTooClose(cells, index) {
+      for (let i = 0; i < cells.length; i++) {
+        if (!cells[i] || !isMainHabitationObject(cells[i].object)) continue;
+        if (chebyshevDistanceBetweenIndexes(index, i) <= 1) return true;
+      }
+      return false;
+    }
+    function clearGeneratedFoodAreaObjects(cells) {
+      for (let index = 0; index < cells.length; index++) {
+        const cell = cells[index];
+        if (!cell || (!isCropObjectId(cell.object) && cell.object !== 'garden')) continue;
+        cell.object = null;
+        cell.footprint = null;
+        cell.footprintParent = null;
+        cell.fenceEdges = null;
+        cell.fenceGatePath = false;
+        cell.fenceGateSides = null;
+        if (cell.motif === 'economy-food' || cell.motif === 'crop-plot') cell.motif = null;
+      }
+    }
+    function cropObjectIdsForArchetype() {
+      return archetypeKey === 'pastoral'
         ? ['wheat', 'corn', 'crop', 'sunflower', 'pumpkin']
         : archetypeKey === 'river'
           ? ['crop', 'wheat', 'carrot', 'flower']
-          : ['crop', 'wheat', 'corn', 'pumpkin'];
-      const plot = featureIndexesNear(anchor, 1)
-        .filter(index => cells[index] && cells[index].terrain !== 'water')
-        .slice(0, Math.max(4, Math.min(6, Math.ceil(size * 0.55))));
+          : ['crop', 'wheat', 'corn', 'pumpkin', 'carrot'];
+    }
+    function squareFoodPlotCandidates(cells, anchor, targetCount, options = {}) {
+      if (anchor < 0) return [];
+      const center = xyFor(anchor);
+      const target = Math.max(1, Math.floor(targetCount || 1));
+      function candidateAllowed(index) {
+        if (index < 0) return false;
+        const cell = cells[index];
+        const foodObject = cell && (isCropObjectId(cell.object) || cell.object === 'garden');
+        if (!cell || cell.terrain === 'water' || (cell.object && !(options.allowFoodObjects && foodObject)) || (cell.fenceGatePath && !options.allowFoodObjects) || (isProtectedEconomyCell(cell) && !(options.allowFoodObjects && foodObject))) return false;
+        if (options.avoidMainHabitation && hasMainHabitationTooClose(cells, index)) return false;
+        return true;
+      }
+      function plotSort(order) {
+        return (a, b) => {
+          const orderA = order.has(a) ? order.get(a) : 10000;
+          const orderB = order.has(b) ? order.get(b) : 10000;
+          if (orderA !== orderB) return orderA - orderB;
+          const ca = xyFor(a);
+          const cb = xyFor(b);
+          const da = Math.max(Math.abs(ca.x - center.x), Math.abs(ca.y - center.y)) + distanceBetweenIndexes(a, anchor) * 0.08 + cellRand(a, 'food-square') * 0.05;
+          const db = Math.max(Math.abs(cb.x - center.x), Math.abs(cb.y - center.y)) + distanceBetweenIndexes(b, anchor) * 0.08 + cellRand(b, 'food-square') * 0.05;
+          return da - db;
+        };
+      }
+      if (options.noFallback) {
+        let best = [];
+        let bestOrder = new Map();
+        for (let side = Math.max(2, Math.ceil(Math.sqrt(target))); side <= Math.min(size, Math.max(2, Math.ceil(Math.sqrt(target)) + 3)); side++) {
+          const local = [];
+          const localOrder = new Map();
+          const startX = clampIntLocal(Math.round(center.x - (side - 1) / 2), 0, Math.max(0, size - side), 0);
+          const startY = clampIntLocal(Math.round(center.y - (side - 1) / 2), 0, Math.max(0, size - side), 0);
+          for (let y = startY; y < startY + side; y++) {
+            for (let x = startX; x < startX + side; x++) {
+              const index = indexFor(x, y);
+              if (!localOrder.has(index)) localOrder.set(index, localOrder.size);
+              if (candidateAllowed(index)) local.push(index);
+            }
+          }
+          if (local.length >= target) return local.sort(plotSort(localOrder));
+          if (local.length > best.length) {
+            best = local;
+            bestOrder = localOrder;
+          }
+        }
+        return best.sort(plotSort(bestOrder));
+      }
+      const seen = new Set();
+      const squareOrder = new Map();
+      const out = [];
+      function consider(index) {
+        if (index < 0 || seen.has(index)) return;
+        seen.add(index);
+        if (!candidateAllowed(index)) return;
+        out.push(index);
+      }
+      for (let side = Math.max(2, Math.ceil(Math.sqrt(target))); side <= Math.min(size, Math.max(2, Math.ceil(Math.sqrt(target)) + 3)); side++) {
+        const startX = clampIntLocal(Math.round(center.x - (side - 1) / 2), 0, Math.max(0, size - side), 0);
+        const startY = clampIntLocal(Math.round(center.y - (side - 1) / 2), 0, Math.max(0, size - side), 0);
+        for (let y = startY; y < startY + side; y++) {
+          for (let x = startX; x < startX + side; x++) {
+            const index = indexFor(x, y);
+            if (!squareOrder.has(index)) squareOrder.set(index, squareOrder.size);
+            consider(index);
+          }
+        }
+        if (out.length >= target) break;
+      }
+      if (out.length < target && !options.noFallback) {
+        for (const index of featureIndexesNear(anchor, Math.max(2, Math.floor(size * 0.28)))) consider(index);
+      }
+      return out.sort((a, b) => {
+        return plotSort(squareOrder)(a, b);
+      });
+    }
+    function bestSquareFoodPlotAnchor(cells, targetCount) {
+      const preferred = cropPlotAnchor(cells);
+      if (preferred < 0) return -1;
+      const target = Math.max(1, Math.floor(targetCount || 1));
+      const minimum = Math.min(target, 4);
+      const candidates = featureIndexesNear(preferred, Math.max(2, Math.floor(size * 0.34)))
+        .filter(index => cells[index] && cells[index].terrain !== 'water' && !hasMainHabitationTooClose(cells, index))
+        .sort((a, b) => distanceBetweenIndexes(a, preferred) - distanceBetweenIndexes(b, preferred) + cellRand(a, 'food-anchor-square') * 0.08);
+      for (const index of candidates) {
+        if (squareFoodPlotCandidates(cells, index, target, { avoidMainHabitation: true, allowFoodObjects: true, noFallback: true }).length >= minimum) return index;
+      }
+      return preferred;
+    }
+    function consolidateGeneratedCropPlot(cells) {
+      const existing = cells
+        .map((cell, index) => ({ cell, index }))
+        .filter(({ cell }) => cell && isCropObjectId(cell.object));
+      if (existing.length < 4) return 0;
+      const cropIds = cropObjectIdsForArchetype();
+      const target = existing.length;
+      const anchor = bestSquareFoodPlotAnchor(cells, target);
+      if (anchor < 0) return 0;
+      const plot = squareFoodPlotCandidates(cells, anchor, target, { avoidMainHabitation: true, allowFoodObjects: true, noFallback: true }).slice(0, target);
+      if (plot.length < Math.min(target, 4)) return 0;
+      clearGeneratedFoodAreaObjects(cells);
+      const placedPlot = [];
+      for (let i = 0; i < plot.length; i++) {
+        const index = plot[i];
+        if (!setFeatureTerrain(cells, index, 'dirt')) continue;
+        if (forcePlaceObject(cells, index, cropIds[i % cropIds.length], 'dirt')) {
+          cells[index].motif = 'crop-plot';
+          placedPlot.push(index);
+        }
+      }
+      connectFeatureToPath(cells, anchor);
+      applyGeneratedFenceEnclosure(cells, placedPlot, { level: 1, style: 'garden' });
+      return placedPlot.length;
+    }
+    function applyCropPlotMotif(cells) {
+      clearGeneratedFoodAreaObjects(cells);
+      const anchor = cropPlotAnchor(cells);
+      if (anchor < 0) return false;
+      const cropIds = cropObjectIdsForArchetype();
+      const targetPlot = Math.max(4, Math.min(6, Math.ceil(size * 0.55)));
+      const plot = squareFoodPlotCandidates(cells, anchor, targetPlot, { avoidMainHabitation: true }).slice(0, targetPlot);
       const placedPlot = [];
       for (let i = 0; i < plot.length; i++) {
         const index = plot[i];
@@ -2051,16 +2244,24 @@
       const anchor = cropPlotAnchor(cells);
       if (anchor < 0) return 0;
       const home = ensureEconomyHomeNear(cells, anchor);
-      const openHomeNeighbor = home >= 0 ? openNeighborForPath(cells, home) : -1;
-      const plotAnchor = openHomeNeighbor >= 0 ? openHomeNeighbor : anchor;
-      const cropIds = archetypeKey === 'pastoral'
-        ? ['wheat', 'corn', 'crop', 'sunflower', 'pumpkin']
-        : archetypeKey === 'river'
-          ? ['crop', 'wheat', 'carrot', 'flower']
-          : ['crop', 'wheat', 'corn', 'pumpkin', 'carrot'];
+      const plotAnchorCandidates = featureIndexesNear(anchor, Math.max(2, Math.floor(size * 0.24)))
+        .filter(index => cells[index] && cells[index].terrain !== 'water' && !cells[index].object && !isProtectedEconomyCell(cells[index]) && !hasMainHabitationTooClose(cells, index))
+        .sort((a, b) => {
+          const homeScoreA = home >= 0 ? Math.abs(distanceBetweenIndexes(a, home) - 2) * 0.25 : 0;
+          const homeScoreB = home >= 0 ? Math.abs(distanceBetweenIndexes(b, home) - 2) * 0.25 : 0;
+          const da = distanceBetweenIndexes(a, anchor) + homeScoreA + cellRand(a, 'food-plot-anchor') * 0.1;
+          const db = distanceBetweenIndexes(b, anchor) + homeScoreB + cellRand(b, 'food-plot-anchor') * 0.1;
+          return da - db;
+        });
+      const plotAnchor = plotAnchorCandidates[0] == null ? anchor : plotAnchorCandidates[0];
+      const cropIds = cropObjectIdsForArchetype();
       let placed = 0;
       const placedFood = [];
-      for (const index of economyPlacementCandidates(cells, plotAnchor, Math.max(2, Math.floor(size * 0.2)), { homeIndex: home, homeDistance: 3 })) {
+      const squareCandidates = squareFoodPlotCandidates(cells, plotAnchor, need, { avoidMainHabitation: true });
+      const fallbackCandidates = economyPlacementCandidates(cells, plotAnchor, Math.max(2, Math.floor(size * 0.26)), { homeIndex: home, homeDistance: 4 })
+        .filter(index => !hasMainHabitationTooClose(cells, index));
+      const candidates = squareCandidates.concat(fallbackCandidates.filter(index => squareCandidates.indexOf(index) === -1));
+      for (const index of candidates) {
         if (placed >= need) break;
         if (!setFeatureTerrain(cells, index, 'dirt')) continue;
         if (!forcePlaceObject(cells, index, cropIds[placed % cropIds.length], 'dirt')) continue;
@@ -2127,8 +2328,7 @@
       let placed = 0;
       for (const index of economyPlacementCandidates(cells, anchor, Math.max(2, Math.floor(size * 0.26)), { nearHome: false })) {
         if (placed >= need) break;
-        const terrain = cells[index].terrain === 'path' ? 'path' : 'stone';
-        if (!forcePlaceObject(cells, index, 'spotlight', terrain)) continue;
+        if (!forcePlaceObject(cells, index, 'totem', 'grass')) continue;
         markEconomyCell(cells, index, 'defense');
         placed++;
       }
@@ -2728,6 +2928,28 @@
       }
     }
 
+    function limitLampPlacements(cells) {
+      const lampIndexes = cells
+        .map((cell, index) => ({ cell, index }))
+        .filter(({ cell }) => cell && cell.object === 'lamp')
+        .sort((a, b) => {
+          const ar = cellRand(a.index, 'lamp-limit');
+          const br = cellRand(b.index, 'lamp-limit');
+          return ar === br ? a.index - b.index : ar - br;
+        });
+      const kept = [];
+      for (const { index } of lampIndexes) {
+        const adjacent = kept.some(keptIndex => neighbors(index).indexOf(keptIndex) !== -1);
+        if (!adjacent && kept.length < 2) {
+          kept.push(index);
+        } else if (cells[index]) {
+          cells[index].object = null;
+          cells[index].footprint = null;
+          cells[index].footprintParent = null;
+        }
+      }
+    }
+
     function makeCells() {
       const land = createLandMask();
       const cells = Array.from({ length: size * size }, (_, index) => {
@@ -2735,15 +2957,18 @@
         return { terrain: terrainForBiomeField(index), object: null };
       });
       applyTerrainMotifs(cells);
+      ensureMinimumWaterTiles(cells, 5);
       carvePaths(cells);
       applyEconomyViabilityPass(cells);
       applyArchetypeGrammar(cells);
       applyArchetypeResourcePolish(cells);
       validateEconomyFloors(cells);
+      consolidateGeneratedCropPlot(cells);
       ensureRoadBridgeCrossing(cells);
       applyPathsideHomeMotif(cells);
       placeBridgeCandidates(cells, archetypeKey === 'river' || archetypeKey === 'harbor' ? 1 : 0.35);
       placeObjects(cells);
+      limitLampPlacements(cells);
       repairGeneratedFenceGatePaths(cells);
       repairGeneratedFenceOpenings(cells);
       ensureGeneratedResourceComponentGates(cells);
@@ -2751,6 +2976,7 @@
       ensureRoadBridgeCrossing(cells);
       forceRoadBridgeCrossing(cells);
       scrubInvalidWaterBridges(cells);
+      ensureMinimumWaterTiles(cells, 5);
       orientGeneratedTowers(cells);
       return cells;
     }
@@ -2865,22 +3091,6 @@
       return { kind: null, floors: 1, buildingType: null, fenceSide: null, appearance: null };
     }
     function terrainFloorsFor(cell, index, mapped) {
-      const terrain = cell && cell.terrain;
-      const kind = mapped && mapped.kind;
-      const rockLike = kind === 'rock' || kind === 'crystal' || kind === 'totem' || kind === 'ruins';
-      if (kind && !rockLike) return 1;
-      if (terrain === 'water' || terrain === 'path' || terrain === 'dirt' || terrain === 'sand' || terrain === 'prairie') return 1;
-      const hills = pct(elevMix, 'hills', 30);
-      const mountains = pct(elevMix, 'mountains', 15);
-      if (terrain === 'cliff') {
-        const max = clampIntLocal(3 + mountains / 18, 3, 7, 4);
-        return floorsByRand(index, 2, max, 'cliff-height');
-      }
-      if (terrain === 'stone') {
-        if (cellRand(index, 'stone-height') < (mountains + hills * 0.5) / 130) return floorsByRand(index, 2, 5, 'stone-height-hi');
-        return 1;
-      }
-      if (!kind && terrain === 'grass' && cellRand(index, 'grass-hill') < hills / 380) return 2;
       return 1;
     }
     function floorsByRand(index, min, max, salt) {
@@ -2900,6 +3110,14 @@
         mapped.buildingType = null;
         mapped.fenceSide = null;
         mapped.appearance = null;
+      }
+      if (mapped.kind && !mappedObjectContributesToGenerationEconomy(mapped)) {
+        mapped.kind = null;
+        mapped.floors = 1;
+        mapped.buildingType = null;
+        mapped.fenceSide = null;
+        mapped.appearance = null;
+        mapped.rotationY = null;
       }
       const fenceExtras = terrain === 'water' ? [] : (mapped.extras || []).concat(labFenceExtrasForCell(cell));
       const entry = {

--- a/engine/world/28-generate-panel-agent.js
+++ b/engine/world/28-generate-panel-agent.js
@@ -138,6 +138,9 @@
     const planetDropEl = document.getElementById('gen-planet-drop');
     const planetDropValueEl = document.getElementById('gen-planet-drop-value');
     const genActionsEl = goBtn ? goBtn.closest('.gen-actions') : null;
+    const progressEl = document.getElementById('gen-progress');
+    const progressFillEl = document.getElementById('gen-progress-fill');
+    const progressLabelEl = document.getElementById('gen-progress-label');
 
     const _genPreviewState = { data: null, meta: null, group: null, mats: [], geoms: [] };
 
@@ -273,19 +276,29 @@
       return true;
     }
 
-    function _genPreviewCommit() {
+    async function _genPreviewCommit() {
       const data = _genPreviewState.data;
       const meta = _genPreviewState.meta || {};
       if (!data) return false;
       _genPreviewDispose();
       _genPreviewSetControls(false);
       if (typeof setCameraMode === 'function') setCameraMode('perspective');
-      const ok = applyState(data, {
-        sliced: true,
-        keepCamera: true,
-        renderOrigin: meta.renderOrigin || undefined,
+      setGenerationLocked(true);
+      setStatus('applying preview…', 'busy');
+      setGenerationProgress(18, 'Preparing apply');
+      await generationPaintYield();
+      const ok = await applyGeneratedStateWithProgress(data, {
+        start: 24,
+        end: 94,
+        label: 'Applying preview',
+        terrainBake: true,
+        apply: {
+          keepCamera: true,
+          renderOrigin: meta.renderOrigin || undefined,
+        },
       });
       if (!ok) {
+        setGenerationLocked(false);
         setStatus('renderer rejected the preview', 'error');
         return false;
       }
@@ -293,7 +306,10 @@
         initLandscapeMesh();
         rebuildTerrainRender();
       }
-      setStatus('applied · seed: ' + (meta.seed || 'random') + (meta.planetDrop ? ' · planet ' + meta.planetDrop + 'm below' : ''), '');
+      setGenerationProgress(100, 'Complete');
+      setGenerationLocked(false);
+      clearGenerationProgress();
+      setStatus('applied · seed: ' + (meta.seed || 'random') + (meta.planetDrop ? ' · planet ' + meta.planetDrop + 'm below' : ''), 'done');
       if (window.__tinyworldAgent) window.__tinyworldAgent.say('Applied the generated preview.');
       return true;
     }
@@ -495,6 +511,71 @@
     function setStatus(msg, kind) {
       statusEl.textContent = msg || '';
       statusEl.className = kind || '';
+    }
+
+    function setGenerationProgress(value, label) {
+      const pct = Math.max(0, Math.min(100, Number(value) || 0));
+      if (progressEl) {
+        progressEl.hidden = false;
+        progressEl.setAttribute('aria-valuenow', String(Math.round(pct)));
+      }
+      if (progressFillEl) progressFillEl.style.width = pct.toFixed(1) + '%';
+      if (progressLabelEl) progressLabelEl.textContent = label || (Math.round(pct) + '%');
+    }
+
+    function clearGenerationProgress(delay = 900) {
+      setTimeout(() => {
+        if (progressEl) progressEl.hidden = true;
+        if (progressFillEl) progressFillEl.style.width = '0%';
+        if (progressLabelEl) progressLabelEl.textContent = 'Preparing generation';
+        if (progressEl) progressEl.setAttribute('aria-valuenow', '0');
+      }, delay);
+    }
+
+    function generationPaintYield() {
+      return new Promise(resolve => {
+        if (typeof requestAnimationFrame === 'function') requestAnimationFrame(() => resolve());
+        else setTimeout(resolve, 0);
+      });
+    }
+
+    function setGenerationLocked(locked) {
+      if (typeof setGenerationViewLocked === 'function') setGenerationViewLocked(locked);
+      [goBtn, applyPreviewBtn, regeneratePreviewBtn, discardPreviewBtn].forEach(btn => {
+        if (btn) btn.disabled = !!locked;
+      });
+    }
+
+    function requestGeneratedTerrainBake() {
+      try {
+        if (typeof window.__tinyworldRequestTerrainBake === 'function') window.__tinyworldRequestTerrainBake();
+      } catch (_) {}
+    }
+
+    function applyGeneratedStateWithProgress(data, opts = {}) {
+      return new Promise(resolve => {
+        const start = Number.isFinite(opts.start) ? opts.start : 35;
+        const end = Number.isFinite(opts.end) ? opts.end : 94;
+        const label = opts.label || 'Building world';
+        const applyOpts = Object.assign({}, opts.apply || {}, {
+          sliced: true,
+          onProgress(info) {
+            const total = Math.max(1, (info && info.total) || 1);
+            const done = Math.max(0, Math.min(total, (info && info.done) || 0));
+            const phase = info && info.phase ? ' · ' + info.phase : '';
+            setGenerationProgress(start + (end - start) * (done / total), label + phase);
+          },
+          onDone() {
+            if (opts.terrainBake) requestGeneratedTerrainBake();
+            if (opts.apply && typeof opts.apply.onDone === 'function') {
+              try { opts.apply.onDone(); } catch (_) {}
+            }
+            resolve(true);
+          },
+        });
+        const ok = typeof applyState === 'function' && applyState(data, applyOpts);
+        if (!ok) resolve(false);
+      });
     }
 
     function applyGenerationAutofillSetting(disabled) {
@@ -803,19 +884,30 @@
       if (procedural) {
         const effectiveSeed = seed || randomSeed();
         if (!seed && seedEl) seedEl.value = effectiveSeed;
-        goBtn.disabled = true;
+        setGenerationLocked(true);
         setStatus('generating random island…', 'busy');
+        setGenerationProgress(6, 'Preparing seed');
         try {
           applyGenerationAutofillSetting(disableAutofill);
+          await generationPaintYield();
+          setGenerationProgress(18, 'Selecting terrain and resources');
           const data = useLandscape
             ? generateLandscapeWorld({ seed: effectiveSeed, biomes, elevation, gridSize })
             : generateProceduralWorld({ seed: effectiveSeed, biomes, elevation, gridSize });
           if (wantsPlanetLandscape) {
             data.planetLandscape = planetLandscapeStateFromSelection(effectiveSeed, planetBiome, planetStyleMode, planetDrop);
           }
+          setGenerationProgress(30, 'Validating world');
+          await generationPaintYield();
           const err = (typeof validateWorld === 'function') ? validateWorld(data) : null;
           if (err) throw new Error('random island schema: ' + err);
-          if (typeof applyState === 'function' && !applyState(data, { sliced: true })) {
+          const applied = await applyGeneratedStateWithProgress(data, {
+            start: 36,
+            end: 94,
+            label: 'Rendering island',
+            terrainBake: !useLandscape,
+          });
+          if (!applied) {
             throw new Error('renderer rejected the procedural scene');
           }
           // Build the landscape overlay after applyState created the engine.
@@ -831,12 +923,14 @@
             }
           }
           if (wantsPlanetLandscape && typeof setCameraMode === 'function') setCameraMode('perspective');
-          setStatus('done · seed: ' + effectiveSeed + (wantsPlanetLandscape ? ' · planet ' + planetDrop + 'm below' : ''), '');
+          setGenerationProgress(100, 'Complete');
+          clearGenerationProgress();
+          setStatus('done · seed: ' + effectiveSeed + (wantsPlanetLandscape ? ' · planet ' + planetDrop + 'm below' : ''), 'done');
         } catch (err) {
           console.error('random island generate failed:', err);
           setStatus(String(err.message || err).slice(0, 140), 'error');
         } finally {
-          goBtn.disabled = false;
+          setGenerationLocked(false);
         }
         return;
       }
@@ -893,12 +987,15 @@
         setStatus('using ' + model + ' for JSON generation', 'busy');
       }
       saveProviderState();
-      goBtn.disabled = true;
+      setGenerationLocked(true);
+      setGenerationProgress(8, 'Preparing request');
       if (statusEl.textContent.indexOf('using ') !== 0) {
         setStatus('generating', 'busy');
       }
       try {
         hidePlanOverlay();
+        await generationPaintYield();
+        setGenerationProgress(28, 'Requesting JSON');
         progress.say('Generating validated world JSON with ' + model + '…');
         const data = await generateWorld(provider, model, key, decoratedPrompt, gridSize);
         if (!data) { setStatus('', ''); return; } // superseded by a newer generation
@@ -908,6 +1005,7 @@
         }
         const receivedCells = data && Array.isArray(data.cells) ? data.cells.length : 0;
         progress.say('Received JSON with ' + receivedCells + ' cells. Building holographic diff preview…');
+        setGenerationProgress(76, 'Building preview');
         hidePlanOverlay();
         if (typeof setCameraMode === 'function') setCameraMode('perspective');
         const ok = _genPreviewStage(data, {
@@ -917,6 +1015,8 @@
           planetDrop: wantsPlanetLandscape ? planetDrop : 0,
         });
         if (!ok) throw new Error('preview rejected the scene');
+        setGenerationProgress(100, 'Preview ready');
+        clearGenerationProgress();
         modal.hidden = false;
         progress.done('Preview ready — inspect the holographic diff, then Apply, Regenerate, or Discard.');
       } catch (err) {
@@ -926,8 +1026,7 @@
         progress.error(String(err.message || err).slice(0, 180));
         setStatus(String(err.message || err).slice(0, 140), 'error');
       } finally {
-        if (typeof setGenerationViewLocked === 'function') setGenerationViewLocked(false);
-        goBtn.disabled = false;
+        setGenerationLocked(false);
       }
     });
 

--- a/engine/world/30-ui-boot-wiring.js
+++ b/engine/world/30-ui-boot-wiring.js
@@ -1,3 +1,16 @@
+  // -------- random island preview mode --------
+  function randomIslandPreviewModeEnabled() {
+    try {
+      const params = new URLSearchParams(window.location.search || '');
+      return params.get('randomIslandPreview') === '1' || params.get('islandPreview') === '1';
+    } catch (_) {
+      return false;
+    }
+  }
+  if (randomIslandPreviewModeEnabled()) {
+    document.body.classList.add('random-island-preview-mode');
+  }
+
   // -------- welcome dialog --------
   function initWelcomeDialog() {
   
@@ -320,6 +333,10 @@ syncTinyworldOwnerToolControls();
       chooseWelcomeMode('play');
     };
     const showWelcome = (opts = {}) => {
+      if (randomIslandPreviewModeEnabled()) {
+        closeWelcome();
+        return;
+      }
       if (!opts.skipRoomCleanup) {
         try {
           const worlds = window.__tinyworldWorlds;
@@ -382,6 +399,10 @@ syncTinyworldOwnerToolControls();
         ? window.__tinyworldTinyverseSlugParam()
         : null;
       chooseWelcomeMode(tinyverseSlug ? 'play' : 'build');
+      return;
+    }
+    if (randomIslandPreviewModeEnabled()) {
+      closeWelcome();
       return;
     }
     showWelcome({ skipRoomCleanup: true });
@@ -3210,6 +3231,8 @@ syncTinyworldOwnerToolControls();
       const intensityReadout = document.getElementById('weather-intensity-readout');
       const splashesRange = document.getElementById('weather-splashes');
       const splashesReadout = document.getElementById('weather-splashes-readout');
+      const directionalLightRange = document.getElementById('directional-light-strength');
+      const directionalLightReadout = document.getElementById('directional-light-strength-readout');
 
       function paintPills() {
         if (seasonPills) seasonPills.querySelectorAll('.pill').forEach(p => {
@@ -3228,6 +3251,8 @@ syncTinyworldOwnerToolControls();
         if (intensityReadout) intensityReadout.textContent = Math.round(weatherIntensity * 100) + '%';
         if (splashesRange) splashesRange.value = String(Math.round(weatherSplashIntensity * 100));
         if (splashesReadout) splashesReadout.textContent = Math.round(weatherSplashIntensity * 100) + '%';
+        if (directionalLightRange) directionalLightRange.value = String(Math.round(renderDirectionalSun * 100));
+        if (directionalLightReadout) directionalLightReadout.textContent = Math.round(renderDirectionalSun * 100) + '%';
       }
       repaintTimeWeatherPopup = paintReadout;
       syncTimeRangeEditability = function () {
@@ -3307,6 +3332,19 @@ syncTinyworldOwnerToolControls();
           if (typeof setWeatherSplashIntensity === 'function') setWeatherSplashIntensity(value / 100);
           paintReadout();
           try { localStorage.setItem(WEATHER_SPLASHES_LS, weatherSplashIntensity.toFixed(2)); } catch (_) {}
+        });
+      }
+      if (directionalLightRange) {
+        directionalLightRange.addEventListener('input', () => {
+          const value = Math.max(0, Math.min(1000, parseInt(directionalLightRange.value, 10) || 0));
+          renderDirectionalSun = value / 100;
+          try { localStorage.setItem(RENDER_LS.directionalSun, renderDirectionalSun.toFixed(2)); } catch (_) {}
+          if (typeof applyLightingSettings === 'function') applyLightingSettings();
+          lightBase = null;
+          applyLights();
+          paintReadout();
+          if (typeof requestShadowMapUpdate === 'function') requestShadowMapUpdate();
+          if (typeof renderSceneIfReady === 'function') renderSceneIfReady();
         });
       }
     }
@@ -4465,6 +4503,171 @@ syncTinyworldOwnerToolControls();
       close();
       setTimeout(() => openNewWorldReveal(profile), 180);
     }
+
+    const RANDOM_ISLAND_PREVIEW_PARENT_SOURCE = 'tinyworld-random-island-preview-control';
+    const RANDOM_ISLAND_PREVIEW_APP_SOURCE = 'tinyworld-random-island-preview';
+    let randomIslandPreviewCurrent = null;
+
+    function randomIslandPreviewPost(type, payload = {}) {
+      if (!randomIslandPreviewModeEnabled()) return;
+      const msg = Object.assign({
+        source: RANDOM_ISLAND_PREVIEW_APP_SOURCE,
+        type,
+      }, payload);
+      try {
+        if (window.parent && window.parent !== window) window.parent.postMessage(msg, window.location.origin);
+      } catch (_) {}
+    }
+
+    function randomIslandPreviewCleanArchetype(value) {
+      const key = String(value || '').trim().toLowerCase();
+      return ['pastoral', 'forest', 'quarry', 'river', 'village', 'fortress', 'ruins', 'harbor'].indexOf(key) !== -1
+        ? key
+        : randomIslandArchetypeForWorldMenu();
+    }
+
+    function randomIslandPreviewGridSize(value) {
+      return coerceGridSize(value, GRID);
+    }
+
+    function randomIslandPreviewStatePayload() {
+      const worldState = (typeof buildWorldStateObject === 'function')
+        ? buildWorldStateObject()
+        : (randomIslandPreviewCurrent && randomIslandPreviewCurrent.world);
+      return {
+        seed: randomIslandPreviewCurrent && randomIslandPreviewCurrent.seed || '',
+        archetype: randomIslandPreviewCurrent && randomIslandPreviewCurrent.archetype || '',
+        profile: randomIslandPreviewCurrent && randomIslandPreviewCurrent.profile || null,
+        world: worldState || null,
+      };
+    }
+
+    function randomIslandPreviewForceEnhancedWater() {
+      try {
+        if (typeof renderEnhancedWater !== 'undefined') renderEnhancedWater = true;
+        if (typeof RENDER_LS !== 'undefined' && RENDER_LS.enhancedWater) {
+          localStorage.setItem(RENDER_LS.enhancedWater, '1');
+        }
+        const enhancedWaterEl = document.getElementById('render-enhanced-water');
+        if (enhancedWaterEl) enhancedWaterEl.checked = true;
+        if (typeof refreshWaterShaderMaterials === 'function') refreshWaterShaderMaterials();
+        if (typeof landscapeEngineInstance !== 'undefined'
+            && landscapeEngineInstance && landscapeEngineInstance.waterMat
+            && landscapeEngineInstance.waterMat.uniforms
+            && landscapeEngineInstance.waterMat.uniforms.uEnhance) {
+          landscapeEngineInstance.waterMat.uniforms.uEnhance.value = 1.0;
+        }
+      } catch (_) {}
+    }
+
+    function randomIslandPreviewApplyWorld(data, profile, meta = {}) {
+      if (!data || typeof applyState !== 'function') {
+        randomIslandPreviewPost('error', { message: 'Random island preview could not load a world.' });
+        return false;
+      }
+      dismissWelcomeLaunchForNewWorld();
+      leaveWorldRoomForMenuLoad();
+      document.body.classList.add('random-island-preview-mode');
+      randomIslandPreviewForceEnhancedWater();
+      randomIslandPreviewCurrent = {
+        seed: meta.seed || profile && profile.seed || '',
+        archetype: meta.archetype || profile && profile.archetypeKey || '',
+        world: data,
+        profile,
+      };
+      let postedReady = false;
+      function finishRandomIslandPreviewReveal() {
+        if (postedReady) return;
+        postedReady = true;
+        try {
+          if (profile) openNewWorldReveal(profile);
+          randomIslandPreviewPost('ready', { state: randomIslandPreviewStatePayload() });
+        } catch (err) {
+          console.error('[random-island-preview] reveal failed:', err);
+          randomIslandPreviewPost('error', {
+            message: err && err.message ? err.message : 'Random island reveal failed.',
+            state: randomIslandPreviewStatePayload(),
+          });
+        }
+      }
+      const ok = applyState(data, {
+        onDone: () => setTimeout(finishRandomIslandPreviewReveal, 60),
+      });
+      if (!ok) {
+        randomIslandPreviewPost('error', { message: 'Random island preview rejected the world JSON.' });
+        return false;
+      }
+      return true;
+    }
+
+    function randomIslandPreviewGenerate(opts = {}) {
+      if (typeof generateProceduralWorld !== 'function') {
+        randomIslandPreviewPost('error', { message: 'Random island generator is unavailable.' });
+        return false;
+      }
+      const seed = String(opts.seed || randomIslandSeedForWorldMenu()).trim() || randomIslandSeedForWorldMenu();
+      const archetype = randomIslandPreviewCleanArchetype(opts.archetype);
+      const gridSize = randomIslandPreviewGridSize(opts.gridSize);
+      const mix = randomIslandMixForWorldMenu(archetype);
+      const data = generateProceduralWorld({
+        seed,
+        archetype,
+        biomes: mix.biomes,
+        elevation: mix.elevation,
+        gridSize,
+      });
+      const profile = typeof buildRandomIslandEconomyProfile === 'function'
+        ? buildRandomIslandEconomyProfile(data, { seed, archetype })
+        : { seed, archetypeKey: archetype, name: 'New world', archetype, stats: {}, statDefs: [], traits: [], topStats: [], highlights: [], economy: { potential: 1, rarity: 'Common' } };
+      return randomIslandPreviewApplyWorld(data, profile, { seed, archetype });
+    }
+
+    function randomIslandPreviewLoad(payload) {
+      const source = payload && payload.type === 'tinyworld.randomIslandReveal' ? payload.world : payload;
+      if (!source || source.v !== 4 || !Array.isArray(source.cells)) {
+        randomIslandPreviewPost('error', { message: 'File is not a TinyWorld island reveal file or v:4 world JSON.' });
+        return false;
+      }
+      const seed = String(payload && payload.seed || source.seed || 'loaded-island');
+      const archetype = String(payload && payload.archetype || payload && payload.profile && payload.profile.archetypeKey || '').trim().toLowerCase();
+      const profile = payload && payload.profile
+        ? payload.profile
+        : (typeof buildRandomIslandEconomyProfile === 'function'
+          ? buildRandomIslandEconomyProfile(source, { seed, archetype })
+          : { seed, archetypeKey: archetype, name: 'Loaded island', archetype, stats: {}, statDefs: [], traits: [], topStats: [], highlights: [], economy: { potential: 1, rarity: 'Common' } });
+      return randomIslandPreviewApplyWorld(source, profile, { seed, archetype: archetype || profile.archetypeKey || '' });
+    }
+
+    function randomIslandPreviewHandleMessage(event) {
+      if (!randomIslandPreviewModeEnabled()) return;
+      if (event.origin !== window.location.origin) return;
+      const msg = event.data || {};
+      if (!msg || msg.source !== RANDOM_ISLAND_PREVIEW_PARENT_SOURCE) return;
+      if (msg.command === 'generate') {
+        randomIslandPreviewGenerate(msg);
+      } else if (msg.command === 'load') {
+        randomIslandPreviewLoad(msg.payload);
+      } else if (msg.command === 'export') {
+        randomIslandPreviewPost('state', { state: randomIslandPreviewStatePayload() });
+      }
+    }
+
+    function bootRandomIslandPreviewFromQuery() {
+      if (!randomIslandPreviewModeEnabled()) return;
+      const params = new URLSearchParams(window.location.search || '');
+      const seed = params.get('randomIslandSeed') || params.get('seed') || randomIslandSeedForWorldMenu();
+      const archetype = params.get('randomIslandArchetype') || params.get('archetype') || randomIslandArchetypeForWorldMenu();
+      const gridSize = params.get('randomIslandGrid') || params.get('gridSize') || GRID;
+      window.addEventListener('message', randomIslandPreviewHandleMessage);
+      setTimeout(() => randomIslandPreviewGenerate({ seed, archetype, gridSize }), 380);
+    }
+
+    window.__tinyworldRandomIslandPreview = {
+      generate: randomIslandPreviewGenerate,
+      load: randomIslandPreviewLoad,
+      exportState: randomIslandPreviewStatePayload,
+    };
+    bootRandomIslandPreviewFromQuery();
 
     async function worldMenuAccessToken() {
       const Auth = window.TinyWorldAuth;

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,6 +27,18 @@
   status = 200
 
 [[redirects]]
+  from = "/random-island-preview"
+  to = "/.netlify/functions/random-island-preview"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/random-island-preview.html"
+  to = "/.netlify/functions/random-island-preview"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/roadmap"
   to = "/roadmap.html"
   status = 200

--- a/netlify/functions/lib/auth.mjs
+++ b/netlify/functions/lib/auth.mjs
@@ -9,7 +9,10 @@ const WALLET_LOGIN_CHALLENGE_TTL_SECONDS = 10 * 60;
 function bearerToken(request) {
   const header = request.headers.get('authorization') || '';
   const match = header.match(/^Bearer\s+(.+)$/i);
-  return match ? match[1].trim() : '';
+  if (match) return match[1].trim();
+  const cookie = request.headers.get('cookie') || '';
+  const cookieMatch = cookie.match(/(?:^|;\s*)nf_jwt=([^;]+)/);
+  return cookieMatch ? decodeURIComponent(cookieMatch[1]) : '';
 }
 
 function envValue(name) {

--- a/netlify/functions/random-island-preview.mjs
+++ b/netlify/functions/random-island-preview.mjs
@@ -1,0 +1,153 @@
+import { getAuthUser } from './lib/auth.mjs';
+
+export const config = { path: '/.netlify/functions/random-island-preview' };
+
+const PREVIEW_OWNER_EMAILS = new Set([
+  'jason@bouncingfish.com',
+  'jason.kneen@bouncingfish.com',
+  'jason.kneen@gmail.com',
+]);
+
+function htmlResponse(body, status = 200) {
+  return new Response(body, {
+    status,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+    },
+  });
+}
+
+function gateHtml(message) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TinyWorld Island Reveal Preview</title>
+  <style>
+    :root { color-scheme: light; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      color: #172133;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: linear-gradient(180deg, #eef5f6, #dfe9e4);
+    }
+    main {
+      width: min(520px, calc(100vw - 32px));
+      padding: 28px;
+      border: 1px solid rgba(255, 255, 255, 0.78);
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.86);
+      box-shadow: 0 22px 70px -38px rgba(20, 32, 52, 0.72);
+    }
+    h1 { margin: 0 0 10px; font: 760 28px/1.05 Georgia, "Times New Roman", serif; }
+    p { margin: 0 0 18px; color: #5a687a; line-height: 1.5; }
+    a {
+      display: inline-flex;
+      min-height: 40px;
+      align-items: center;
+      padding: 0 14px;
+      border-radius: 999px;
+      color: #fff;
+      background: #276ad8;
+      text-decoration: none;
+      font-weight: 760;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Jason-only island preview</h1>
+    <p>${message}</p>
+    <a href="/tiny-world-builder">Sign in to TinyWorld</a>
+  </main>
+</body>
+</html>`;
+}
+
+function previewHtml() {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TinyWorld Island Reveal Preview</title>
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" href="styles/random-island-preview.css">
+</head>
+<body>
+  <main class="rip-shell">
+    <section class="rip-toolbar" aria-label="Island reveal preview controls">
+      <div class="rip-brand">
+        <span class="rip-kicker">TinyWorld</span>
+        <h1>Island Reveal</h1>
+      </div>
+      <form class="rip-controls" id="rip-controls">
+        <label>
+          <span>Archetype</span>
+          <select id="rip-archetype">
+            <option value="random">Random</option>
+            <option value="pastoral">Pastoral</option>
+            <option value="forest">Forest</option>
+            <option value="quarry">Quarry</option>
+            <option value="river">River</option>
+            <option value="village">Village</option>
+            <option value="fortress">Fortress</option>
+            <option value="ruins">Ruins</option>
+            <option value="harbor">Harbor</option>
+          </select>
+        </label>
+        <label>
+          <span>Grid</span>
+          <select id="rip-grid-size">
+            <option value="8">8 x 8</option>
+            <option value="10">10 x 10</option>
+            <option value="12">12 x 12</option>
+            <option value="16">16 x 16</option>
+            <option value="20">20 x 20</option>
+          </select>
+        </label>
+        <label class="rip-seed-field">
+          <span>Seed</span>
+          <input id="rip-seed" type="text" autocomplete="off">
+        </label>
+        <button type="submit" class="rip-primary">Random</button>
+        <button type="button" id="rip-save-reveal">Save Island File</button>
+        <button type="button" id="rip-save-world">Save Game JSON</button>
+        <button type="button" id="rip-load-button">Load</button>
+        <input id="rip-load-file" type="file" accept=".json,application/json" hidden>
+      </form>
+      <div class="rip-status" id="rip-status" role="status">Starting real TinyWorld renderer...</div>
+    </section>
+
+    <section class="rip-frame-wrap" aria-label="Real TinyWorld island reveal">
+      <iframe
+        id="rip-frame"
+        title="TinyWorld rendered island reveal"
+        src="about:blank"
+        allow="fullscreen"
+      ></iframe>
+    </section>
+  </main>
+  <script src="scripts/random-island-preview.js"></script>
+</body>
+</html>`;
+}
+
+export default async function randomIslandPreview(request) {
+  const user = await getAuthUser(request);
+  const email = String(user && user.email || '').trim().toLowerCase();
+  if (!email) {
+    return htmlResponse(gateHtml('This screen is a private preview. Sign in as Jason, then reopen the island preview link.'), 401);
+  }
+  if (!PREVIEW_OWNER_EMAILS.has(email)) {
+    return htmlResponse(gateHtml('This private island preview is currently shared only with Jason.'), 403);
+  }
+  return htmlResponse(previewHtml());
+}

--- a/news.html
+++ b/news.html
@@ -291,6 +291,13 @@
             features and experiments.
           </p>
           <p>
+            The island generator is also getting a cleaner technical foundation: stronger
+            day-night sun lighting, flatter generated island terrain, merged terrain surfaces for
+            lower draw calls, fewer no-effect props in generated islands, a simpler non-build
+            generation flow, and a progress bar so large islands can render without freezing the
+            main UI.
+          </p>
+          <p>
             The important phrase is <strong>economic potential</strong>. That doesn't mean a full
             live economy has to be active immediately. It means islands can start to have readable
             value and personality — one strong in food production, another with better defensive

--- a/publish.sh
+++ b/publish.sh
@@ -17,6 +17,7 @@ Creates a clean dist/ folder for publishing Tiny World Builder.
 Outputs:
   dist/index.html                 Landing page entry point
   dist/tiny-world-builder.html    Original app filename
+  dist/random-island-preview.html Private Netlify-function route, not a public static copy
   dist/world.schema.json
   dist/README.md
   dist/LICENSE

--- a/random-island-preview.html
+++ b/random-island-preview.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TinyWorld Island Reveal Preview</title>
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" href="styles/random-island-preview.css">
+</head>
+<body>
+  <main class="rip-shell">
+    <section class="rip-toolbar" aria-label="Island reveal preview controls">
+      <div class="rip-brand">
+        <span class="rip-kicker">TinyWorld</span>
+        <h1>Island Reveal</h1>
+      </div>
+      <form class="rip-controls" id="rip-controls">
+        <label>
+          <span>Archetype</span>
+          <select id="rip-archetype">
+            <option value="random">Random</option>
+            <option value="pastoral">Pastoral</option>
+            <option value="forest">Forest</option>
+            <option value="quarry">Quarry</option>
+            <option value="river">River</option>
+            <option value="village">Village</option>
+            <option value="fortress">Fortress</option>
+            <option value="ruins">Ruins</option>
+            <option value="harbor">Harbor</option>
+          </select>
+        </label>
+        <label>
+          <span>Grid</span>
+          <select id="rip-grid-size">
+            <option value="8">8 x 8</option>
+            <option value="10">10 x 10</option>
+            <option value="12">12 x 12</option>
+            <option value="16">16 x 16</option>
+            <option value="20">20 x 20</option>
+          </select>
+        </label>
+        <label class="rip-seed-field">
+          <span>Seed</span>
+          <input id="rip-seed" type="text" autocomplete="off">
+        </label>
+        <button type="submit" class="rip-primary">Random</button>
+        <button type="button" id="rip-save-reveal">Save Island File</button>
+        <button type="button" id="rip-save-world">Save Game JSON</button>
+        <button type="button" id="rip-load-button">Load</button>
+        <input id="rip-load-file" type="file" accept=".json,application/json" hidden>
+      </form>
+      <div class="rip-status" id="rip-status" role="status">Starting real TinyWorld renderer...</div>
+    </section>
+
+    <section class="rip-frame-wrap" aria-label="Real TinyWorld island reveal">
+      <iframe
+        id="rip-frame"
+        title="TinyWorld rendered island reveal"
+        src="about:blank"
+        allow="fullscreen"
+      ></iframe>
+    </section>
+  </main>
+  <script src="scripts/random-island-preview.js"></script>
+</body>
+</html>

--- a/scripts/random-island-preview.js
+++ b/scripts/random-island-preview.js
@@ -1,0 +1,201 @@
+(function () {
+  'use strict';
+
+  const CONTROL_SOURCE = 'tinyworld-random-island-preview-control';
+  const APP_SOURCE = 'tinyworld-random-island-preview';
+  const ARCHETYPES = ['pastoral', 'forest', 'quarry', 'river', 'village', 'fortress', 'ruins', 'harbor'];
+  const state = {
+    ready: false,
+    pendingExport: null,
+    pendingLoad: null,
+    current: null,
+  };
+
+  const el = {
+    form: document.getElementById('rip-controls'),
+    archetype: document.getElementById('rip-archetype'),
+    gridSize: document.getElementById('rip-grid-size'),
+    seed: document.getElementById('rip-seed'),
+    saveReveal: document.getElementById('rip-save-reveal'),
+    saveWorld: document.getElementById('rip-save-world'),
+    loadButton: document.getElementById('rip-load-button'),
+    loadFile: document.getElementById('rip-load-file'),
+    status: document.getElementById('rip-status'),
+    frame: document.getElementById('rip-frame'),
+  };
+
+  function randomChoice(values) {
+    return values[Math.floor(Math.random() * values.length)];
+  }
+
+  function randomIslandSeed() {
+    const labels = ['mossbridge', 'stonefall', 'cloverdock', 'pinewatch', 'saltmeadow', 'relicshoal', 'lanternbay', 'crownmeadow'];
+    const n = Math.floor(Math.random() * 90000) + 10000;
+    return randomChoice(labels) + '-' + n;
+  }
+
+  function slug(value) {
+    const clean = String(value || 'island').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    return clean || 'island';
+  }
+
+  function setStatus(text) {
+    el.status.textContent = text || '';
+  }
+
+  function selectedArchetype() {
+    const value = el.archetype.value;
+    return value || 'random';
+  }
+
+  function frameUrl(seed, archetype, gridSize) {
+    const params = new URLSearchParams();
+    params.set('randomIslandPreview', '1');
+    params.set('randomIslandSeed', seed);
+    params.set('randomIslandArchetype', archetype);
+    params.set('randomIslandGrid', String(gridSize));
+    params.set('randomIslandNonce', String(Date.now()) + '-' + Math.floor(Math.random() * 1000000));
+    params.set('ai', '0');
+    return '/tiny-world-builder?' + params.toString();
+  }
+
+  function postToFrame(message) {
+    if (!el.frame || !el.frame.contentWindow) return;
+    el.frame.contentWindow.postMessage(Object.assign({ source: CONTROL_SOURCE }, message), window.location.origin);
+  }
+
+  function requestExport(kind) {
+    state.pendingExport = kind;
+    postToFrame({ command: 'export' });
+  }
+
+  function downloadJson(filename, value) {
+    const blob = new Blob([JSON.stringify(value, null, 2) + '\n'], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 200);
+  }
+
+  function saveCurrent(kind, current) {
+    if (!current || !current.world) {
+      setStatus('The rendered island is not ready yet.');
+      return;
+    }
+    const profile = current.profile || {};
+    const name = profile.name || 'island';
+    if (kind === 'world') {
+      downloadJson('tinyworld-world-' + slug(name) + '.json', current.world);
+      setStatus('Saved game JSON from the real rendered island.');
+      return;
+    }
+    downloadJson('tinyworld-island-' + slug(name) + '-reveal.json', {
+      type: 'tinyworld.randomIslandReveal',
+      version: 1,
+      savedAt: new Date().toISOString(),
+      seed: current.seed || '',
+      archetype: current.archetype || '',
+      world: current.world,
+      profile,
+    });
+    setStatus('Saved island reveal file from the real rendered island.');
+  }
+
+  function generateIsland() {
+    el.archetype.value = 'random';
+    const archetype = selectedArchetype();
+    const gridSize = Number(el.gridSize.value || 8);
+    const seed = randomIslandSeed();
+    el.seed.value = seed;
+    state.ready = false;
+    state.current = null;
+    state.pendingLoad = null;
+    setStatus(archetype === 'random'
+      ? 'Rendering a random island in TinyWorld...'
+      : 'Rendering ' + archetype + ' island in TinyWorld...');
+    el.frame.src = frameUrl(seed, archetype, gridSize);
+  }
+
+  function loadPayload(payload) {
+    if (!state.ready) {
+      state.pendingLoad = payload;
+      return;
+    }
+    postToFrame({ command: 'load', payload });
+    setStatus('Loading island into the TinyWorld renderer...');
+  }
+
+  function readSelectedFile(file) {
+    const reader = new FileReader();
+    reader.onload = function () {
+      try {
+        loadPayload(JSON.parse(String(reader.result || '')));
+      } catch (err) {
+        console.error(err);
+        setStatus(err && err.message ? err.message : 'Could not load island file.');
+      }
+    };
+    reader.onerror = function () {
+      setStatus('Could not read island file.');
+    };
+    reader.readAsText(file);
+  }
+
+  window.addEventListener('message', function (event) {
+    if (event.origin !== window.location.origin) return;
+    const msg = event.data || {};
+    if (!msg || msg.source !== APP_SOURCE) return;
+    if (msg.type === 'error') {
+      if (msg.state) {
+        state.ready = true;
+        state.current = msg.state;
+      }
+      setStatus(msg.message || 'TinyWorld renderer reported an error.');
+      return;
+    }
+    if (msg.type === 'ready' || msg.type === 'state') {
+      state.ready = true;
+      state.current = msg.state || state.current;
+      const profile = state.current && state.current.profile;
+      if (profile && profile.name) setStatus('Viewing ' + profile.name + ' in the real TinyWorld renderer.');
+      else setStatus('TinyWorld renderer is ready.');
+      if (state.pendingLoad) {
+        const pending = state.pendingLoad;
+        state.pendingLoad = null;
+        loadPayload(pending);
+        return;
+      }
+      if (state.pendingExport) {
+        const kind = state.pendingExport;
+        state.pendingExport = null;
+        saveCurrent(kind, state.current);
+      }
+    }
+  });
+
+  el.form.addEventListener('submit', function (event) {
+    event.preventDefault();
+    generateIsland();
+  });
+  el.saveReveal.addEventListener('click', function () {
+    requestExport('reveal');
+  });
+  el.saveWorld.addEventListener('click', function () {
+    requestExport('world');
+  });
+  el.loadButton.addEventListener('click', function () {
+    el.loadFile.click();
+  });
+  el.loadFile.addEventListener('change', function () {
+    const file = el.loadFile.files && el.loadFile.files[0];
+    if (file) readSelectedFile(file);
+    el.loadFile.value = '';
+  });
+
+  el.seed.value = randomIslandSeed();
+  generateIsland();
+})();

--- a/styles/random-island-preview.css
+++ b/styles/random-island-preview.css
@@ -1,0 +1,222 @@
+:root {
+  color-scheme: light;
+  --rip-ink: #172133;
+  --rip-muted: #5a687a;
+  --rip-line: rgba(44, 58, 80, 0.16);
+  --rip-panel: rgba(255, 255, 255, 0.88);
+  --rip-blue: #276ad8;
+  --rip-shadow: 0 18px 60px -34px rgba(20, 32, 52, 0.72);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  color: var(--rip-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(180deg, rgba(237, 244, 246, 0.92), rgba(226, 235, 230, 0.96)),
+    #edf2f0;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+select,
+input {
+  border-radius: 8px;
+}
+
+button {
+  min-height: 38px;
+  border: 1px solid var(--rip-line);
+  color: #223047;
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.82) inset;
+  padding: 0 13px;
+  font-weight: 760;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #fff;
+}
+
+button:disabled {
+  cursor: default;
+  opacity: 0.48;
+}
+
+.rip-primary {
+  border-color: rgba(39, 106, 216, 0.32);
+  color: #fff;
+  background: var(--rip-blue);
+  box-shadow: 0 12px 26px -18px rgba(39, 106, 216, 0.85);
+}
+
+.rip-primary:hover {
+  background: #1f5fc5;
+}
+
+.rip-shell {
+  width: 100%;
+  height: 100%;
+  padding: 12px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 10px;
+}
+
+.rip-toolbar,
+.rip-frame-wrap {
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 8px;
+  background: var(--rip-panel);
+  box-shadow: var(--rip-shadow);
+  backdrop-filter: blur(18px) saturate(160%);
+  -webkit-backdrop-filter: blur(18px) saturate(160%);
+}
+
+.rip-toolbar {
+  position: relative;
+  z-index: 2;
+  padding: 10px 12px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) minmax(180px, auto);
+  align-items: end;
+  gap: 14px;
+}
+
+.rip-brand h1 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 27px;
+  line-height: 1;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.rip-kicker,
+.rip-controls label span {
+  display: block;
+  color: var(--rip-muted);
+  font-size: 10px;
+  font-weight: 820;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.rip-controls {
+  display: grid;
+  grid-template-columns: minmax(118px, 150px) minmax(92px, 110px) minmax(180px, 1fr) repeat(4, auto);
+  gap: 8px;
+  align-items: end;
+}
+
+.rip-controls label {
+  display: grid;
+  gap: 5px;
+}
+
+.rip-controls select,
+.rip-controls input {
+  width: 100%;
+  height: 38px;
+  border: 1px solid var(--rip-line);
+  background: rgba(255, 255, 255, 0.84);
+  color: #223047;
+  padding: 0 10px;
+}
+
+.rip-status {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  color: var(--rip-muted);
+  font-size: 12px;
+  line-height: 1.35;
+  text-align: right;
+}
+
+.rip-frame-wrap {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: #dfe8e7;
+}
+
+.rip-frame-wrap iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #dfe8e7;
+}
+
+@media (max-width: 1180px) {
+  html,
+  body {
+    overflow: auto;
+  }
+
+  .rip-shell {
+    min-height: 100%;
+    height: auto;
+  }
+
+  .rip-toolbar {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .rip-controls {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
+
+  .rip-seed-field {
+    grid-column: 1 / -1;
+  }
+
+  .rip-status {
+    justify-content: flex-start;
+    text-align: left;
+  }
+
+  .rip-frame-wrap {
+    height: min(760px, calc(100vh - 276px));
+    min-height: 520px;
+  }
+}
+
+@media (max-width: 620px) {
+  .rip-shell {
+    padding: 8px;
+  }
+
+  .rip-brand h1 {
+    font-size: 28px;
+  }
+
+  .rip-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .rip-frame-wrap {
+    height: min(760px, calc(100vh - 432px));
+    min-height: 460px;
+  }
+}

--- a/styles/tiny-world.css
+++ b/styles/tiny-world.css
@@ -252,10 +252,59 @@
     margin-left: 1px;
     color: #8d887d;
   }
-  .invite-top-btn {
+  .sun-strength-control {
     position: fixed;
     top: 14px;
     left: calc(50% + 118px);
+    z-index: 17;
+    height: 42px;
+    width: 178px;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 12px;
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    border-radius: 22px;
+    background: rgba(255, 255, 255, 0.62);
+    color: var(--ink);
+    font: 750 11px/1 "Space Grotesk", system-ui, sans-serif;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.85) inset,
+      0 1px 2px rgba(20, 30, 50, 0.05),
+      0 10px 30px -14px rgba(40, 50, 80, 0.28);
+    backdrop-filter: blur(22px) saturate(180%);
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+  }
+  .sun-strength-control span {
+    flex: 0 0 auto;
+  }
+  .sun-strength-control input[type="range"] {
+    flex: 1 1 auto;
+    min-width: 0;
+    accent-color: #f1b84b;
+  }
+  .sun-strength-control output {
+    flex: 0 0 34px;
+    text-align: right;
+    font-size: 10px;
+    color: var(--muted);
+  }
+  body.ui-theme-dark .sun-strength-control {
+    background: rgba(24, 30, 44, 0.74);
+    border-color: rgba(220, 236, 255, 0.22);
+    color: #f4f7ff;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.14) inset,
+      0 10px 30px -14px rgba(0, 0, 0, 0.72);
+  }
+  body.ui-theme-dark .sun-strength-control output {
+    color: rgba(244, 247, 255, 0.72);
+  }
+  .invite-top-btn {
+    position: fixed;
+    top: 14px;
+    left: calc(50% + 306px);
     z-index: 17;
     height: 42px;
     display: inline-flex;
@@ -4552,8 +4601,9 @@
   body.welcome-launch-open .brand,
   body.welcome-launch-open .brand-banner,
   body.welcome-launch-open .world-pill,
-  body.welcome-launch-open #invite-top-btn,
-  body.welcome-launch-open .token-corner,
+    body.welcome-launch-open #invite-top-btn,
+    body.welcome-launch-open .sun-strength-control,
+    body.welcome-launch-open .token-corner,
   body.welcome-launch-open .appbar,
   body.welcome-launch-open .controls,
   body.welcome-launch-open .toolbar,
@@ -4770,6 +4820,7 @@
     white-space: nowrap;
   }
   .modal-foot #gen-status.error { color: #b84838; }
+  .modal-foot #gen-status.done { color: #2d7d4d; }
   .modal-foot #gen-status.busy::after {
     content: '…';
     animation: dots 1s steps(4, end) infinite;
@@ -4960,6 +5011,35 @@
     transition: opacity 0.5s ease;
   }
   body.showcase .controls #showcase-mode { opacity: 1; pointer-events: auto; }
+  body.random-island-preview-mode .brand,
+  body.random-island-preview-mode .controls,
+  body.random-island-preview-mode .world-pill,
+  body.random-island-preview-mode #invite-top-btn,
+  body.random-island-preview-mode .token-corner,
+  body.random-island-preview-mode .appbar,
+  body.random-island-preview-mode .tool-palette,
+  body.random-island-preview-mode .flyout,
+  body.random-island-preview-mode .toolbar,
+  body.random-island-preview-mode .audio-panel,
+  body.random-island-preview-mode .help,
+  body.random-island-preview-mode .unsaved-banner,
+  body.random-island-preview-mode .minimap-wrap,
+  body.random-island-preview-mode #layers-toggle,
+  body.random-island-preview-mode #layers-panel,
+  body.random-island-preview-mode #agent-input,
+  body.random-island-preview-mode #agent-panel,
+  body.random-island-preview-mode #agent-panel-handle,
+  body.random-island-preview-mode #crowd-panel,
+  body.random-island-preview-mode #crowd-panel-handle,
+  body.random-island-preview-mode #stamp-builder-panel,
+  body.random-island-preview-mode .showcase-exit {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+  }
+  body.random-island-preview-mode #welcome-modal {
+    display: none !important;
+  }
   body.new-world-reveal-open .controls,
   body.new-world-reveal-open .toolbar,
   body.new-world-reveal-open .appbar,
@@ -7042,6 +7122,38 @@
     justify-content: flex-end;
     gap: 10px;
     margin-top: 6px;
+  }
+  .gen-progress {
+    display: grid;
+    grid-template-columns: minmax(120px, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    margin-top: 8px;
+  }
+  .gen-progress[hidden] {
+    display: none;
+  }
+  .gen-progress-track {
+    height: 9px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(41, 54, 72, 0.14);
+    box-shadow: inset 0 0 0 1px rgba(41, 54, 72, 0.12);
+  }
+  .gen-progress-fill {
+    width: 0%;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #3a72c8, #47a56f);
+    transition: width 160ms ease;
+  }
+  .gen-progress-label {
+    min-width: 132px;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 700;
+    text-align: right;
+    white-space: nowrap;
   }
   .btn.confirm-destructive {
     background: #b84838;
@@ -9882,6 +9994,14 @@
     .invite-top-btn svg {
       width: 14px;
       height: 14px;
+    }
+    .sun-strength-control {
+      left: auto;
+      right: 8px;
+      top: 104px;
+      width: 178px;
+      height: 36px;
+      padding: 0 10px;
     }
     body.tw-worlds-play .brand,
     body.tw-worlds-play .brand-banner,

--- a/tests/random-island-generator.test.mjs
+++ b/tests/random-island-generator.test.mjs
@@ -79,6 +79,39 @@ test('random island generator is deterministic and emits complete v4 cells', () 
   }
 });
 
+test('random island generator emits flat terrain and suppresses no-effect props', () => {
+  for (const archetype of Object.keys(ARCHETYPE_MIXES)) {
+    const island = makeIsland({
+      seed: 'wave2-cleanup-' + archetype,
+      archetype,
+      biomes: ARCHETYPE_MIXES[archetype].biomes,
+      elevation: ARCHETYPE_MIXES[archetype].elevation,
+    });
+    assert.ok(island.cells.every(cell => cell.terrainFloors === 1), archetype + ' should emit flat terrain');
+    assert.equal(island.cells.some(cell => cell.kind === 'spotlight'), false, archetype + ' should suppress spotlight props');
+  }
+});
+
+test('random island generator limits lamp posts to two non-adjacent cells', () => {
+  for (const archetype of Object.keys(ARCHETYPE_MIXES)) {
+    const island = makeIsland({
+      seed: 'wave2-lamps-' + archetype,
+      archetype,
+      biomes: ARCHETYPE_MIXES[archetype].biomes,
+      elevation: ARCHETYPE_MIXES[archetype].elevation,
+    });
+    const lamps = island.cells.filter(cell => cell.kind === 'lamp-post');
+    assert.ok(lamps.length <= 2, archetype + ' should emit at most two lamp posts');
+    for (const lamp of lamps) {
+      assert.equal(
+        adjacentCells(island.cells, lamp).some(neighbor => neighbor.kind === 'lamp-post'),
+        false,
+        archetype + ' lamp posts should not be adjacent'
+      );
+    }
+  }
+});
+
 test('explicit archetypes map lab props to native TinyWorld assets', () => {
   const island = makeIsland({
     seed: 'test-village',
@@ -158,7 +191,7 @@ const ARCHETYPE_MIXES = {
   fortress: {
     biomes: { grass: 20, forest: 8, water: 8, dirt: 20, settlement: 44 },
     elevation: { plains: 22, hills: 38, mountains: 40 },
-    signature: ['house', 'rock', 'spotlight'],
+    signature: ['house', 'rock', 'crystal'],
   },
   ruins: {
     biomes: { grass: 26, forest: 20, water: 10, dirt: 24, settlement: 20 },
@@ -188,6 +221,45 @@ function cellsWithin(cells, cell, distance) {
 
 function nearCell(cells, cell, predicate, distance = 1) {
   return cellsWithin(cells, cell, distance).some(predicate);
+}
+
+function chebyshevDistance(cell, other) {
+  return Math.max(Math.abs(cell.x - other.x), Math.abs(cell.z - other.z));
+}
+
+function connectedCellGroups(cells, groupCells) {
+  const groupKeys = new Set(groupCells.map(cell => cell.x + ',' + cell.z));
+  const byCoord = cellByCoord(cells);
+  const seen = new Set();
+  const groups = [];
+  for (const start of groupCells) {
+    const startKey = start.x + ',' + start.z;
+    if (seen.has(startKey)) continue;
+    const stack = [start];
+    const group = [];
+    while (stack.length) {
+      const cell = stack.pop();
+      const key = cell.x + ',' + cell.z;
+      if (seen.has(key) || !groupKeys.has(key)) continue;
+      seen.add(key);
+      group.push(cell);
+      for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
+        const neighbor = byCoord.get((cell.x + dx) + ',' + (cell.z + dz));
+        if (neighbor) stack.push(neighbor);
+      }
+    }
+    groups.push(group);
+  }
+  return groups;
+}
+
+function boundingBoxForCells(cells) {
+  const xs = cells.map(cell => cell.x);
+  const zs = cells.map(cell => cell.z);
+  return {
+    width: Math.max(...xs) - Math.min(...xs) + 1,
+    height: Math.max(...zs) - Math.min(...zs) + 1,
+  };
 }
 
 function fenceSideFacesNeighbor(fence, neighbor) {
@@ -336,7 +408,7 @@ function resourceCells(island, resourceId) {
     if (resourceId === 'food') return isFoodCell(cell);
     if (resourceId === 'materials') return cell.kind === 'tree' || cell.kind === 'rock' || cell.kind === 'crystal';
     if (resourceId === 'commerce') return cell.kind === 'lamp-post' || cell.kind === 'bridge' || (cell.kind === 'house' && cell.buildingType !== 'tower');
-    if (resourceId === 'defense') return cell.kind === 'fence' || cell.kind === 'spotlight' || isTowerCell(cell);
+    if (resourceId === 'defense') return cell.kind === 'fence' || cell.kind === 'totem' || isTowerCell(cell);
     if (resourceId === 'charm') return ['flower', 'bush', 'tree', 'crystal', 'totem', 'ruins'].includes(cell.kind);
     return false;
   });
@@ -407,6 +479,10 @@ test('explicit archetypes produce grouped signature features', () => {
     const grouped = featureCells.filter(cell => adjacentCells(island.cells, cell).some(neighbor => (
       signature.has(neighbor.kind)
       || ((archetype === 'river' || archetype === 'harbor') && neighbor.terrain === 'water')
+    )) || island.cells.some(neighbor => (
+      neighbor !== cell
+      && chebyshevDistance(cell, neighbor) <= 1
+      && signature.has(neighbor.kind)
     )));
 
     assert.ok(featureCells.length >= 5, archetype + ' should emit enough signature features');
@@ -556,6 +632,40 @@ test('resource motif pass composes fenced crop plots and animal pens', () => {
   }
 });
 
+test('generated food plots prefer compact square-ish areas buffered from main houses', () => {
+  for (const [archetype, config] of Object.entries(ARCHETYPE_MIXES)) {
+    for (let i = 0; i < 4; i++) {
+      const island = makeIsland({
+        seed: 'food-plot-clarity-' + archetype + '-' + i,
+        archetype,
+        biomes: config.biomes,
+        elevation: config.elevation,
+      });
+      const cropCells = island.cells.filter(cell => CROP_KINDS.has(cell.kind));
+      const mainHomes = island.cells.filter(cell => cell.kind === 'house' && cell.buildingType !== 'tower');
+
+      for (const crop of cropCells) {
+        assert.equal(
+          mainHomes.some(home => chebyshevDistance(crop, home) <= 1),
+          false,
+          archetype + ' crop at ' + crop.x + ',' + crop.z + ' should keep one block between it and the main house'
+        );
+      }
+
+      if (cropCells.length < 4) continue;
+      const largestPlot = connectedCellGroups(island.cells, cropCells)
+        .sort((a, b) => b.length - a.length)[0];
+      const bounds = boundingBoxForCells(largestPlot);
+      const minimumGroupedFood = archetype === 'harbor' ? 2 : 3;
+      assert.ok(largestPlot.length >= Math.min(minimumGroupedFood, cropCells.length), archetype + ' should keep a clear grouped food plot');
+      if (largestPlot.length >= 4) {
+        assert.ok(Math.abs(bounds.width - bounds.height) <= 3, archetype + ' food plot should be square-ish');
+        assert.ok(bounds.width * bounds.height <= largestPlot.length + 6, archetype + ' food plot should avoid scattered thin lines');
+      }
+    }
+  }
+});
+
 test('economy viability pass gives every archetype a resource floor', () => {
   const minimumCells = {
     food: 2,
@@ -599,7 +709,7 @@ test('low-food quarry islands still place capped food near habitation', () => {
       island.cells,
       cell,
       neighbor => neighbor.kind === 'house' && neighbor.buildingType !== 'tower',
-      3
+      4
     ));
 
     assert.ok(foodCells.length >= 2, 'quarry should still have a food floor');

--- a/tests/terrain-tile-bounds.test.mjs
+++ b/tests/terrain-tile-bounds.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function sliceBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, 'missing start marker: ' + start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, 'missing end marker: ' + end);
+  return source.slice(startIndex, endIndex);
+}
+
+const tileFactoryPath = path.resolve('engine/world/05-tile-factory.js');
+const historyFactoryPath = path.resolve('engine/world/06-history-object-factories.js');
+const ghostPath = path.resolve('engine/world/15-ghost-generation-fade.js');
+
+test('terrain tile geometry stays inside one logical cell in x/z', () => {
+  const tileFactory = readFileSync(tileFactoryPath, 'utf8');
+  const historyFactory = readFileSync(historyFactoryPath, 'utf8');
+  const ghost = readFileSync(ghostPath, 'utf8');
+
+  const voxelTop = sliceBetween(tileFactory, 'function addVoxelTerrainTop', 'function addVoxelTerrainSurfaceDetails');
+  assert.match(voxelTop, /const panelSize = cellSize;/);
+  assert.doesNotMatch(voxelTop, /panelOverlap|cellSize \+/);
+
+  const voxelRiser = sliceBetween(tileFactory, 'function addVoxelTerrainRiser', 'function addVoxelTerrainRiserBacking');
+  assert.match(voxelRiser, /const panelW = cellSize;/);
+  assert.match(voxelRiser, /const panelH = riserHeight \/ verticalCells;/);
+  assert.match(voxelRiser, /-half \+ sideDepth \* 0\.5/);
+  assert.match(voxelRiser, /half - sideDepth \* 0\.5/);
+  assert.doesNotMatch(voxelRiser, /panelW = cellSize \+|panelH = riserHeight \/ verticalCells \+/);
+
+  const edgeWeeds = sliceBetween(tileFactory, 'function addSurfaceEdgeWeeds', 'function getWaterfallFoamGeometry');
+  assert.match(edgeWeeds, /Math\.max\(w \* 0\.5,/);
+  assert.doesNotMatch(edgeWeeds, /const inset = 0\.018 \+|const inset = 0\.035 \+/);
+
+  const makeTile = sliceBetween(historyFactory, 'function makeTile', '// -------- tile surface height --------');
+  assert.match(makeTile, /let riserSize = TILE;/);
+  assert.match(makeTile, /let topSize\s+= TILE;/);
+  assert.match(makeTile, /riserSize\s+= TILE;/);
+  assert.match(makeTile, /topSize\s+= TILE;/);
+  assert.match(makeTile, /const seamOverlap = 0;/);
+  assert.doesNotMatch(makeTile, /TILE \* 1\.04|TILE \* 0\.98|seamOverlap = 0\.006/);
+
+  const cheapGhost = sliceBetween(ghost, 'function ensureCheapGhostGeoms', 'function getCheapGhostTerrainBucket');
+  assert.match(cheapGhost, /const size = TILE;/);
+  assert.doesNotMatch(cheapGhost, /TILE \* 1\.04/);
+
+  const ghostTile = sliceBetween(ghost, 'function makeGhostTile', 'function buildGhostBoard');
+  assert.match(ghostTile, /getBoxGeometry\(TILE, height, TILE\)/);
+  assert.doesNotMatch(ghostTile, /TILE \* 1\.04/);
+});

--- a/tiny-world-builder.html
+++ b/tiny-world-builder.html
@@ -115,6 +115,12 @@
     </button>
   </div>
 
+  <label class="sun-strength-control" aria-label="Directional sun strength">
+    <span>Sun</span>
+    <input id="directional-light-strength" type="range" min="0" max="1000" step="5" value="100" />
+    <output id="directional-light-strength-readout">100%</output>
+  </label>
+
   <button type="button" class="invite-top-btn" id="invite-top-btn" data-pos-type="primary" data-tooltip="Invite collaborators" aria-label="Invite collaborators">
     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M19 8v6"/><path d="M22 11h-6"/></svg>
     <span>Invite</span>
@@ -1052,6 +1058,12 @@
       </div>
 
       <div class="help-line">Generate now previews a holographic diff first. Apply the preview only when it looks right.</div>
+      <div class="gen-progress" id="gen-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" hidden>
+        <div class="gen-progress-track">
+          <div class="gen-progress-fill" id="gen-progress-fill"></div>
+        </div>
+        <span class="gen-progress-label" id="gen-progress-label">Preparing generation</span>
+      </div>
       <div class="modal-foot gen-actions">
         <span id="gen-status"></span>
         <button class="btn gen-preview-action" id="gen-discard" type="button" hidden>Discard</button>

--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -36,7 +36,7 @@ const WATCH_PATHS = [
 const WATCH_ROOT_FILES = [
   'index.html', 'tiny-world-builder.html', 'roadmap.html',
   'features.html', 'community.html', 'terms.html', 'privacy.html', 'code-of-conduct.html',
-  'worlds.html', 'docs.html', 'harvest.html',
+  'worlds.html', 'docs.html', 'harvest.html', 'random-island-preview.html',
 ];
 
 function watchDir(dir) {


### PR DESCRIPTION
## Summary
- add a Jason-only random island preview route backed by Netlify auth-aware function handling
- sync local random island generation behavior: flat terrain, minimum water tiles, lamp cap/non-adjacency, clearer buffered food plots, no-effect prop suppression, merged terrain/progress updates
- expose the visible directional sun strength control up to 1000% and preserve the brighter day/night sun behavior
- tighten fence/gate visuals, share corner posts, swing gates outward, and keep waterfall-side water out of reflective/refractive captures
- update Wave 2/docs/skills and add coverage for generator/terrain tile bounds

## Testing
- Not run in this pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new random island preview page with export, load, and save options.
  * Introduced a directional sun strength control for adjusting scene lighting.
  * Added generation progress feedback during world creation.

* **Improvements**
  * Random island generation now produces flatter, more consistent islands with cleaner terrain and water behavior.
  * Improved water visuals with richer reflections, refraction, and foam effects.
  * Updated fences, terrain edges, and ghost overlays for better alignment and rendering.

* **Bug Fixes**
  * Reduced generation issues around crowded housing, food plots, and lamp placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->