### PR TITLE
Add standalone Island Viewer

### DIFF
--- a/.codex/skills/tinyworld-integrations/SKILL.md
+++ b/.codex/skills/tinyworld-integrations/SKILL.md
@@ -64,6 +64,12 @@ backend:
   `vendor/tinyworld-auth.js` with an import map to vendored
   `@netlify/identity` / `gotrue-js`; do not reintroduce a remote identity
   widget script.
+- The builder should not show working-looking account UI on hosts that cannot
+  serve Netlify Identity. Treat 404/405 `/.netlify/identity/*` failures from
+  the browser `getSettings()` probe or login calls as "auth unavailable": hide
+  sign-in/account commands, keep local/static building usable, and leave cloud
+  save/share/collab actions gated off. For local account work, use Netlify dev
+  at `http://localhost:8888/tiny-world-builder`.
 - Profile image fields stored through `/api/profile`, `/api/admin-users`, or
   community preset-avatar saves must be absolute `http(s)` URLs. Preset avatar
   paths under `assets/avatars/*.png` are normalized with the trusted site origin

--- a/.codex/skills/tinyworld-island-viewer/SKILL.md
+++ b/.codex/skills/tinyworld-island-viewer/SKILL.md
@@ -61,11 +61,16 @@ Rules:
 - Generated Island Viewer islands are fixed at `8 x 8`.
 - Persist viewer defaults only under `tinyworld:island-viewer:*`. Do not write
   viewer graphics into normal builder `tinyworld:render:*` keys.
+- Use `npm run stats:island-viewer -- --count 1000` for on-demand sequential
+  generator sweeps. The CLI loads the viewer generator directly, validates
+  schema/invariants, and writes reports under
+  `stats-runs/island-viewer-sequential/`.
 
 Validation:
 
 - `npm test`
 - `npm run build`
+- `npm run stats:island-viewer -- --count 1000`
 - Check `/island-viewer` or `/island-viewer.html`: page loads through the
   builder-engine renderer, generated saves contain no legacy bridge metadata,
   and the shell does not request `scripts/tinyworld-island-core.js` or

--- a/.codex/skills/tinyworld-island-viewer/SKILL.md
+++ b/.codex/skills/tinyworld-island-viewer/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: tinyworld-island-viewer
+description: Use when changing the first-class Island Viewer shell, sequential generated-island viewer routing, or viewer-scoped graphics defaults.
+---
+
+# TinyWorld Island Viewer
+
+Island Viewer is the first-class generated-island viewing surface:
+
+- Shell: `island-viewer.html`
+- Styles: `styles/island-viewer.css`
+- Generator: `scripts/island-viewer-sequential-generator.js`
+- Renderer adapter: `scripts/island-viewer-engine-runtime.js`
+- Controller: `scripts/island-viewer.js`
+- Compatibility redirect: `random-island-preview.html`
+
+Rules:
+
+- Keep the active generator viewer-only and sequential. `island-viewer.html`
+  should load `scripts/island-viewer-sequential-generator.js`, not the giant
+  `scripts/tinyworld-island-core.js` copied random-island bundle.
+- Keep the builder-engine renderer stack active for now. Do not load
+  `scripts/island-viewer-renderer.js` on `island-viewer.html` while
+  `scripts/island-viewer-engine-runtime.js` provides the current look.
+- The sequential layer stack is: all grass, first house, corner towers, paths,
+  extra houses, fenced crops, fenced animals, rock patch, then water route.
+- The viewer sequential generator must emit schema-valid `v:4` world cells,
+  use normal `terrain: "path"` cells for public path output, and expose
+  `TinyWorldIslandGenerator.generate(...)` and `.profile(...)`.
+- Do not emit `water-bridge` or `bridgeAxis` metadata from the active viewer
+  generator. Bridges are allowed only through the new local detector: after
+  water carving, scan local crossings with path cells on one axis and water
+  cells on the perpendicular axis, then turn only the center water cell into a
+  normal `kind: "bridge"`.
+- Strategic lanterns are native `kind: "lamp-post"` cells placed after bridge
+  detection. Keep them on empty grass cells that touch exactly two perpendicular
+  path cells, and keep every pair more than 3 Manhattan spaces apart.
+- A manor is a rare native `house` with `buildingType: "manor"`, not a promoted
+  cottage. Only roll the 25% manor chance after at least three normal houses
+  exist, reserve its footprint during generation, and connect a path from the
+  cell in front of its door back into the existing path network before plots,
+  rocks, water, or lanterns run.
+- Trees and bushes are native `kind: "tree"` / `kind: "bush"` decoration placed
+  after the functional path/water/bridge/lamp layers. Only use empty grass cells,
+  keep trees spaced out, and let bushes fill smaller remaining border/garden
+  opportunities without occupying paths.
+- The initial fenced crop plot should keep its four dirt plot cells and fence
+  gates, but each cell rolls independently: 25% empty, otherwise evenly between
+  wheat, corn, carrot, pumpkin, and sunflower.
+- After the sparse tree/bush pass, run a final weighted infill loop over normal
+  empty buildable cells until none remain. The infill choices should stay within
+  native economy objects: crops, ore, sheep/cow, bushes, and trees. Do not fill
+  water, paths, fences, structures, or reserved manor footprint cells.
+- Water route planning must treat path crossings as single-cell crossings per
+  connected path area. Do not let water carve two adjacent path cells or run
+  along the path before turning back into normal terrain.
+- Keep normal viewer chrome minimal. It is not a build screen: visible controls
+  should stay viewer actions such as New Island, Load, and Save.
+- Put archetype/grid/seed and graphics controls in the local/developer defaults
+  helper, not in the primary viewer toolbar.
+- Generated Island Viewer islands are fixed at `8 x 8`.
+- Persist viewer defaults only under `tinyworld:island-viewer:*`. Do not write
+  viewer graphics into normal builder `tinyworld:render:*` keys.
+
+Validation:
+
+- `npm test`
+- `npm run build`
+- Check `/island-viewer` or `/island-viewer.html`: page loads through the
+  builder-engine renderer, generated saves contain no legacy bridge metadata,
+  and the shell does not request `scripts/tinyworld-island-core.js` or
+  `scripts/island-viewer-renderer.js`.

--- a/docs/island-viewer.md
+++ b/docs/island-viewer.md
@@ -40,3 +40,25 @@ normal builder, worlds, or other scenes.
 
 `random-island-preview.html` remains only as a compatibility redirect to
 `island-viewer.html`.
+
+## Sequential Generator Evaluation
+
+Run statistical sweeps from the repo root:
+
+```bash
+npm run stats:island-viewer -- --count 1000
+```
+
+The evaluator loads `scripts/island-viewer-sequential-generator.js` directly,
+runs 1,000 deterministic seeds across all viewer archetypes, validates the emitted
+`v:4` schema shape and viewer invariants, then writes a timestamped report plus
+`stats-runs/island-viewer-sequential/latest.json`.
+
+Useful options:
+
+- `--count 2500` changes the total number of generated islands.
+- `--archetype river` evaluates all requested samples against one archetype
+  instead of distributing them across all eight.
+- `--seed-prefix my-run` changes the deterministic seed family.
+- `--out-dir scratch/my-stats` writes reports somewhere else.
+- `--strict` exits non-zero if any schema/invariant error is found.

--- a/docs/island-viewer.md
+++ b/docs/island-viewer.md
@@ -1,0 +1,42 @@
+# Island Viewer
+
+`island-viewer.html` is the first-class shell for viewing generated TinyWorld
+islands. It owns its own Three.js canvas and loads
+`scripts/island-viewer-sequential-generator.js`, the builder-engine renderer
+stack, `scripts/island-viewer-engine-runtime.js`, and `scripts/island-viewer.js`;
+it must not iframe, boot, or depend on `tiny-world-builder.html`.
+
+The normal viewer toolbar is intentionally small: New Island, Load, Save, and a
+local-dev Defaults helper. Archetype, grid, seed, and graphics-template controls
+live in the Defaults helper because the viewer is not a build screen.
+
+Viewer defaults are stored separately from builder settings:
+
+- `tinyworld:island-viewer:defaults.v1` for archetype/grid/seed defaults.
+- `tinyworld:island-viewer:graphics.v1` for renderer defaults.
+- `tinyworld:island-viewer:*` only. The viewer must not write normal builder
+  keys such as `tinyworld:render:*`, `tinyworld:crowd:*`, or
+  `tinyworld:view.camera`.
+
+The standalone generation runtime exposes `TinyWorldIslandGenerator.generate(...)`
+and `.profile(...)`. Generated viewer islands are fixed at 8 x 8 and come from
+the sequential viewer-only layer stack, not the giant random-island generator
+bundle. The public `v:4` output uses normal schema cells, including
+`terrain: "path"` for paths.
+
+Generation is intentionally layered: grass base, first house, towers, paths,
+extra houses, optional manor, fenced crop plot, fenced animal plot, rock patch,
+water route, bridge detection, lanterns, trees/bushes, then weighted infill.
+The water route can cross a connected path area through only one path cell, so
+it does not carve adjacent path cells in the same crossing.
+
+The active viewer generator may emit normal `kind: "bridge"` cells only from
+local crossing detection: path cells on one axis and water cells on the
+perpendicular axis. It must not emit `water-bridge` or `bridgeAxis` metadata.
+Generated viewer terrain should not emit sand; loaded legacy sand is normalized
+to grass by the viewer runtime. Do not persist viewer defaults into
+`tinyworld:render:*`, because that would let the viewer interfere with the
+normal builder, worlds, or other scenes.
+
+`random-island-preview.html` remains only as a compatibility redirect to
+`island-viewer.html`.

--- a/engine/world/30-ui-boot-wiring.js
+++ b/engine/world/30-ui-boot-wiring.js
@@ -1597,6 +1597,7 @@ syncTinyworldOwnerToolControls();
       return;
     }
     window.__tinyworldAuthEnabled = !!Auth;
+    window.__tinyworldAuthUnavailable = false;
     if (!Auth) {
       // No auth library — single-user local mode. Hide all auth UI
       // and treat the user as logged in so settings/AI aren't
@@ -1629,6 +1630,20 @@ syncTinyworldOwnerToolControls();
     const logoutBtn = document.getElementById('auth-logout-btn');
     const accountBtn = document.getElementById('account-btn');
     const walletLoginBtn = document.getElementById('auth-wallet-login');
+    let identityUnavailable = false;
+
+    function authUnavailableMessage() {
+      return localDev
+        ? 'Email sign-in needs Netlify dev. Run npx netlify dev and open http://localhost:8888/tiny-world-builder.'
+        : 'Sign-in is not available on this host. Open the Netlify deployment with Identity enabled.';
+    }
+
+    function authErrorLooksUnavailable(err) {
+      const status = Number(err && err.status);
+      const message = String((err && err.message) || '');
+      return status === 404 || status === 405 ||
+        /Method Not Allowed|Not Found|Netlify Identity is not available|Could not determine the Identity endpoint URL/i.test(message);
+    }
 
     function showError(msg) {
       errorEl.textContent = msg;
@@ -1645,6 +1660,34 @@ syncTinyworldOwnerToolControls();
     function clearMessages() {
       errorEl.hidden = true;
       successEl.hidden = true;
+    }
+
+    function disableUnavailableAuthUi(keepModalOpen) {
+      identityUnavailable = true;
+      window.__tinyworldAuthUnavailable = true;
+      window.__tinyworldAuthEnabled = false;
+      setLoggedInState(true);
+      if (!keepModalOpen) closeTinyModal(modal);
+      bootApp();
+      const menu = document.getElementById('world-menu');
+      if (menu) {
+        ['manage', 'share', 'collaborate'].forEach(action => {
+          const btn = menu.querySelector('[data-action="' + action + '"]');
+          if (btn) btn.hidden = true;
+        });
+      }
+      if (typeof window.syncToolbarAccountButton === 'function') window.syncToolbarAccountButton();
+    }
+
+    function showAuthFailure(err, authMessage) {
+      if (identityUnavailable || err instanceof Auth.MissingIdentityError || authErrorLooksUnavailable(err)) {
+        disableUnavailableAuthUi(true);
+        showError(authUnavailableMessage());
+      } else if (err instanceof Auth.AuthError) {
+        showError(authMessage || err.message);
+      } else {
+        showError('Something went wrong. Please try again.');
+      }
     }
 
     function showForm(name) {
@@ -1774,17 +1817,20 @@ syncTinyworldOwnerToolControls();
       });
       document.getElementById('auth-oauth-login').hidden = enabled.length === 0;
       document.getElementById('auth-oauth-signup').hidden = enabled.length === 0;
-    }).catch(() => {});
+    }).catch(err => {
+      if (authErrorLooksUnavailable(err)) disableUnavailableAuthUi(false);
+    });
 
     // Tracks the live login state so gated controls can react to it.
     // Anonymous users get the app, settings/AI/cloud are locked.
     window.__loggedIn = false;
     function setLoggedInState(isLoggedIn) {
       window.__loggedIn = !!isLoggedIn;
-      if (logoutBtn) logoutBtn.hidden = !isLoggedIn;
-      if (accountBtn) accountBtn.hidden = !isLoggedIn;
+      const authAvailable = !!window.__tinyworldAuthEnabled;
+      if (logoutBtn) logoutBtn.hidden = !isLoggedIn || !authAvailable;
+      if (accountBtn) accountBtn.hidden = !isLoggedIn || !authAvailable;
       const loginBtnTop = document.getElementById('auth-login-btn-top');
-      if (loginBtnTop) loginBtnTop.hidden = !!isLoggedIn;
+      if (loginBtnTop) loginBtnTop.hidden = !!isLoggedIn || !authAvailable;
       // Lock badges + tooltips for the gated buttons.
       const settingsBtn = document.getElementById('render-settings');
       const generateBtn = document.getElementById('generate');
@@ -1830,6 +1876,12 @@ syncTinyworldOwnerToolControls();
     }
 
     function openLoginModal(reason) {
+      if (identityUnavailable) {
+        showForm('login');
+        showError(authUnavailableMessage());
+        openTinyModal(modal, errorEl);
+        return;
+      }
       clearMessages();
       const subtitle = modal.querySelector('.auth-subtitle');
       if (subtitle && reason) subtitle.textContent = reason;
@@ -1874,13 +1926,7 @@ syncTinyworldOwnerToolControls();
         await Auth.login(email, password);
         enterApp();
       } catch (err) {
-        if (err instanceof Auth.AuthError) {
-          showError(err.status === 401 ? 'Invalid email or password.' : err.message);
-        } else if (err instanceof Auth.MissingIdentityError) {
-          showError('Identity is not enabled on this site.');
-        } else {
-          showError('Something went wrong. Please try again.');
-        }
+        showAuthFailure(err, err && err.status === 401 ? 'Invalid email or password.' : '');
       } finally {
         setLoading(btn, false);
       }
@@ -1911,13 +1957,7 @@ syncTinyworldOwnerToolControls();
           }
         }
       } catch (err) {
-        if (err instanceof Auth.AuthError) {
-          showError(err.status === 403 ? 'Signups are not allowed.' : err.message);
-        } else if (err instanceof Auth.MissingIdentityError) {
-          showError('Identity is not enabled on this site.');
-        } else {
-          showError('Something went wrong. Please try again.');
-        }
+        showAuthFailure(err, err && err.status === 403 ? 'Signups are not allowed.' : '');
       } finally {
         setLoading(btn, false);
       }
@@ -1933,11 +1973,7 @@ syncTinyworldOwnerToolControls();
         await Auth.requestPasswordRecovery(email);
         showSuccess('Check your email for a password reset link.');
       } catch (err) {
-        if (err instanceof Auth.AuthError) {
-          showError(err.message);
-        } else {
-          showError('Something went wrong. Please try again.');
-        }
+        showAuthFailure(err, '');
       } finally {
         setLoading(btn, false);
       }
@@ -1954,11 +1990,7 @@ syncTinyworldOwnerToolControls();
         showSuccess('Password updated. You are now signed in.');
         setTimeout(enterApp, 1200);
       } catch (err) {
-        if (err instanceof Auth.AuthError) {
-          showError(err.message);
-        } else {
-          showError('Something went wrong. Please try again.');
-        }
+        showAuthFailure(err, '');
       } finally {
         setLoading(btn, false);
       }
@@ -2005,7 +2037,7 @@ syncTinyworldOwnerToolControls();
             return true;
         }
       } catch (err) {
-        if (err instanceof Auth.AuthError) showError(err.message);
+        showAuthFailure(err, '');
       }
       return false;
     }
@@ -2013,11 +2045,14 @@ syncTinyworldOwnerToolControls();
     // Check existing session or callback
     (async () => {
       const handled = await processCallback();
+      if (identityUnavailable) return;
       if (handled) return;
       const user = await Auth.getUser();
+      if (identityUnavailable) return;
       if (user) {
         enterApp();
       } else if (await twCloudRestoreWalletSession()) {
+        if (identityUnavailable) return;
         enterApp();
       } else {
         // Anonymous mode by default — boot the app, gate
@@ -3616,9 +3651,9 @@ syncTinyworldOwnerToolControls();
     const manageBtn = menu.querySelector('[data-action="manage"]');
     const shareBtn = menu.querySelector('[data-action="share"]');
     const collaborateBtn = menu.querySelector('[data-action="collaborate"]');
-    if (!window.TinyWorldAuth && manageBtn) manageBtn.hidden = true;
-    if (!window.TinyWorldAuth && shareBtn) shareBtn.hidden = true;
-    if (!window.TinyWorldAuth && collaborateBtn) collaborateBtn.hidden = true;
+    if (!window.__tinyworldAuthEnabled && manageBtn) manageBtn.hidden = true;
+    if (!window.__tinyworldAuthEnabled && shareBtn) shareBtn.hidden = true;
+    if (!window.__tinyworldAuthEnabled && collaborateBtn) collaborateBtn.hidden = true;
     let sharedRoomsLoading = false;
 
     function menuWorlds() {
@@ -4711,9 +4746,13 @@ syncTinyworldOwnerToolControls();
     }
 
     async function createCurrentWorldShare(options = {}) {
-      if (!window.TinyWorldAuth || !window.__loggedIn) {
+      if (!twCloudLoggedIn()) {
         if (!options.keepMenuOpen) close();
-        if (typeof window.__openLoginModal === 'function') window.__openLoginModal('Sign in to save and share worlds');
+        if (window.__tinyworldAuthEnabled && typeof window.__openLoginModal === 'function') {
+          window.__openLoginModal('Sign in to save and share worlds');
+        } else {
+          twToast('Cloud sharing is not available on this host.', 'warn');
+        }
         return null;
       }
       updateActiveSnapshot();
@@ -4762,8 +4801,12 @@ syncTinyworldOwnerToolControls();
     }
 
     function openInviteDialog() {
-      if (!window.TinyWorldAuth || !window.__loggedIn) {
-        if (typeof window.__openLoginModal === 'function') window.__openLoginModal('Sign in to invite collaborators');
+      if (!twCloudLoggedIn()) {
+        if (window.__tinyworldAuthEnabled && typeof window.__openLoginModal === 'function') {
+          window.__openLoginModal('Sign in to invite collaborators');
+        } else {
+          twToast('Collaboration invites are not available on this host.', 'warn');
+        }
         return;
       }
       const back = document.createElement('div');
@@ -5166,7 +5209,7 @@ syncTinyworldOwnerToolControls();
       items.push({ group: 'Settings', label: 'Settings — Environment',  run: settingsTab('environment') });
       items.push({ group: 'Settings', label: 'Settings — Crowd',        run: settingsTab('crowd') });
       items.push({ group: 'Settings', label: 'Settings — AI Config',    run: settingsTab('ai') });
-      if (window.TinyWorldAuth) {
+      if (window.__tinyworldAuthEnabled) {
         items.push({ group: 'Account', label: 'Open account / My Worlds', run: topBtnAction('account-btn') });
         items.push({ group: 'Account', label: 'Sign in', run: () => {
           const top = document.getElementById('auth-login-btn-top');

--- a/island-viewer.html
+++ b/island-viewer.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TinyWorld Island Viewer</title>
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" href="styles/island-viewer.css">
+</head>
+<body>
+  <main class="iv-shell">
+    <section class="iv-topbar" aria-label="Island viewer controls">
+      <div class="iv-brand">
+        <span class="iv-kicker">TinyWorld</span>
+        <h1>Island Viewer</h1>
+      </div>
+      <div class="iv-status" id="iv-status" role="status">Starting TinyWorld island renderer...</div>
+      <div class="iv-actions" aria-label="Viewer actions">
+        <button type="button" class="iv-primary" id="iv-new">New Island</button>
+        <button type="button" id="iv-load-button">Load</button>
+        <button type="button" id="iv-save-reveal">Save</button>
+        <button type="button" id="iv-dev-toggle" hidden>Defaults</button>
+        <input id="iv-load-file" type="file" accept=".json,application/json" hidden>
+      </div>
+    </section>
+
+    <section class="iv-frame-wrap" id="app" aria-label="Rendered TinyWorld island">
+      <noscript>Island Viewer needs JavaScript to render TinyWorld islands.</noscript>
+    </section>
+  </main>
+
+  <aside class="iv-dev-panel" id="iv-dev-panel" hidden aria-label="Island viewer defaults">
+    <form id="iv-dev-form">
+      <div class="iv-dev-head">
+        <div>
+          <span class="iv-kicker">Developer</span>
+          <h2>Viewer Defaults</h2>
+        </div>
+        <button type="button" id="iv-dev-close" aria-label="Close viewer defaults">Close</button>
+      </div>
+
+      <div class="iv-dev-grid">
+        <label>
+          <span>Archetype</span>
+          <select id="iv-archetype">
+            <option value="random">Random</option>
+            <option value="pastoral">Pastoral</option>
+            <option value="forest">Forest</option>
+            <option value="quarry">Quarry</option>
+            <option value="river">River</option>
+            <option value="village">Village</option>
+            <option value="fortress">Fortress</option>
+            <option value="ruins">Ruins</option>
+            <option value="harbor">Harbor</option>
+          </select>
+        </label>
+        <label>
+          <span>Grid</span>
+          <select id="iv-grid-size">
+            <option value="8">8 x 8</option>
+          </select>
+        </label>
+        <label class="iv-wide">
+          <span>Seed</span>
+          <input id="iv-seed" type="text" autocomplete="off">
+        </label>
+
+        <label>
+          <span>Resolution</span>
+          <input id="iv-render-resolution" type="range" min="50" max="125" step="5">
+          <output id="iv-render-resolution-value"></output>
+        </label>
+        <label>
+          <span>Shadow</span>
+          <select id="iv-shadow-quality">
+            <option value="low">Low</option>
+            <option value="balanced">Balanced</option>
+            <option value="high">High</option>
+          </select>
+        </label>
+        <label>
+          <span>Lighting</span>
+          <input id="iv-lighting" type="range" min="50" max="500" step="1">
+          <output id="iv-lighting-value"></output>
+        </label>
+        <label>
+          <span>Sun</span>
+          <input id="iv-sun-strength" type="range" min="0" max="1000" step="5">
+          <output id="iv-sun-strength-value"></output>
+        </label>
+        <label>
+          <span>Sun angle</span>
+          <input id="iv-sun-angle" type="range" min="0" max="359" step="1">
+          <output id="iv-sun-angle-value"></output>
+        </label>
+        <label>
+          <span>Time cycle</span>
+          <select id="iv-time-cycle">
+            <option value="live">Live</option>
+            <option value="fixed">Fixed</option>
+          </select>
+        </label>
+        <label>
+          <span>Time of day</span>
+          <input id="iv-time-of-day" type="range" min="0" max="1439" step="5">
+          <output id="iv-time-of-day-value"></output>
+        </label>
+        <label>
+          <span>Ambient fill</span>
+          <input id="iv-ambient-fill" type="range" min="0" max="500" step="1">
+          <output id="iv-ambient-fill-value"></output>
+        </label>
+        <label>
+          <span>Clouds</span>
+          <input id="iv-clouds" type="range" min="0" max="100" step="1">
+          <output id="iv-clouds-value"></output>
+        </label>
+        <label>
+          <span>Cloud height</span>
+          <input id="iv-cloud-height" type="range" min="9" max="16" step="0.5">
+          <output id="iv-cloud-height-value"></output>
+        </label>
+      </div>
+
+      <div class="iv-dev-checks">
+        <label><input id="iv-enhanced-water" type="checkbox"> Enhanced water</label>
+        <label><input id="iv-cloud-sea" type="checkbox"> Cloud sea</label>
+        <label><input id="iv-distant-worlds" type="checkbox"> Distant worlds</label>
+      </div>
+
+      <div class="iv-dev-actions">
+        <button type="button" id="iv-apply-defaults">Apply</button>
+        <button type="button" class="iv-primary" id="iv-save-defaults">Save Defaults</button>
+        <button type="button" id="iv-reset-defaults">Reset</button>
+      </div>
+    </form>
+  </aside>
+
+  <script id="tinyworld-island-viewer-defaults-bootstrap">
+  /* =====================================================================
+     Island Viewer defaults bootstrap — seeds only viewer-scoped defaults
+     from tinyworld-defaults.json. The embedded builder keeps its own
+     island-viewer render namespace and never receives normal builder keys.
+     ===================================================================== */
+  (function tinyworldIslandViewerDefaultsBootstrap() {
+    try {
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', 'tinyworld-defaults.json', false);
+      xhr.send(null);
+      if (xhr.status < 200 || xhr.status >= 300) return;
+      var data = JSON.parse(xhr.responseText || '{}');
+      if (!data || !data.settings || typeof data.settings !== 'object') return;
+      Object.keys(data.settings).forEach(function (key) {
+        if (typeof key !== 'string' || key.indexOf('tinyworld:island-viewer:') !== 0) return;
+        if (localStorage.getItem(key) !== null) return;
+        try { localStorage.setItem(key, String(data.settings[key])); } catch (_) {}
+      });
+    } catch (_) {}
+  })();
+  </script>
+  <script src="vendor/three/tinyworld-three.r185.min.js"></script>
+  <script src="scripts/island-viewer-engine-prelude.js"></script>
+  <script src="scripts/island-viewer-sequential-generator.js"></script>
+  <script src="engine/world/00-prelude.js"></script>
+  <script src="engine/world/01-render-core.js"></script>
+  <script src="engine/world/02-cameras-lighting.js"></script>
+  <script src="engine/world/03-geometry-materials.js"></script>
+  <script src="engine/world/04-textures.js"></script>
+  <script src="engine/world/05-tile-factory.js"></script>
+  <script src="engine/world/06-history-object-factories.js"></script>
+  <script src="engine/world/07-house-primitives.js"></script>
+  <script src="engine/world/08-voxel-stamp-renderer.js"></script>
+  <script src="engine/world/09b-voxel-build-factories.js"></script>
+  <script src="engine/world/10-world-data.js"></script>
+  <script src="engine/world/11-vehicle-crowd.js"></script>
+  <script src="engine/world/12-selection-tool.js"></script>
+  <script src="engine/world/13-distant-dressing-ghost.js"></script>
+  <script src="engine/world/15-ghost-generation-fade.js"></script>
+  <script src="engine/world/16-drop-anim-adjacency.js"></script>
+  <script src="engine/world/17-tile-renderers.js"></script>
+  <script src="engine/world/23-particles-clouds.js"></script>
+  <script src="scripts/island-viewer-engine-runtime.js"></script>
+  <script src="scripts/island-viewer.js"></script>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,6 +27,16 @@
   status = 200
 
 [[redirects]]
+  from = "/island-viewer"
+  to = "/island-viewer.html"
+  status = 200
+
+[[redirects]]
+  from = "/island-viewer/"
+  to = "/island-viewer.html"
+  status = 200
+
+[[redirects]]
   from = "/random-island-preview"
   to = "/.netlify/functions/random-island-preview"
   status = 200

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "perf": "node tools/perf-probe.js",
     "vendor:three": "node tools/build-three-vendor.mjs",
     "stats:random-island": "node tools/random-island-stats.mjs",
+    "stats:island-viewer": "node tools/island-viewer-sequential-stats.mjs",
     "sample:random-island": "node tools/random-island-samples.mjs",
     "db:local": "tools/db-local.sh",
     "party:dev": "partykit dev party/index.js --port 1999",

--- a/publish.sh
+++ b/publish.sh
@@ -17,7 +17,8 @@ Creates a clean dist/ folder for publishing Tiny World Builder.
 Outputs:
   dist/index.html                 Landing page entry point
   dist/tiny-world-builder.html    Original app filename
-  dist/random-island-preview.html Private Netlify-function route, not a public static copy
+  dist/island-viewer.html          First-class island viewer shell
+  dist/random-island-preview.html  Compatibility redirect to island-viewer
   dist/world.schema.json
   dist/README.md
   dist/LICENSE
@@ -76,6 +77,8 @@ cp code-of-conduct.html "$DIST/code-of-conduct.html"
 cp worlds.html "$DIST/worlds.html"
 cp collabs.html "$DIST/collabs.html"
 cp harvest.html "$DIST/harvest.html"
+cp island-viewer.html "$DIST/island-viewer.html"
+cp random-island-preview.html "$DIST/random-island-preview.html"
 cp builder.html "$DIST/builder.html"
 cp LandscapeEngine.js "$DIST/LandscapeEngine.js"
 cp world.schema.json "$DIST/world.schema.json"

--- a/random-island-preview.html
+++ b/random-island-preview.html
@@ -3,64 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>TinyWorld Island Reveal Preview</title>
-  <link rel="icon" href="data:,">
-  <link rel="stylesheet" href="styles/random-island-preview.css">
+  <meta http-equiv="refresh" content="0; url=island-viewer.html">
+  <title>TinyWorld Island Viewer</title>
+  <link rel="canonical" href="island-viewer.html">
+  <script>
+    location.replace('island-viewer.html' + location.search + location.hash);
+  </script>
 </head>
 <body>
-  <main class="rip-shell">
-    <section class="rip-toolbar" aria-label="Island reveal preview controls">
-      <div class="rip-brand">
-        <span class="rip-kicker">TinyWorld</span>
-        <h1>Island Reveal</h1>
-      </div>
-      <form class="rip-controls" id="rip-controls">
-        <label>
-          <span>Archetype</span>
-          <select id="rip-archetype">
-            <option value="random">Random</option>
-            <option value="pastoral">Pastoral</option>
-            <option value="forest">Forest</option>
-            <option value="quarry">Quarry</option>
-            <option value="river">River</option>
-            <option value="village">Village</option>
-            <option value="fortress">Fortress</option>
-            <option value="ruins">Ruins</option>
-            <option value="harbor">Harbor</option>
-          </select>
-        </label>
-        <label>
-          <span>Grid</span>
-          <select id="rip-grid-size">
-            <option value="8">8 x 8</option>
-            <option value="10">10 x 10</option>
-            <option value="12">12 x 12</option>
-            <option value="16">16 x 16</option>
-            <option value="20">20 x 20</option>
-          </select>
-        </label>
-        <label class="rip-seed-field">
-          <span>Seed</span>
-          <input id="rip-seed" type="text" autocomplete="off">
-        </label>
-        <button type="submit" class="rip-primary">Random</button>
-        <button type="button" id="rip-save-reveal">Save Island File</button>
-        <button type="button" id="rip-save-world">Save Game JSON</button>
-        <button type="button" id="rip-load-button">Load</button>
-        <input id="rip-load-file" type="file" accept=".json,application/json" hidden>
-      </form>
-      <div class="rip-status" id="rip-status" role="status">Starting real TinyWorld renderer...</div>
-    </section>
-
-    <section class="rip-frame-wrap" aria-label="Real TinyWorld island reveal">
-      <iframe
-        id="rip-frame"
-        title="TinyWorld rendered island reveal"
-        src="about:blank"
-        allow="fullscreen"
-      ></iframe>
-    </section>
-  </main>
-  <script src="scripts/random-island-preview.js"></script>
+  <p><a href="island-viewer.html">Open Island Viewer</a></p>
 </body>
 </html>

--- a/scripts/island-viewer-engine-prelude.js
+++ b/scripts/island-viewer-engine-prelude.js
@@ -1,0 +1,47 @@
+(function () {
+  'use strict';
+
+  window.__tinyworldStandaloneIslandViewer = true;
+
+  window.selectedTool = null;
+  window.suppressSave = true;
+  window.toolThumbCanvases = new Map();
+
+  window.saveState = function saveState() {};
+  window.fireWebhook = function fireWebhook() {};
+  window.invalidateThumbCache = function invalidateThumbCache() {};
+  window.refreshToolThumb = function refreshToolThumb() {};
+  window.refreshOpenStampBuilderCards = function refreshOpenStampBuilderCards() {};
+  window.isEditableIslandCell = function isEditableIslandCell() {
+    return false;
+  };
+  window.editableIslandForWorldCell = function editableIslandForWorldCell() {
+    return null;
+  };
+  window.selectedEditableIsland = function selectedEditableIsland() {
+    return null;
+  };
+  window.cellRenderParentForCell = function cellRenderParentForCell() {
+    return worldGroup;
+  };
+  window.cellRenderPositionForCell = function cellRenderPositionForCell(x, z) {
+    return tilePos(x, z);
+  };
+  window.cellDisplayPointForCell = function cellDisplayPointForCell(x, z, island, out) {
+    return out ? tilePosInto(out, x, z) : tilePos(x, z);
+  };
+  window.stampCellUserData = function stampCellUserData(root, x, z) {
+    if (!root || !root.userData) return;
+    root.userData.gx = x;
+    root.userData.gz = z;
+    delete root.userData.boardX;
+    delete root.userData.boardZ;
+    delete root.userData.editableIslandId;
+  };
+  window.floorDiv = function floorDiv(a, b) {
+    return Math.floor(a / b);
+  };
+  window.positiveMod = function positiveMod(a, b) {
+    return ((a % b) + b) % b;
+  };
+})();

--- a/scripts/island-viewer-engine-runtime.js
+++ b/scripts/island-viewer-engine-runtime.js
@@ -1,0 +1,250 @@
+(function () {
+  'use strict';
+
+  const VIEWER_GRID_SIZE = 8;
+  const GRAPHICS_DEFAULTS_VERSION = 2;
+  const DEFAULT_GRAPHICS = {
+    viewerEffectsVersion: GRAPHICS_DEFAULTS_VERSION,
+    resolution: 0.85,
+    shadow: 'balanced',
+    lighting: 0.92,
+    directionalSun: 1.1,
+    directionalSunAngle: 37,
+    timeCycle: 'fixed',
+    timeOfDay: 720,
+    ambientFill: 0.92,
+    clouds: 0.34,
+    cloudHeight: 10.5,
+    enhancedWater: false,
+    cloudSea: false,
+    distantWorlds: false,
+  };
+
+  window.__tinyworldStandaloneIslandViewer = true;
+
+  function clone(value) {
+    return JSON.parse(JSON.stringify(value || null));
+  }
+
+  function clampNumber(value, fallback, min, max) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.max(min, Math.min(max, n));
+  }
+
+  function normalizeTerrain(value) {
+    if (value === 'sand') return 'grass';
+    return ['grass', 'path', 'dirt', 'water', 'stone', 'lava', 'snow'].includes(value) ? value : 'grass';
+  }
+
+  function normalizeGraphics(value) {
+    const raw = value || {};
+    const source = Object.assign({}, DEFAULT_GRAPHICS, raw);
+    const stableEffects = raw.viewerEffectsVersion === GRAPHICS_DEFAULTS_VERSION;
+    return {
+      viewerEffectsVersion: GRAPHICS_DEFAULTS_VERSION,
+      resolution: clampNumber(source.resolution, DEFAULT_GRAPHICS.resolution, 0.5, 1.25),
+      shadow: ['low', 'balanced', 'high'].includes(source.shadow) ? source.shadow : DEFAULT_GRAPHICS.shadow,
+      lighting: clampNumber(source.lighting, DEFAULT_GRAPHICS.lighting, 0.5, 5),
+      directionalSun: clampNumber(source.directionalSun, DEFAULT_GRAPHICS.directionalSun, 0, 10),
+      directionalSunAngle: Math.round(clampNumber(source.directionalSunAngle, DEFAULT_GRAPHICS.directionalSunAngle, 0, 359)),
+      timeCycle: ['live', 'fixed'].includes(source.timeCycle) ? source.timeCycle : DEFAULT_GRAPHICS.timeCycle,
+      timeOfDay: Math.round(clampNumber(source.timeOfDay, DEFAULT_GRAPHICS.timeOfDay, 0, 1439)),
+      ambientFill: clampNumber(source.ambientFill, DEFAULT_GRAPHICS.ambientFill, 0, 5),
+      clouds: clampNumber(source.clouds, DEFAULT_GRAPHICS.clouds, 0, 1),
+      cloudHeight: clampNumber(source.cloudHeight, DEFAULT_GRAPHICS.cloudHeight, 9, 16),
+      enhancedWater: stableEffects && source.enhancedWater === true,
+      cloudSea: stableEffects && source.cloudSea === true,
+      distantWorlds: stableEffects && source.distantWorlds === true,
+    };
+  }
+
+  function normalizeCell(raw, x, z) {
+    const cell = Array.isArray(raw)
+      ? {
+        x: raw[0],
+        z: raw[1],
+        terrain: raw[2],
+        kind: raw[3] === undefined ? null : raw[3],
+        floors: raw[4],
+        buildingType: raw[5],
+        terrainFloors: raw[6],
+        fenceSide: raw[7],
+        extras: raw[8],
+        transform: raw[9],
+        appearance: raw[10],
+      }
+      : Object.assign({}, raw || {});
+    let terrain = normalizeTerrain(cell.terrain);
+    if (cell.path === true && terrain !== 'water') terrain = 'path';
+    return {
+      x: Number.isInteger(cell.x) ? cell.x : x,
+      z: Number.isInteger(cell.z) ? cell.z : z,
+      terrain,
+      kind: cell.kind || null,
+      floors: Math.max(1, Math.min(8, Math.round(Number(cell.floors) || 1))),
+      terrainFloors: Math.max(1, Math.min(8, Math.round(Number(cell.terrainFloors) || 1))),
+      buildingType: cell.buildingType || null,
+      fenceSide: cell.fenceSide || null,
+      extras: Array.isArray(cell.extras) ? cell.extras.filter(Boolean) : [],
+      transform: cell.transform || null,
+      appearance: cell.appearance || null,
+    };
+  }
+
+  function normalizeWorld(input) {
+    const source = input && input.type === 'tinyworld.islandViewerReveal' ? input.world
+      : input && input.type === 'tinyworld.randomIslandReveal' ? input.world
+        : input;
+    if (!source || typeof source !== 'object' || !Array.isArray(source.cells)) {
+      throw new Error('File is not a TinyWorld island reveal file or v:4 world JSON.');
+    }
+    const byCoord = new Map();
+    for (const raw of source.cells) {
+      const cell = normalizeCell(raw, 0, 0);
+      if (cell.x < 0 || cell.x >= VIEWER_GRID_SIZE || cell.z < 0 || cell.z >= VIEWER_GRID_SIZE) continue;
+      byCoord.set(cell.x + ',' + cell.z, cell);
+    }
+    const cells = [];
+    for (let x = 0; x < VIEWER_GRID_SIZE; x++) {
+      for (let z = 0; z < VIEWER_GRID_SIZE; z++) {
+        cells.push(byCoord.get(x + ',' + z) || normalizeCell({ x, z, terrain: 'grass' }, x, z));
+      }
+    }
+    return { v: 4, gridSize: VIEWER_GRID_SIZE, cells };
+  }
+
+  function setViewerGridSize() {
+    if (typeof GRID !== 'undefined' && GRID !== VIEWER_GRID_SIZE) GRID = VIEWER_GRID_SIZE;
+    if (typeof initCellMeshesGrid === 'function') initCellMeshesGrid();
+  }
+
+  function applyCell(cell, animate) {
+    setCell(cell.x, cell.z, {
+      terrain: cell.terrain,
+      terrainFloors: cell.terrainFloors,
+      kind: cell.kind,
+      floors: cell.floors,
+      buildingType: cell.buildingType,
+      fenceSide: cell.fenceSide,
+      extras: cell.extras,
+      appearance: cell.appearance,
+      rotationY: cell.transform && Number.isFinite(cell.transform.rotationY) ? cell.transform.rotationY : undefined,
+      animate,
+      impactDust: false,
+      forceTile: true,
+    });
+  }
+
+  function clearViewerWorld() {
+    for (let x = 0; x < VIEWER_GRID_SIZE; x++) {
+      for (let z = 0; z < VIEWER_GRID_SIZE; z++) {
+        setCell(x, z, {
+          terrain: 'grass',
+          terrainFloors: 1,
+          kind: null,
+          floors: 1,
+          buildingType: null,
+          fenceSide: null,
+          extras: [],
+          appearance: null,
+          rotationY: 0,
+          animate: false,
+          impactDust: false,
+          forceTile: true,
+        });
+      }
+    }
+  }
+
+  function applyGraphics(settings) {
+    const graphics = normalizeGraphics(settings);
+    if (typeof setRenderResolutionScale === 'function') setRenderResolutionScale(graphics.resolution);
+    if (typeof renderShadowQuality !== 'undefined') renderShadowQuality = graphics.shadow;
+    if (typeof renderLighting !== 'undefined') renderLighting = graphics.lighting;
+    if (typeof renderDirectionalSun !== 'undefined') renderDirectionalSun = graphics.directionalSun;
+    if (typeof renderDirectionalSunAngle !== 'undefined') renderDirectionalSunAngle = graphics.directionalSunAngle;
+    if (typeof renderAmbientFill !== 'undefined') renderAmbientFill = graphics.ambientFill;
+    if (typeof renderCloudAmount !== 'undefined') renderCloudAmount = graphics.clouds;
+    if (typeof renderCloudHeight !== 'undefined') renderCloudHeight = graphics.cloudHeight;
+    if (typeof renderEnhancedWater !== 'undefined') renderEnhancedWater = !!graphics.enhancedWater;
+    if (typeof renderCloudSea !== 'undefined') renderCloudSea = !!graphics.cloudSea;
+    if (typeof renderDistantWorlds !== 'undefined') renderDistantWorlds = !!graphics.distantWorlds;
+    if (typeof applyLightingSettings === 'function') applyLightingSettings();
+    if (typeof applyCloudSettings === 'function') applyCloudSettings();
+    if (typeof applyWaterMaterialSettings === 'function') applyWaterMaterialSettings();
+    if (typeof renderScene === 'function') renderScene();
+    return graphics;
+  }
+
+  function mount(container, options) {
+    const state = {
+      world: { v: 4, gridSize: VIEWER_GRID_SIZE, cells: [] },
+      profile: null,
+      graphics: normalizeGraphics(options && options.graphics),
+      raf: 0,
+      disposed: false,
+    };
+
+    function frame(now) {
+      if (state.disposed) return;
+      state.raf = requestAnimationFrame(frame);
+      const dt = 1 / 60;
+      if (typeof tickDropAnims === 'function') tickDropAnims(dt);
+      if (typeof tickRippleAnims === 'function') tickRippleAnims(dt);
+      if (typeof updateClouds === 'function') updateClouds(dt);
+      if (typeof tickWaterTextureFlow === 'function') tickWaterTextureFlow(dt);
+      if (typeof updateWaterfallEffects === 'function') updateWaterfallEffects((now || performance.now()) / 1000);
+      if (typeof updateAllBuildingWindowLights === 'function') updateAllBuildingWindowLights();
+      if (typeof renderScene === 'function') renderScene();
+    }
+
+    function loadWorld(world, meta) {
+      setViewerGridSize();
+      const normalized = normalizeWorld(world);
+      state.world = normalized;
+      state.profile = meta && meta.profile || null;
+      if (meta && meta.graphics) state.graphics = normalizeGraphics(meta.graphics);
+      clearViewerWorld();
+      for (const cell of normalized.cells) applyCell(cell, false);
+      applyGraphics(state.graphics);
+      if (typeof target !== 'undefined' && target && target.set) target.set(0, 0, 0);
+      if (typeof viewSize !== 'undefined') viewSize = 8.2;
+      if (typeof cameraMode !== 'undefined') cameraMode = 'perspective';
+      if (typeof updateCamera === 'function') updateCamera();
+      if (typeof renderScene === 'function') renderScene();
+      return exportWorld();
+    }
+
+    function exportWorld() {
+      return clone(state.world);
+    }
+
+    function dispose() {
+      state.disposed = true;
+      if (state.raf) cancelAnimationFrame(state.raf);
+    }
+
+    applyGraphics(state.graphics);
+    state.raf = requestAnimationFrame(frame);
+    return {
+      loadWorld,
+      exportWorld,
+      applyGraphics(nextGraphics) {
+        state.graphics = applyGraphics(nextGraphics);
+      },
+      dispose,
+      get profile() { return state.profile; },
+    };
+  }
+
+  window.TinyWorldIslandRenderer = {
+    mount,
+    normalizeWorld,
+    normalizeGraphics,
+    defaults: {
+      graphics: Object.assign({}, DEFAULT_GRAPHICS),
+      gridSize: VIEWER_GRID_SIZE,
+    },
+  };
+})();

--- a/scripts/island-viewer-sequential-generator.js
+++ b/scripts/island-viewer-sequential-generator.js
@@ -1,0 +1,1372 @@
+(function () {
+  'use strict';
+
+  const VIEWER_GRID_SIZE = 8;
+  const ARCHETYPES = ['pastoral', 'forest', 'quarry', 'river', 'village', 'fortress', 'ruins', 'harbor'];
+
+  function randomSeed() {
+    return 'tiny-' + Math.floor(Math.random() * 1000000).toString(36);
+  }
+
+  function hashSeed(value) {
+    let h = 1779033703 ^ String(value).length;
+    const str = String(value);
+    for (let i = 0; i < str.length; i++) {
+      h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+      h = (h << 13) | (h >>> 19);
+    }
+    return function hash() {
+      h = Math.imul(h ^ (h >>> 16), 2246822507);
+      h = Math.imul(h ^ (h >>> 13), 3266489909);
+      return (h ^= h >>> 16) >>> 0;
+    };
+  }
+
+  function seededRandom(value) {
+    let n = hashSeed(value)();
+    return function random() {
+      let t = (n += 0x6d2b79f5);
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  function pick(values, seed) {
+    const rng = seededRandom(seed);
+    return values[Math.floor(rng() * values.length)] || values[0];
+  }
+
+  function normalizeArchetype(value, seed) {
+    const raw = String(value || 'random').trim().toLowerCase();
+    if (ARCHETYPES.includes(raw)) return raw;
+    return pick(ARCHETYPES, String(seed || '') + '|viewer-archetype');
+  }
+
+  function indexFor(x, z) {
+    return z * VIEWER_GRID_SIZE + x;
+  }
+
+  function xyFor(index) {
+    return { x: index % VIEWER_GRID_SIZE, z: Math.floor(index / VIEWER_GRID_SIZE) };
+  }
+
+  function inBounds(x, z) {
+    return x >= 0 && x < VIEWER_GRID_SIZE && z >= 0 && z < VIEWER_GRID_SIZE;
+  }
+
+  function sideNeighborIndex(index, side) {
+    const point = xyFor(index);
+    if (side === 'n') return inBounds(point.x, point.z - 1) ? indexFor(point.x, point.z - 1) : -1;
+    if (side === 's') return inBounds(point.x, point.z + 1) ? indexFor(point.x, point.z + 1) : -1;
+    if (side === 'e') return inBounds(point.x + 1, point.z) ? indexFor(point.x + 1, point.z) : -1;
+    if (side === 'w') return inBounds(point.x - 1, point.z) ? indexFor(point.x - 1, point.z) : -1;
+    return -1;
+  }
+
+  function cardinalNeighbors(index) {
+    return ['n', 'e', 's', 'w']
+      .map(side => sideNeighborIndex(index, side))
+      .filter(next => next >= 0);
+  }
+
+  function distanceBetween(a, b) {
+    const pa = xyFor(a);
+    const pb = xyFor(b);
+    return Math.abs(pa.x - pb.x) + Math.abs(pa.z - pb.z);
+  }
+
+  function sideTowardIndex(fromIndex, toIndex) {
+    const from = xyFor(fromIndex);
+    const to = xyFor(toIndex);
+    const dx = to.x - from.x;
+    const dz = to.z - from.z;
+    if (Math.abs(dx) >= Math.abs(dz)) return dx >= 0 ? 'e' : 'w';
+    return dz >= 0 ? 's' : 'n';
+  }
+
+  function rotationYForSide(side) {
+    if (side === 'n') return Math.PI;
+    if (side === 'e') return Math.PI / 2;
+    if (side === 'w') return -Math.PI / 2;
+    return 0;
+  }
+
+  function cellRand(seed, index, salt) {
+    const point = xyFor(index);
+    return seededRandom(String(seed) + '|cell|' + point.x + '|' + point.z + '|' + salt)();
+  }
+
+  function makeBaseCells() {
+    return Array.from({ length: VIEWER_GRID_SIZE * VIEWER_GRID_SIZE }, () => ({
+      terrain: 'grass',
+      object: null,
+      path: false,
+      doorSide: null,
+      motif: null,
+      fenceEdges: null,
+    }));
+  }
+
+  function hasPath(cell) {
+    return !!(cell && cell.terrain !== 'water' && cell.path === true);
+  }
+
+  function markPath(cells, index) {
+    if (!cells[index] || cells[index].terrain === 'water') return false;
+    cells[index].terrain = 'grass';
+    cells[index].path = true;
+    return true;
+  }
+
+  function hasFenceEdges(cell) {
+    return !!(cell && Array.isArray(cell.fenceEdges) && cell.fenceEdges.length);
+  }
+
+  function addFenceEdge(cells, index, side, level, style) {
+    if (!cells[index] || ['n', 'e', 's', 'w'].indexOf(side) === -1) return false;
+    if (!cells[index].fenceEdges) cells[index].fenceEdges = [];
+    const fenceStyle = style === 'garden' || style === 'gate' ? style : 'wood';
+    const fenceLevel = Math.max(1, Math.min(8, Math.round(level || 1)));
+    const existing = cells[index].fenceEdges.find(edge => edge.side === side && edge.style === fenceStyle);
+    if (existing) {
+      existing.level = Math.max(existing.level || 1, fenceLevel);
+      return false;
+    }
+    cells[index].fenceEdges.push({ side, level: fenceLevel, style: fenceStyle });
+    return true;
+  }
+
+  function firstHouseIndex(seed) {
+    const inset = 2;
+    const count = VIEWER_GRID_SIZE - inset * 2;
+    const roll = Math.floor(seededRandom(String(seed) + '|first-house')() * count * count);
+    return indexFor(inset + (roll % count), inset + Math.floor(roll / count));
+  }
+
+  function towerIndexes(seed, houseIndex) {
+    const corners = [
+      indexFor(0, 0),
+      indexFor(VIEWER_GRID_SIZE - 1, 0),
+      indexFor(VIEWER_GRID_SIZE - 1, VIEWER_GRID_SIZE - 1),
+      indexFor(0, VIEWER_GRID_SIZE - 1),
+    ];
+    corners.sort((a, b) => {
+      const distanceDelta = distanceBetween(b, houseIndex) - distanceBetween(a, houseIndex);
+      if (distanceDelta) return distanceDelta;
+      return cellRand(seed, a, 'tower-corner-tie') - cellRand(seed, b, 'tower-corner-tie');
+    });
+    const roll = seededRandom(String(seed) + '|tower-count')();
+    const count = roll < 0.125 ? 4 : roll < 0.25 ? 3 : roll < 0.5 ? 2 : 1;
+    return corners.slice(0, count);
+  }
+
+  function anchors(seed) {
+    const house = firstHouseIndex(seed);
+    const towers = towerIndexes(seed, house);
+    return {
+      house,
+      tower: towers[0],
+      towers,
+    };
+  }
+
+  function placeFirstHouseLayer(cells, seed) {
+    const a = anchors(seed);
+    cells[a.house].object = 'house';
+    cells[a.house].doorSide = sideTowardIndex(a.house, a.tower);
+    return a.house;
+  }
+
+  function placeTowerLayer(cells, seed) {
+    const a = anchors(seed);
+    for (const tower of a.towers) {
+      cells[tower].object = 'watchtower';
+      cells[tower].doorSide = sideTowardIndex(tower, a.house);
+    }
+    return a.towers;
+  }
+
+  function isHouseSideCell(index, houseIndex) {
+    return ['n', 'e', 's', 'w'].some(side => sideNeighborIndex(houseIndex, side) === index);
+  }
+
+  function pathRoute(cells, startIndex, endIndex, houseIndex) {
+    if (startIndex < 0 || endIndex < 0) return [];
+    const queue = [startIndex];
+    const seen = new Set([startIndex]);
+    const previous = new Map();
+    while (queue.length) {
+      const current = queue.shift();
+      if (current === endIndex) {
+        const route = [current];
+        let cursor = current;
+        while (previous.has(cursor)) {
+          cursor = previous.get(cursor);
+          route.push(cursor);
+        }
+        return route.reverse();
+      }
+      for (const next of cardinalNeighbors(current)) {
+        if (seen.has(next)) continue;
+        const cell = cells[next];
+        if (!cell) continue;
+        if (cell.object && next !== endIndex) continue;
+        if (next !== startIndex && next !== endIndex && isHouseSideCell(next, houseIndex)) continue;
+        seen.add(next);
+        previous.set(next, current);
+        queue.push(next);
+      }
+    }
+    return [];
+  }
+
+  function carvePath(cells, startIndex, endIndex, houseIndex) {
+    for (const index of pathRoute(cells, startIndex, endIndex, houseIndex)) {
+      if (cells[index] && !cells[index].object) markPath(cells, index);
+    }
+  }
+
+  function connectHouseTowerPathLayer(cells, seed) {
+    const a = anchors(seed);
+    const houseFront = sideNeighborIndex(a.house, cells[a.house].doorSide);
+    for (const tower of a.towers) {
+      const towerFront = sideNeighborIndex(tower, cells[tower].doorSide);
+      carvePath(cells, houseFront, towerFront, a.house);
+    }
+  }
+
+  function additionalHouseCount(seed) {
+    let count = 0;
+    if (seededRandom(String(seed) + '|extra-house-2')() < 0.5) {
+      count++;
+      if (seededRandom(String(seed) + '|extra-house-3')() < 0.25) {
+        count++;
+        if (seededRandom(String(seed) + '|extra-house-4')() < 0.125) count++;
+      }
+    }
+    return count;
+  }
+
+  function houseIndexes(cells) {
+    const indexes = [];
+    for (let index = 0; index < cells.length; index++) {
+      if (cells[index] && (cells[index].object === 'house' || cells[index].object === 'manor')) indexes.push(index);
+    }
+    return indexes;
+  }
+
+  function plainHouseIndexes(cells) {
+    const indexes = [];
+    for (let index = 0; index < cells.length; index++) {
+      if (cells[index] && cells[index].object === 'house') indexes.push(index);
+    }
+    return indexes;
+  }
+
+  function houseSpacingOk(cells, index) {
+    return houseIndexes(cells).every(houseIndex => {
+      const a = xyFor(index);
+      const b = xyFor(houseIndex);
+      return Math.max(Math.abs(a.x - b.x), Math.abs(a.z - b.z)) >= 2;
+    });
+  }
+
+  function extraHouseCandidates(cells, seed, ordinal) {
+    const candidates = [];
+    for (let index = 0; index < cells.length; index++) {
+      const cell = cells[index];
+      if (!cell || cell.object || hasPath(cell) || cell.terrain === 'water') continue;
+      if (cell.motif || hasFenceEdges(cell)) continue;
+      if (!houseSpacingOk(cells, index)) continue;
+      const pathSides = ['n', 'e', 's', 'w'].filter(side => {
+        const neighbor = sideNeighborIndex(index, side);
+        return neighbor >= 0 && hasPath(cells[neighbor]);
+      });
+      if (pathSides.length !== 1) continue;
+      candidates.push({
+        index,
+        side: pathSides[0],
+        score: cellRand(seed, index, 'extra-house-pick-' + ordinal + '-' + pathSides[0]),
+      });
+    }
+    candidates.sort((a, b) => a.score - b.score);
+    return candidates;
+  }
+
+  function cloneCells(cells) {
+    return cells.map(cell => {
+      if (!cell) return cell;
+      return {
+        ...cell,
+        fenceEdges: Array.isArray(cell.fenceEdges) ? cell.fenceEdges.map(edge => ({ ...edge })) : null,
+      };
+    });
+  }
+
+  function plotCandidates(cells, seed, salt) {
+    const candidates = [];
+    for (let z = 0; z < VIEWER_GRID_SIZE - 1; z++) {
+      for (let x = 0; x < VIEWER_GRID_SIZE - 1; x++) {
+        const patch = [indexFor(x, z), indexFor(x + 1, z), indexFor(x, z + 1), indexFor(x + 1, z + 1)];
+        if (!patch.every(index => cells[index]
+          && !cells[index].object
+          && !cells[index].motif
+          && !hasPath(cells[index])
+          && cells[index].terrain !== 'water'
+          && !hasFenceEdges(cells[index]))) continue;
+        const patchSet = new Set(patch);
+        const pathEdges = [];
+        for (const index of patch) {
+          for (const side of ['n', 'e', 's', 'w']) {
+            const neighbor = sideNeighborIndex(index, side);
+            if (neighbor >= 0 && !patchSet.has(neighbor) && hasPath(cells[neighbor])) {
+              pathEdges.push({ index, side });
+            }
+          }
+        }
+        if (!pathEdges.length) continue;
+        candidates.push({ patch, pathEdges, score: seededRandom(String(seed) + '|' + salt + '|' + x + ',' + z)() });
+      }
+    }
+    candidates.sort((a, b) => a.score - b.score);
+    return candidates;
+  }
+
+  function gateKey(candidate, seed, salt) {
+    if (!candidate || !Array.isArray(candidate.pathEdges) || !candidate.pathEdges.length) return '';
+    const gates = candidate.pathEdges
+      .map(edge => ({
+        edge,
+        key: edge.index + ':' + edge.side,
+        score: seededRandom(String(seed) + '|' + salt + '|gate|' + edge.index + ':' + edge.side)(),
+      }))
+      .sort((a, b) => a.score === b.score ? a.key.localeCompare(b.key) : a.score - b.score);
+    return gates[0].key;
+  }
+
+  function cropCandidates(cells, seed) {
+    return plotCandidates(cells, seed, 'crop-area');
+  }
+
+  function animalCandidates(cells, seed) {
+    return plotCandidates(cells, seed, 'animal-area');
+  }
+
+  function placeFencedCropAreaLayer(cells, seed) {
+    const candidate = cropCandidates(cells, seed)[0];
+    if (!candidate) return [];
+    const cropIds = ['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'];
+    const patchSet = new Set(candidate.patch);
+    const gate = gateKey(candidate, seed, 'crop-area');
+    candidate.patch.forEach(index => {
+      const roll = cellRand(seed, index, 'crop-area-fill');
+      cells[index].object = roll < 0.25 ? null : cropIds[Math.min(cropIds.length - 1, Math.floor(((roll - 0.25) / 0.75) * cropIds.length))];
+      cells[index].terrain = 'dirt';
+      cells[index].motif = 'crop-area';
+      for (const side of ['n', 'e', 's', 'w']) {
+        const neighbor = sideNeighborIndex(index, side);
+        if (neighbor >= 0 && patchSet.has(neighbor)) continue;
+        addFenceEdge(cells, index, side, 1, gate === index + ':' + side ? 'gate' : 'garden');
+      }
+    });
+    return candidate.patch;
+  }
+
+  function placeFencedAnimalAreaLayer(cells, seed) {
+    const candidate = animalCandidates(cells, seed)[0];
+    if (!candidate) return [];
+    const patchSet = new Set(candidate.patch);
+    const gate = gateKey(candidate, seed, 'animal-area');
+    candidate.patch.forEach(index => {
+      cells[index].terrain = 'grass';
+      cells[index].motif = 'animal-area';
+      if (cellRand(seed, index, 'animal-fill') < 0.5) {
+        cells[index].object = cellRand(seed, index, 'animal-kind') < 0.75 ? 'sheep' : 'cow';
+      }
+      for (const side of ['n', 'e', 's', 'w']) {
+        const neighbor = sideNeighborIndex(index, side);
+        if (neighbor >= 0 && patchSet.has(neighbor)) continue;
+        addFenceEdge(cells, index, side, 2, gate === index + ':' + side ? 'gate' : 'wood');
+      }
+    });
+    return candidate.patch;
+  }
+
+  function keepsPlotCapacity(cells, seed, candidate) {
+    if (!candidate) return false;
+    const trial = cloneCells(cells);
+    trial[candidate.index].object = 'house';
+    trial[candidate.index].doorSide = candidate.side;
+    if (!cropCandidates(trial, seed).length) return false;
+    placeFencedCropAreaLayer(trial, seed);
+    return animalCandidates(trial, seed).length > 0;
+  }
+
+  function placeAdditionalHousesLayer(cells, seed) {
+    const placed = [];
+    for (let i = 0; i < additionalHouseCount(seed); i++) {
+      const candidate = extraHouseCandidates(cells, seed, i)
+        .find(option => keepsPlotCapacity(cells, seed, option));
+      if (!candidate) break;
+      cells[candidate.index].object = 'house';
+      cells[candidate.index].doorSide = candidate.side;
+      placed.push(candidate.index);
+    }
+    return placed;
+  }
+
+  function sideOffsetsForSide(side) {
+    if (side === 'n') return { forward: [0, -1], back: [0, 1], lateral: [1, 0] };
+    if (side === 'e') return { forward: [1, 0], back: [-1, 0], lateral: [0, 1] };
+    if (side === 'w') return { forward: [-1, 0], back: [1, 0], lateral: [0, 1] };
+    return { forward: [0, 1], back: [0, -1], lateral: [1, 0] };
+  }
+
+  function manorFootprintIndexes(anchorIndex, doorSide) {
+    const point = xyFor(anchorIndex);
+    const offsets = sideOffsetsForSide(doorSide);
+    const cells = [];
+    for (const lateral of [-1, 0, 1]) {
+      for (const depth of [0, 1]) {
+        const x = point.x + offsets.lateral[0] * lateral + offsets.back[0] * depth;
+        const z = point.z + offsets.lateral[1] * lateral + offsets.back[1] * depth;
+        if (!inBounds(x, z)) return [];
+        cells.push(indexFor(x, z));
+      }
+    }
+    return [...new Set(cells)];
+  }
+
+  function doorFrontIndex(anchorIndex, doorSide) {
+    return sideNeighborIndex(anchorIndex, doorSide);
+  }
+
+  function isHouseProtectedSideCell(cells, index) {
+    for (let houseIndex = 0; houseIndex < cells.length; houseIndex++) {
+      const cell = cells[houseIndex];
+      if (!cell || (cell.object !== 'house' && cell.object !== 'watchtower' && cell.object !== 'manor')) continue;
+      if (!['n', 'e', 's', 'w'].some(side => sideNeighborIndex(houseIndex, side) === index)) continue;
+      if (doorFrontIndex(houseIndex, cell.doorSide || 's') === index) continue;
+      return true;
+    }
+    return false;
+  }
+
+  function canRouteManorPathCell(cells, index, startIndex, blocked) {
+    if (!cells[index] || blocked.has(index)) return false;
+    if (hasPath(cells[index])) return true;
+    if (isHouseProtectedSideCell(cells, index)) return false;
+    return !!(cells[index]
+      && !cells[index].object
+      && !cells[index].motif
+      && cells[index].terrain !== 'water'
+      && !hasFenceEdges(cells[index]));
+  }
+
+  function routeManorDoorToPath(cells, startIndex, blocked) {
+    if (startIndex < 0 || !cells[startIndex] || blocked.has(startIndex)) return [];
+    if (hasPath(cells[startIndex])) return [startIndex];
+    const queue = [startIndex];
+    const seen = new Set([startIndex]);
+    const previous = new Map();
+    while (queue.length) {
+      const current = queue.shift();
+      for (const next of cardinalNeighbors(current)) {
+        if (seen.has(next) || blocked.has(next)) continue;
+        if (hasPath(cells[next])) {
+          const route = [next, current];
+          let cursor = current;
+          while (previous.has(cursor)) {
+            cursor = previous.get(cursor);
+            route.push(cursor);
+          }
+          return route.reverse();
+        }
+        if (!canRouteManorPathCell(cells, next, startIndex, blocked)) continue;
+        seen.add(next);
+        previous.set(next, current);
+        queue.push(next);
+      }
+    }
+    return [];
+  }
+
+  function manorCandidates(cells, seed) {
+    const candidates = [];
+    for (let index = 0; index < cells.length; index++) {
+      for (const side of ['n', 'e', 's', 'w']) {
+        const footprint = manorFootprintIndexes(index, side);
+        if (footprint.length !== 6) continue;
+        if (!footprint.every(cellIndex => isEmptyBuildableCell(cells, cellIndex))) continue;
+        const blocked = new Set(footprint);
+        const front = doorFrontIndex(index, side);
+        if (!canRouteManorPathCell(cells, front, front, blocked)) continue;
+        const route = routeManorDoorToPath(cells, front, blocked);
+        if (!route.length || !route.some(routeIndex => hasPath(cells[routeIndex]))) continue;
+        candidates.push({
+          index,
+          side,
+          footprint,
+          route,
+          score: route.length
+            + (isEdgeIndex(index) ? 1 : 0)
+            + cellRand(seed, index, 'manor-' + side) * 0.5,
+        });
+      }
+    }
+    candidates.sort((a, b) => a.score - b.score);
+    return candidates;
+  }
+
+  function placeManorLayer(cells, seed) {
+    if (plainHouseIndexes(cells).length < 3) return null;
+    if (seededRandom(String(seed) + '|manor-chance')() >= 0.25) return null;
+    const candidate = manorCandidates(cells, seed)[0];
+    if (!candidate) return null;
+    for (const index of candidate.footprint) cells[index].motif = 'manor-footprint';
+    cells[candidate.index].object = 'manor';
+    cells[candidate.index].doorSide = candidate.side;
+    cells[candidate.index].motif = 'manor';
+    for (const index of candidate.route) {
+      if (cells[index] && !cells[index].object) markPath(cells, index);
+    }
+    return candidate.index;
+  }
+
+  function isEmptyBuildableCell(cells, index) {
+    const cell = cells[index];
+    return !!(cell
+      && !cell.object
+      && !cell.motif
+      && !hasPath(cell)
+      && cell.terrain !== 'water'
+      && !hasFenceEdges(cell));
+  }
+
+  function rockPatch(cells, seed) {
+    const candidates = [];
+    for (let z = 0; z < VIEWER_GRID_SIZE - 1; z++) {
+      for (let x = 0; x < VIEWER_GRID_SIZE - 1; x++) {
+        const patch = [indexFor(x, z), indexFor(x + 1, z), indexFor(x, z + 1), indexFor(x + 1, z + 1)];
+        if (!patch.every(index => isEmptyBuildableCell(cells, index))) continue;
+        candidates.push({ patch, score: seededRandom(String(seed) + '|rock-patch|' + x + ',' + z)() });
+      }
+    }
+    candidates.sort((a, b) => a.score - b.score);
+    return candidates.length ? candidates[0].patch : [];
+  }
+
+  function placeRockPatchLayer(cells, seed) {
+    const patch = rockPatch(cells, seed);
+    for (const index of patch) {
+      cells[index].terrain = 'stone';
+      cells[index].object = cellRand(seed, index, 'rock-patch-ore') < 0.25 ? 'ore' : 'stone';
+      cells[index].motif = 'quarry';
+    }
+    return patch;
+  }
+
+  function isEdgeIndex(index) {
+    const point = xyFor(index);
+    return point.x === 0 || point.z === 0 || point.x === VIEWER_GRID_SIZE - 1 || point.z === VIEWER_GRID_SIZE - 1;
+  }
+
+  function waterStarts(cells, seed) {
+    const center = (VIEWER_GRID_SIZE - 1) / 2;
+    const starts = [];
+    for (let index = 0; index < cells.length; index++) {
+      if (!isEmptyBuildableCell(cells, index) || isEdgeIndex(index)) continue;
+      const point = xyFor(index);
+      const inner = point.x >= 2 && point.z >= 2 && point.x <= VIEWER_GRID_SIZE - 3 && point.z <= VIEWER_GRID_SIZE - 3;
+      starts.push({
+        index,
+        score: (inner ? 0 : 2)
+          + Math.abs(point.x - center) * 0.35
+          + Math.abs(point.z - center) * 0.35
+          + cellRand(seed, index, 'water-start') * 0.4,
+      });
+    }
+    starts.sort((a, b) => a.score - b.score);
+    return starts;
+  }
+
+  function waterEdges(cells, seed) {
+    const center = (VIEWER_GRID_SIZE - 1) / 2;
+    const edges = [];
+    for (let index = 0; index < cells.length; index++) {
+      if (!isEdgeIndex(index) || !isEmptyBuildableCell(cells, index)) continue;
+      const point = xyFor(index);
+      edges.push({
+        index,
+        score: Math.min(Math.abs(point.x - center), Math.abs(point.z - center)) * 0.1
+          + cellRand(seed, index, 'water-edge'),
+      });
+    }
+    edges.sort((a, b) => a.score - b.score);
+    return edges;
+  }
+
+  function waterPathComponents(cells) {
+    const components = new Map();
+    let nextId = 1;
+    for (let index = 0; index < cells.length; index++) {
+      if (components.has(index) || !hasPath(cells[index])) continue;
+      const id = nextId++;
+      const queue = [index];
+      components.set(index, id);
+      while (queue.length) {
+        const current = queue.shift();
+        for (const neighbor of cardinalNeighbors(current)) {
+          if (components.has(neighbor) || !hasPath(cells[neighbor])) continue;
+          components.set(neighbor, id);
+          queue.push(neighbor);
+        }
+      }
+    }
+    return components;
+  }
+
+  function waterRouteStateKey(index, crossedComponents) {
+    const crossed = Array.from(crossedComponents || []).sort((a, b) => a - b).join(',');
+    return index + '|' + crossed;
+  }
+
+  function canWaterUseCell(cells, index, endIndex, pathComponents, crossedComponents) {
+    if (!cells[index]) return false;
+    if (index !== endIndex && isEdgeIndex(index)) return false;
+    if (isEmptyBuildableCell(cells, index)) return true;
+    if (index === endIndex || !hasPath(cells[index])) return false;
+    const componentId = pathComponents.get(index);
+    return Number.isFinite(componentId) && !crossedComponents.has(componentId);
+  }
+
+  function waterRoute(cells, seed, startIndex, endIndex) {
+    const end = xyFor(endIndex);
+    const pathComponents = waterPathComponents(cells);
+    const startState = { index: startIndex, crossedComponents: new Set(), cost: 0, score: 0 };
+    const startKey = waterRouteStateKey(startIndex, startState.crossedComponents);
+    const frontier = [startState];
+    const best = new Map([[startKey, 0]]);
+    const previous = new Map();
+    const states = new Map([[startKey, startState]]);
+    while (frontier.length) {
+      frontier.sort((a, b) => a.score - b.score);
+      const current = frontier.shift();
+      const currentKey = waterRouteStateKey(current.index, current.crossedComponents);
+      if (best.has(currentKey) && best.get(currentKey) < current.cost) continue;
+      if (current.index === endIndex) {
+        const route = [endIndex];
+        let cursor = currentKey;
+        while (previous.has(cursor)) {
+          cursor = previous.get(cursor);
+          route.push(states.get(cursor).index);
+        }
+        return route.reverse();
+      }
+      for (const next of cardinalNeighbors(current.index)) {
+        if (!canWaterUseCell(cells, next, endIndex, pathComponents, current.crossedComponents)) continue;
+        const crossedComponents = new Set(current.crossedComponents);
+        const componentId = pathComponents.get(next);
+        if (Number.isFinite(componentId)) crossedComponents.add(componentId);
+        const nextKey = waterRouteStateKey(next, crossedComponents);
+        const stepCost = current.cost + 1 + (hasPath(cells[next]) ? 0.35 : 0);
+        if (best.has(nextKey) && best.get(nextKey) <= stepCost) continue;
+        best.set(nextKey, stepCost);
+        previous.set(nextKey, currentKey);
+        const point = xyFor(next);
+        const heuristic = Math.abs(point.x - end.x) + Math.abs(point.z - end.z);
+        const jitter = seededRandom(String(seed) + '|water-route|' + current.index + '>' + next + '|' + endIndex)() * 0.12;
+        const nextState = { index: next, crossedComponents, cost: stepCost, score: stepCost + heuristic + jitter };
+        states.set(nextKey, nextState);
+        frontier.push(nextState);
+      }
+    }
+    return [];
+  }
+
+  function waterPlan(cells, seed) {
+    for (const start of waterStarts(cells, seed)) {
+      for (const edge of waterEdges(cells, seed)) {
+        const route = waterRoute(cells, seed, start.index, edge.index);
+        if (Array.isArray(route) && route.length >= 2) return { route };
+      }
+    }
+    return null;
+  }
+
+  function carveWaterCell(cells, index) {
+    if (!cells[index]) return;
+    cells[index].terrain = 'water';
+    cells[index].path = false;
+    cells[index].motif = 'water-route';
+    cells[index].object = null;
+  }
+
+  function widenWaterEdge(cells, seed, endIndex) {
+    const end = xyFor(endIndex);
+    const horizontalEdge = end.z === 0 || end.z === VIEWER_GRID_SIZE - 1;
+    const target = 1 + Math.floor(cellRand(seed, endIndex, 'water-edge-width') * 3);
+    const offsets = [-1, 1, -2, 2];
+    let count = 1;
+    for (const offset of offsets) {
+      if (count >= target) break;
+      const x = horizontalEdge ? end.x + offset : end.x;
+      const z = horizontalEdge ? end.z : end.z + offset;
+      if (!inBounds(x, z)) continue;
+      const index = indexFor(x, z);
+      if (!isEmptyBuildableCell(cells, index)) continue;
+      if (!cardinalNeighbors(index).some(next => cells[next] && cells[next].terrain === 'water')) continue;
+      carveWaterCell(cells, index);
+      count++;
+    }
+  }
+
+  function placeWaterRouteLayer(cells, seed) {
+    const plan = waterPlan(cells, seed);
+    if (!plan) return [];
+    for (const index of plan.route) carveWaterCell(cells, index);
+    widenWaterEdge(cells, seed, plan.route[plan.route.length - 1]);
+    return plan.route;
+  }
+
+  function pathWaterPathBridgeAxis(cells, index) {
+    if (!cells[index] || cells[index].terrain !== 'water') return null;
+    const west = sideNeighborIndex(index, 'w');
+    const east = sideNeighborIndex(index, 'e');
+    const north = sideNeighborIndex(index, 'n');
+    const south = sideNeighborIndex(index, 's');
+    const westPath = west >= 0 && hasPath(cells[west]);
+    const eastPath = east >= 0 && hasPath(cells[east]);
+    const northPath = north >= 0 && hasPath(cells[north]);
+    const southPath = south >= 0 && hasPath(cells[south]);
+    const westWater = west >= 0 && cells[west] && cells[west].terrain === 'water';
+    const eastWater = east >= 0 && cells[east] && cells[east].terrain === 'water';
+    const northWater = north >= 0 && cells[north] && cells[north].terrain === 'water';
+    const southWater = south >= 0 && cells[south] && cells[south].terrain === 'water';
+    if (westPath && eastPath && northWater && southWater && !northPath && !southPath) return 'x';
+    if (northPath && southPath && westWater && eastWater && !westPath && !eastPath) return 'z';
+    return null;
+  }
+
+  function placePathWaterPathBridgesLayer(cells) {
+    const bridges = [];
+    for (let index = 0; index < cells.length; index++) {
+      const axis = pathWaterPathBridgeAxis(cells, index);
+      if (!axis) continue;
+      cells[index].object = 'bridge';
+      cells[index].motif = 'path-water-path-bridge';
+      bridges.push(index);
+    }
+    return bridges;
+  }
+
+  function isPerpendicularSidePair(a, b) {
+    if (!a || !b || a === b) return false;
+    return !((a === 'n' && b === 's')
+      || (a === 's' && b === 'n')
+      || (a === 'e' && b === 'w')
+      || (a === 'w' && b === 'e'));
+  }
+
+  function lampCornerSides(cells, index) {
+    const sides = ['n', 'e', 's', 'w'].filter(side => {
+      const neighbor = sideNeighborIndex(index, side);
+      return neighbor >= 0 && hasPath(cells[neighbor]);
+    });
+    if (sides.length !== 2 || !isPerpendicularSidePair(sides[0], sides[1])) return null;
+    return sides;
+  }
+
+  function nearbyLampValue(cells, index) {
+    let value = 0;
+    for (let other = 0; other < cells.length; other++) {
+      const cell = cells[other];
+      if (!cell || distanceBetween(index, other) > 2) continue;
+      if (cell.object === 'house') value += 3;
+      else if (cell.object === 'watchtower') value += 2;
+      else if (cell.object === 'bridge') value += 2;
+      else if (cell.object === 'wheat' || cell.object === 'corn' || cell.object === 'carrot' || cell.object === 'pumpkin') value += 1;
+      else if (cell.object === 'cow' || cell.object === 'sheep') value += 1;
+      if (hasFenceEdges(cell)) value += 0.5;
+    }
+    return value;
+  }
+
+  function lampSpacingOk(placed, index) {
+    return placed.every(other => distanceBetween(other, index) > 3);
+  }
+
+  function placeStrategicLampLayer(cells, seed) {
+    const candidates = [];
+    for (let index = 0; index < cells.length; index++) {
+      if (!isEmptyBuildableCell(cells, index)) continue;
+      const sides = lampCornerSides(cells, index);
+      if (!sides) continue;
+      candidates.push({
+        index,
+        score: -nearbyLampValue(cells, index)
+          + (isEdgeIndex(index) ? 0.35 : 0)
+          + cellRand(seed, index, 'strategic-lamp') * 0.25,
+      });
+    }
+    candidates.sort((a, b) => a.score - b.score);
+
+    const placed = [];
+    for (const candidate of candidates) {
+      if (!lampSpacingOk(placed, candidate.index)) continue;
+      cells[candidate.index].object = 'lamp-post';
+      cells[candidate.index].motif = 'path-lamp';
+      placed.push(candidate.index);
+      if (placed.length >= 4) break;
+    }
+    return placed;
+  }
+
+  function nearbyDecorationValue(cells, index) {
+    let value = 0;
+    for (let other = 0; other < cells.length; other++) {
+      const cell = cells[other];
+      const distance = distanceBetween(index, other);
+      if (!cell || distance > 2) continue;
+      if (hasPath(cell)) value += distance === 1 ? 2 : 0.8;
+      if (cell.object === 'house' || cell.object === 'manor') value += distance === 1 ? 2 : 1;
+      if (cell.object === 'watchtower') value += 0.8;
+      if (hasFenceEdges(cell)) value += 1;
+      if (cell.terrain === 'water') value += 0.7;
+    }
+    return value;
+  }
+
+  function placedSpacingOk(placed, index, minDistance) {
+    return placed.every(other => distanceBetween(other, index) > minDistance);
+  }
+
+  function treeCandidates(cells, seed) {
+    const candidates = [];
+    const center = (VIEWER_GRID_SIZE - 1) / 2;
+    for (let index = 0; index < cells.length; index++) {
+      if (!isEmptyBuildableCell(cells, index)) continue;
+      const point = xyFor(index);
+      const edgeBias = isEdgeIndex(index) ? -0.8 : 0;
+      const centerDistance = Math.abs(point.x - center) + Math.abs(point.z - center);
+      candidates.push({
+        index,
+        score: edgeBias
+          - centerDistance * 0.08
+          + nearbyDecorationValue(cells, index) * 0.2
+          + cellRand(seed, index, 'tree-layer') * 0.6,
+      });
+    }
+    candidates.sort((a, b) => a.score - b.score);
+    return candidates;
+  }
+
+  function bushCandidates(cells, seed) {
+    const candidates = [];
+    for (let index = 0; index < cells.length; index++) {
+      if (!isEmptyBuildableCell(cells, index)) continue;
+      candidates.push({
+        index,
+        score: -nearbyDecorationValue(cells, index)
+          + (isEdgeIndex(index) ? 0.2 : 0)
+          + cellRand(seed, index, 'bush-layer') * 0.4,
+      });
+    }
+    candidates.sort((a, b) => a.score - b.score);
+    return candidates;
+  }
+
+  function placeTreeBushLayer(cells, seed) {
+    const placedTrees = [];
+    const placedBushes = [];
+    const treeTarget = 1 + Math.floor(seededRandom(String(seed) + '|tree-target')() * 3);
+    const bushTarget = 2 + Math.floor(seededRandom(String(seed) + '|bush-target')() * 4);
+
+    for (const candidate of treeCandidates(cells, seed)) {
+      if (placedTrees.length >= treeTarget) break;
+      if (!placedSpacingOk(placedTrees, candidate.index, 2)) continue;
+      cells[candidate.index].object = 'tree';
+      cells[candidate.index].motif = 'tree-grove';
+      placedTrees.push(candidate.index);
+    }
+
+    for (const candidate of bushCandidates(cells, seed)) {
+      if (placedBushes.length >= bushTarget) break;
+      if (!placedSpacingOk(placedBushes, candidate.index, 1)) continue;
+      cells[candidate.index].object = 'bush';
+      cells[candidate.index].motif = 'shrub-border';
+      placedBushes.push(candidate.index);
+    }
+
+    return placedTrees.concat(placedBushes);
+  }
+
+  function neighborObjectCount(cells, index, objects) {
+    const allowed = new Set(objects || []);
+    return cardinalNeighbors(index).filter(neighbor => cells[neighbor] && allowed.has(cells[neighbor].object)).length;
+  }
+
+  function neighborTerrainCount(cells, index, terrains) {
+    const allowed = new Set(terrains || []);
+    return cardinalNeighbors(index).filter(neighbor => cells[neighbor] && allowed.has(cells[neighbor].terrain)).length;
+  }
+
+  function weightedInfillOptions(cells, index) {
+    const nearWater = neighborTerrainCount(cells, index, ['water']);
+    const nearStone = neighborTerrainCount(cells, index, ['stone']) + neighborObjectCount(cells, index, ['stone', 'ore']);
+    const nearCrops = neighborObjectCount(cells, index, ['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower']);
+    const nearAnimals = neighborObjectCount(cells, index, ['cow', 'sheep']);
+    const nearGreenery = neighborObjectCount(cells, index, ['tree', 'bush']);
+    const nearBuildings = neighborObjectCount(cells, index, ['house', 'manor', 'watchtower']);
+    const nearPath = cardinalNeighbors(index).filter(neighbor => hasPath(cells[neighbor])).length;
+
+    return [
+      { id: 'crop', weight: 18 + nearWater * 8 + nearCrops * 5 + nearPath * 2 },
+      { id: 'ore', weight: 10 + nearStone * 10 + (isEdgeIndex(index) ? 2 : 0) },
+      { id: 'animal', weight: 12 + nearAnimals * 7 + nearWater * 3 },
+      { id: 'bush', weight: 22 + nearBuildings * 5 + nearPath * 4 + nearGreenery * 2 },
+      { id: 'tree', weight: 16 + (isEdgeIndex(index) ? 7 : 0) + Math.max(0, 2 - nearBuildings) * 2 + nearGreenery },
+    ];
+  }
+
+  function weightedPick(options, roll) {
+    const total = options.reduce((sum, option) => sum + Math.max(0, option.weight || 0), 0);
+    if (total <= 0) return options[0] && options[0].id;
+    let cursor = roll * total;
+    for (const option of options) {
+      cursor -= Math.max(0, option.weight || 0);
+      if (cursor <= 0) return option.id;
+    }
+    return options[options.length - 1].id;
+  }
+
+  function applyInfillObject(cells, index, id, seed, iteration) {
+    const cell = cells[index];
+    if (!cell) return false;
+    if (id === 'crop') {
+      const crops = ['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'];
+      cell.object = pick(crops, String(seed) + '|infill-crop|' + iteration + '|' + index);
+      cell.terrain = 'dirt';
+      cell.motif = 'infill-crop';
+      return true;
+    }
+    if (id === 'ore') {
+      cell.object = 'ore';
+      cell.terrain = 'stone';
+      cell.motif = 'infill-ore';
+      return true;
+    }
+    if (id === 'animal') {
+      cell.object = cellRand(seed, index, 'infill-animal-' + iteration) < 0.72 ? 'sheep' : 'cow';
+      cell.terrain = 'grass';
+      cell.motif = 'infill-animal';
+      return true;
+    }
+    if (id === 'tree') {
+      cell.object = 'tree';
+      cell.terrain = 'grass';
+      cell.motif = 'infill-tree';
+      return true;
+    }
+    cell.object = 'bush';
+    cell.terrain = 'grass';
+    cell.motif = 'infill-bush';
+    return true;
+  }
+
+  function placeProbabilisticInfillLayer(cells, seed) {
+    const placed = [];
+    for (let iteration = 0; iteration < cells.length; iteration++) {
+      const candidates = [];
+      for (let index = 0; index < cells.length; index++) {
+        if (!isEmptyBuildableCell(cells, index)) continue;
+        candidates.push({
+          index,
+          score: cellRand(seed, index, 'infill-order-' + iteration),
+        });
+      }
+      if (!candidates.length) break;
+      candidates.sort((a, b) => a.score - b.score);
+      const index = candidates[0].index;
+      const choice = weightedPick(
+        weightedInfillOptions(cells, index),
+        cellRand(seed, index, 'infill-choice-' + iteration)
+      );
+      if (applyInfillObject(cells, index, choice, seed, iteration)) placed.push(index);
+    }
+    return placed;
+  }
+
+  function terrainForCell(cell) {
+    if (!cell) return 'grass';
+    if (hasPath(cell)) return 'path';
+    if (cell.terrain === 'water') return 'water';
+    if (cell.object === 'stone' || cell.object === 'ore') return 'stone';
+    if (cell.terrain === 'dirt' || ['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'].includes(cell.object)) return 'dirt';
+    return 'grass';
+  }
+
+  function fenceExtras(cell) {
+    if (!cell || !Array.isArray(cell.fenceEdges)) return [];
+    return cell.fenceEdges.map(edge => {
+      const extra = {
+        kind: 'fence',
+        fenceSide: edge.side,
+        floors: Math.max(1, Math.min(8, edge.level || 1)),
+      };
+      if (edge.style === 'garden' || edge.style === 'gate') extra.appearance = { fenceStyle: edge.style };
+      return extra;
+    });
+  }
+
+  function objectForCell(cells, index, seed) {
+    const cell = cells[index];
+    const object = cell && cell.object;
+    const objectStyle = { objectStyle: 'voxel' };
+    const floors = (min, max, salt) => min + Math.floor(cellRand(seed, index, salt) * (max - min + 1));
+    if (object === 'watchtower') {
+      return {
+        kind: 'house',
+        floors: floors(2, 3, 'watchtower'),
+        buildingType: 'tower',
+        appearance: objectStyle,
+        rotationY: rotationYForSide(cell.doorSide || 's'),
+      };
+    }
+    if (object === 'house') {
+      return {
+        kind: 'house',
+        floors: floors(1, 2, 'house'),
+        buildingType: null,
+        appearance: objectStyle,
+        rotationY: rotationYForSide(cell.doorSide || 's'),
+      };
+    }
+    if (object === 'manor') {
+      return {
+        kind: 'house',
+        floors: 2,
+        buildingType: 'manor',
+        appearance: objectStyle,
+        rotationY: rotationYForSide(cell.doorSide || 's'),
+      };
+    }
+    if (object === 'stone' || object === 'ore') {
+      const appearance = object === 'ore'
+        ? { objectStyle: 'voxel', oreMetal: pick(['copper', 'iron', 'silver', 'gold'], String(seed) + '|ore|' + index) }
+        : objectStyle;
+      return {
+        kind: 'rock',
+        floors: floors(object === 'ore' ? 2 : 1, object === 'ore' ? 4 : 3, object),
+        buildingType: null,
+        appearance,
+      };
+    }
+    if (['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'].includes(object)) {
+      return { kind: object, floors: floors(1, 3, object), buildingType: null, appearance: objectStyle };
+    }
+    if (object === 'cow' || object === 'sheep') {
+      return { kind: object, floors: 1, buildingType: null, appearance: objectStyle };
+    }
+    if (object === 'bridge') {
+      return { kind: 'bridge', floors: 1, buildingType: null, appearance: objectStyle };
+    }
+    if (object === 'lamp-post') {
+      return { kind: 'lamp-post', floors: 1, buildingType: null, appearance: objectStyle };
+    }
+    if (object === 'tree') {
+      return { kind: 'tree', floors: floors(1, 3, 'tree'), buildingType: null, appearance: objectStyle };
+    }
+    if (object === 'bush') {
+      return { kind: 'bush', floors: floors(1, 2, 'bush'), buildingType: null, appearance: objectStyle };
+    }
+    return { kind: null, floors: 1, buildingType: null, appearance: null };
+  }
+
+  function generateRandomIslandWorld(options = {}) {
+    const seed = String(options.seed || randomSeed());
+    const archetypeKey = normalizeArchetype(options.archetype || options.archetypeKey, seed);
+    const cells = makeBaseCells();
+    placeFirstHouseLayer(cells, seed);
+    placeTowerLayer(cells, seed);
+    connectHouseTowerPathLayer(cells, seed);
+    placeAdditionalHousesLayer(cells, seed);
+    placeManorLayer(cells, seed);
+    placeFencedCropAreaLayer(cells, seed);
+    placeFencedAnimalAreaLayer(cells, seed);
+    placeRockPatchLayer(cells, seed);
+    placeWaterRouteLayer(cells, seed);
+    placePathWaterPathBridgesLayer(cells);
+    placeStrategicLampLayer(cells, seed);
+    placeTreeBushLayer(cells, seed);
+    placeProbabilisticInfillLayer(cells, seed);
+
+    const out = { v: 4, gridSize: VIEWER_GRID_SIZE, cells: [] };
+    for (let index = 0; index < cells.length; index++) {
+      const point = xyFor(index);
+      const cell = cells[index];
+      const mapped = objectForCell(cells, index, seed);
+      const entry = {
+        x: point.x,
+        z: point.z,
+        terrain: terrainForCell(cell),
+        kind: mapped.kind,
+        floors: mapped.floors || 1,
+        terrainFloors: 1,
+        buildingType: mapped.kind === 'house' ? (mapped.buildingType || null) : null,
+        fenceSide: null,
+      };
+      if (mapped.appearance) entry.appearance = mapped.appearance;
+      const extras = entry.terrain === 'water' ? [] : fenceExtras(cell);
+      if (extras.length) entry.extras = extras;
+      if (Number.isFinite(mapped.rotationY)) entry.transform = { rotationY: mapped.rotationY };
+      out.cells.push(entry);
+    }
+    out.seed = seed;
+    out.archetypeKey = archetypeKey;
+    return out;
+  }
+
+  function objectIdForProfile(cell) {
+    if (!cell) return null;
+    if (!cell.kind) {
+      return Array.isArray(cell.extras) && cell.extras.some(extra => extra && extra.kind === 'fence') ? 'fence' : null;
+    }
+    if (cell.kind === 'house') {
+      if (cell.buildingType === 'tower') return 'watchtower';
+      if (cell.buildingType === 'manor') return 'manor';
+      return 'house';
+    }
+    if (cell.kind === 'rock') return 'stone';
+    if (['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower', 'cow', 'sheep', 'fence', 'bridge', 'lamp-post', 'tree', 'bush'].includes(cell.kind)) return cell.kind;
+    return null;
+  }
+
+  function profileObjectStats(id) {
+    if (id === 'watchtower') return { defense: 2.8, commerce: 0.4 };
+    if (id === 'house') return { commerce: 1.8, charm: 0.8 };
+    if (id === 'manor') return { commerce: 3.2, charm: 1.6, defense: 0.5 };
+    if (id === 'stone') return { materials: 1.0 };
+    if (id === 'fence') return { defense: 1.1 };
+    if (id === 'bridge') return { commerce: 1.2, charm: 0.6 };
+    if (id === 'lamp-post') return { commerce: 0.7, charm: 1.1, defense: 0.2 };
+    if (id === 'tree') return { materials: 0.8, charm: 1.3 };
+    if (id === 'bush') return { food: 0.4, charm: 0.9 };
+    if (id === 'corn') return { food: 2.0 };
+    if (id === 'wheat') return { food: 1.9 };
+    if (id === 'pumpkin') return { food: 1.5, charm: 0.4 };
+    if (id === 'carrot') return { food: 1.5 };
+    if (id === 'sunflower') return { food: 0.8, charm: 1.4 };
+    if (id === 'cow') return { food: 2.2, charm: 0.2 };
+    if (id === 'sheep') return { food: 1.2, charm: 1.0 };
+    return null;
+  }
+
+  function terrainStats(cell) {
+    if (cell && cell.terrain === 'water') return { food: 0.4, charm: 0.8 };
+    if (cell && cell.terrain === 'path') return { commerce: 0.5 };
+    if (cell && cell.terrain === 'dirt') return { materials: 0.2 };
+    if (cell && cell.terrain === 'stone') return { materials: 1.1 };
+    return { charm: 0.3 };
+  }
+
+  function addStats(target, source, factor) {
+    const f = Number.isFinite(Number(factor)) ? Number(factor) : 1;
+    for (const key of ['food', 'materials', 'commerce', 'defense', 'charm']) {
+      target[key] += ((source && Number(source[key])) || 0) * f;
+    }
+  }
+
+  function cellKey(cell) {
+    return cell.x + ',' + cell.z;
+  }
+
+  function buildRandomIslandEconomyProfile(data, options = {}) {
+    const cells = Array.isArray(data && data.cells) ? data.cells : [];
+    const seed = String(options.seed || (data && data.seed) || 'tiny-1');
+    const archetypeKey = normalizeArchetype(options.archetype || options.archetypeKey || (data && data.archetypeKey), seed);
+    const statDefs = [
+      { id: 'food', label: 'Food', color: '#219963' },
+      { id: 'materials', label: 'Materials', color: '#7b8794' },
+      { id: 'commerce', label: 'Commerce', color: '#ce8a15' },
+      { id: 'defense', label: 'Defense', color: '#536276' },
+      { id: 'charm', label: 'Charm', color: '#2473e6' },
+    ];
+    const archetypes = {
+      pastoral: { label: 'Pastoral', bestUse: 'Farming and wool', traits: ['Meadow Economy', 'Gentle Terrain'] },
+      forest: { label: 'Forest', bestUse: 'Wood and charm', traits: ['Deep Grove', 'Wood Reserve'] },
+      quarry: { label: 'Quarry', bestUse: 'Materials', traits: ['Stone Veins', 'Rough Ground'] },
+      river: { label: 'River', bestUse: 'Food and trade', traits: ['River Crossing', 'Fresh Water'] },
+      village: { label: 'Village', bestUse: 'Commerce', traits: ['House Cluster', 'Trade Footpaths'] },
+      fortress: { label: 'Fortress', bestUse: 'Defense', traits: ['Watch Posts', 'Guarded Edge'] },
+      ruins: { label: 'Ruins', bestUse: 'Rare traits', traits: ['Ancient Remains', 'Mystic Finds'] },
+      harbor: { label: 'Harbor', bestUse: 'Trade and charm', traits: ['Coastal Trade', 'Open Shore'] },
+    };
+    const archetype = archetypes[archetypeKey] || archetypes.pastoral;
+    const stats = Object.fromEntries(statDefs.map(stat => [stat.id, 0]));
+    const counts = {};
+    const terrains = {};
+    const byCoord = new Map();
+    const synergies = [];
+
+    for (const cell of cells) {
+      if (!cell || !Number.isInteger(cell.x) || !Number.isInteger(cell.z)) continue;
+      byCoord.set(cellKey(cell), cell);
+      terrains[cell.terrain] = (terrains[cell.terrain] || 0) + 1;
+      const id = objectIdForProfile(cell);
+      if (id) counts[id] = (counts[id] || 0) + 1;
+      addStats(stats, terrainStats(cell), 1);
+      addStats(stats, profileObjectStats(id), Math.max(1, Number(cell.floors) || 1) > 1 && id !== 'cow' && id !== 'sheep' ? 1.12 : 1);
+    }
+
+    function cellAt(x, z) {
+      return byCoord.get(x + ',' + z) || null;
+    }
+
+    function neighborsOf(cell) {
+      return [[1, 0], [-1, 0], [0, 1], [0, -1]]
+        .map(([dx, dz]) => cellAt(cell.x + dx, cell.z + dz))
+        .filter(Boolean);
+    }
+
+    function addSynergy(label) {
+      if (!synergies.includes(label)) synergies.push(label);
+    }
+
+    for (const cell of cells) {
+      if (!cell || !Number.isInteger(cell.x) || !Number.isInteger(cell.z)) continue;
+      const id = objectIdForProfile(cell);
+      const nearby = neighborsOf(cell);
+      if (id === 'sheep' && nearby.some(neighbor => neighbor.terrain === 'grass')) {
+        stats.food += 0.8;
+        stats.charm += 0.5;
+        addSynergy('Sheep Meadow');
+      }
+      if (id === 'cow' && nearby.some(neighbor => neighbor.terrain === 'water' || neighbor.terrain === 'grass')) {
+        stats.food += 1.0;
+        addSynergy('Watered Pasture');
+      }
+      if ((id === 'house' || id === 'manor' || id === 'watchtower') && nearby.some(neighbor => neighbor.terrain === 'path')) {
+        stats.commerce += 1.1;
+        addSynergy(id === 'watchtower' ? 'Watch Path' : id === 'manor' ? 'Connected Manor' : 'Connected House');
+      }
+      if (['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'].includes(id) && nearby.some(neighbor => neighbor.terrain === 'water')) {
+        stats.food += 0.9;
+        addSynergy('Irrigated Crops');
+      }
+      if (id === 'stone' && nearby.some(neighbor => objectIdForProfile(neighbor) === 'stone')) {
+        stats.materials += 0.45;
+        addSynergy('Stone Cluster');
+      }
+      if (id === 'lamp-post' && nearby.some(neighbor => neighbor.terrain === 'path')) {
+        stats.commerce += 0.7;
+        stats.charm += 0.4;
+        addSynergy('Lit Footpaths');
+      }
+      if (id === 'tree' && nearby.some(neighbor => neighbor.terrain === 'water' || objectIdForProfile(neighbor) === 'bush')) {
+        stats.charm += 0.7;
+        addSynergy('Green Grove');
+      }
+      if (id === 'bush' && nearby.some(neighbor => objectIdForProfile(neighbor) === 'house' || objectIdForProfile(neighbor) === 'manor' || neighbor.terrain === 'path')) {
+        stats.charm += 0.5;
+        addSynergy('Trimmed Shrubs');
+      }
+    }
+
+    const roundedStats = Object.fromEntries(Object.entries(stats).map(([key, value]) => [key, Number(value.toFixed(1))]));
+    const topStats = statDefs
+      .map(stat => ({ id: stat.id, label: stat.label, color: stat.color, value: roundedStats[stat.id] || 0 }))
+      .sort((a, b) => b.value - a.value);
+    const traits = archetype.traits.slice();
+    if ((counts.sheep || 0) >= 2) traits.push('Sheep Meadows');
+    if ((counts.cow || 0) >= 2) traits.push('Cattle Pasture');
+    if ((counts.stone || 0) >= 4) traits.push('Rich Quarry');
+    if (((counts.house || 0) + (counts.manor || 0)) >= 3) traits.push('House Cluster');
+    if ((counts.manor || 0) >= 1) traits.push('Manor Grounds');
+    if ((counts.watchtower || 0) >= 2) traits.push('Watch Line');
+    if ((counts.bridge || 0) >= 1) traits.push('Bridge Crossing');
+    if ((counts['lamp-post'] || 0) >= 1) traits.push('Lantern Corners');
+    if ((counts.tree || 0) >= 2) traits.push('Tree Grove');
+    if ((counts.bush || 0) >= 2) traits.push('Shrub Border');
+    if ((terrains.water || 0) >= 5) traits.push('Fresh Water');
+    if ((terrains.dirt || 0) >= 4) traits.push('Tended Plots');
+
+    const weighted = roundedStats.food * 1.05
+      + roundedStats.materials * 0.95
+      + roundedStats.commerce * 0.9
+      + Math.min(roundedStats.defense, 28) * 0.65
+      + roundedStats.charm * 0.82;
+    const rarityScore = weighted + synergies.length * 0.9 + traits.length * 1.2;
+    const rarity = rarityScore >= 126 ? 'Legendary'
+      : rarityScore >= 118 ? 'Epic'
+        : rarityScore >= 110 ? 'Rare'
+          : rarityScore >= 96 ? 'Uncommon'
+            : 'Common';
+    const nameRng = seededRandom(seed + '|name|' + archetypeKey);
+    const prefixes = {
+      pastoral: ['Moss', 'Meadow', 'Clover', 'Wool', 'Green'],
+      forest: ['Pine', 'Fern', 'Oak', 'Moss', 'Canopy'],
+      quarry: ['Stone', 'Granite', 'Slate', 'Iron', 'Cliff'],
+      river: ['Brook', 'River', 'Moss', 'Willow', 'Reed'],
+      village: ['Hearth', 'Market', 'Lantern', 'Cottage', 'Moss'],
+      fortress: ['Watch', 'Iron', 'Shield', 'High', 'Stone'],
+      ruins: ['Relic', 'Moon', 'Elder', 'Totem', 'Crystal'],
+      harbor: ['Shoal', 'Salt', 'Dock', 'Tide', 'Harbor'],
+    };
+    const suffixes = ['Hamlet', 'Shoal', 'Rise', 'Watch', 'Crossing', 'Haven', 'Crown', 'Hollow', 'Reach'];
+    const prefixList = prefixes[archetypeKey] || prefixes.pastoral;
+    const name = prefixList[Math.floor(nameRng() * prefixList.length)] + ' ' + suffixes[Math.floor(nameRng() * suffixes.length)];
+    const sampleCells = predicate => cells
+      .filter(cell => cell && Number.isInteger(cell.x) && Number.isInteger(cell.z) && predicate(cell, objectIdForProfile(cell)))
+      .slice(0, 10)
+      .map(cell => ({ x: cell.x, z: cell.z }));
+
+    return {
+      seed,
+      archetypeKey,
+      archetype: archetype.label,
+      bestUse: archetype.bestUse,
+      name,
+      stats: roundedStats,
+      statDefs,
+      counts,
+      terrains,
+      synergyBonus: Number((synergies.length * 0.9).toFixed(1)),
+      synergies: synergies.slice(0, 8),
+      traits: [...new Set(traits)].slice(0, 6),
+      economy: {
+        weighted: Number(weighted.toFixed(1)),
+        traitBonus: Number((traits.length * 1.2).toFixed(1)),
+        potential: Math.max(1, Math.round(rarityScore)),
+        rarityScore: Number(rarityScore.toFixed(1)),
+        rarity,
+        rarityScope: 'archetype',
+      },
+      topStats,
+      highlights: [
+        { id: 'overview', stat: topStats[0].id, cells: sampleCells(() => true) },
+        { id: 'commerce', stat: 'commerce', cells: sampleCells((cell, id) => cell.terrain === 'path' || id === 'house' || id === 'manor' || id === 'watchtower' || id === 'lamp-post') },
+        { id: 'food', stat: 'food', cells: sampleCells((cell, id) => ['wheat', 'corn', 'pumpkin', 'carrot', 'sunflower', 'cow', 'sheep'].indexOf(id) !== -1 || cell.terrain === 'water') },
+        { id: 'materials', stat: 'materials', cells: sampleCells((cell, id) => id === 'stone' || id === 'tree' || cell.terrain === 'stone' || cell.terrain === 'dirt') },
+        { id: 'defense', stat: 'defense', cells: sampleCells((cell, id) => id === 'watchtower' || id === 'fence') },
+        { id: 'charm', stat: 'charm', cells: sampleCells((cell, id) => id === 'sheep' || id === 'lamp-post' || id === 'tree' || id === 'bush' || cell.terrain === 'water') },
+      ],
+    };
+  }
+
+  function generate(options) {
+    return generateRandomIslandWorld(options || {});
+  }
+
+  function profile(world, options) {
+    return buildRandomIslandEconomyProfile(world, options || {});
+  }
+
+  window.TinyWorldIslandGenerator = {
+    generate,
+    generateRandomIslandWorld,
+    buildRandomIslandEconomyProfile,
+    profile,
+  };
+})();

--- a/scripts/island-viewer.js
+++ b/scripts/island-viewer.js
@@ -1,0 +1,433 @@
+(function () {
+  'use strict';
+
+  const GRAPHICS_LS = 'tinyworld:island-viewer:graphics.v1';
+  const VIEWER_LS = 'tinyworld:island-viewer:defaults.v1';
+  const ISLAND_VIEWER_GRID_SIZE = 8;
+  const GRAPHICS_DEFAULTS_VERSION = 2;
+  const ARCHETYPES = ['pastoral', 'forest', 'quarry', 'river', 'village', 'fortress', 'ruins', 'harbor'];
+  const DEFAULT_GRAPHICS = {
+    viewerEffectsVersion: GRAPHICS_DEFAULTS_VERSION,
+    resolution: 0.85,
+    shadow: 'balanced',
+    lighting: 0.92,
+    directionalSun: 1.1,
+    directionalSunAngle: 37,
+    timeCycle: 'fixed',
+    timeOfDay: 720,
+    ambientFill: 0.92,
+    clouds: 0.34,
+    cloudHeight: 10.5,
+    enhancedWater: false,
+    cloudSea: false,
+    distantWorlds: false,
+  };
+  const DEFAULT_VIEWER = {
+    archetype: 'random',
+    gridSize: ISLAND_VIEWER_GRID_SIZE,
+    seed: '',
+  };
+  const state = {
+    ready: false,
+    current: null,
+    renderer: null,
+    graphics: loadGraphicsDefaults(),
+    viewer: loadViewerDefaults(),
+  };
+
+  const el = {
+    newButton: document.getElementById('iv-new'),
+    saveReveal: document.getElementById('iv-save-reveal'),
+    loadButton: document.getElementById('iv-load-button'),
+    loadFile: document.getElementById('iv-load-file'),
+    status: document.getElementById('iv-status'),
+    viewport: document.getElementById('app'),
+    devToggle: document.getElementById('iv-dev-toggle'),
+    devPanel: document.getElementById('iv-dev-panel'),
+    devClose: document.getElementById('iv-dev-close'),
+    devForm: document.getElementById('iv-dev-form'),
+    archetype: document.getElementById('iv-archetype'),
+    gridSize: document.getElementById('iv-grid-size'),
+    seed: document.getElementById('iv-seed'),
+    resolution: document.getElementById('iv-render-resolution'),
+    resolutionValue: document.getElementById('iv-render-resolution-value'),
+    shadow: document.getElementById('iv-shadow-quality'),
+    lighting: document.getElementById('iv-lighting'),
+    lightingValue: document.getElementById('iv-lighting-value'),
+    sun: document.getElementById('iv-sun-strength'),
+    sunValue: document.getElementById('iv-sun-strength-value'),
+    sunAngle: document.getElementById('iv-sun-angle'),
+    sunAngleValue: document.getElementById('iv-sun-angle-value'),
+    timeCycle: document.getElementById('iv-time-cycle'),
+    timeOfDay: document.getElementById('iv-time-of-day'),
+    timeOfDayValue: document.getElementById('iv-time-of-day-value'),
+    ambient: document.getElementById('iv-ambient-fill'),
+    ambientValue: document.getElementById('iv-ambient-fill-value'),
+    clouds: document.getElementById('iv-clouds'),
+    cloudsValue: document.getElementById('iv-clouds-value'),
+    cloudHeight: document.getElementById('iv-cloud-height'),
+    cloudHeightValue: document.getElementById('iv-cloud-height-value'),
+    enhancedWater: document.getElementById('iv-enhanced-water'),
+    cloudSea: document.getElementById('iv-cloud-sea'),
+    distantWorlds: document.getElementById('iv-distant-worlds'),
+    applyDefaults: document.getElementById('iv-apply-defaults'),
+    saveDefaults: document.getElementById('iv-save-defaults'),
+    resetDefaults: document.getElementById('iv-reset-defaults'),
+  };
+
+  function randomChoice(values) {
+    return values[Math.floor(Math.random() * values.length)];
+  }
+
+  function randomIslandSeed() {
+    const labels = ['mossgate', 'stonefall', 'cloverdock', 'pinewatch', 'saltmeadow', 'relicshoal', 'lanternbay', 'crownmeadow'];
+    const n = Math.floor(Math.random() * 90000) + 10000;
+    return randomChoice(labels) + '-' + n;
+  }
+
+  function slug(value) {
+    const clean = String(value || 'island').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    return clean || 'island';
+  }
+
+  function clampNumber(value, fallback, min, max) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.max(min, Math.min(max, n));
+  }
+
+  function formatTimeOfDay(value) {
+    const total = Math.round(clampNumber(value, DEFAULT_GRAPHICS.timeOfDay, 0, 1439));
+    const h = String(Math.floor(total / 60) % 24).padStart(2, '0');
+    const m = String(total % 60).padStart(2, '0');
+    return h + ':' + m;
+  }
+
+  function loadJsonStorage(key, fallback) {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(key) || 'null');
+      return parsed && typeof parsed === 'object' ? parsed : fallback;
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  function normalizeGraphics(value) {
+    const raw = value || {};
+    const source = Object.assign({}, DEFAULT_GRAPHICS, raw);
+    const stableEffects = raw.viewerEffectsVersion === GRAPHICS_DEFAULTS_VERSION;
+    return {
+      viewerEffectsVersion: GRAPHICS_DEFAULTS_VERSION,
+      resolution: clampNumber(source.resolution, DEFAULT_GRAPHICS.resolution, 0.5, 1.25),
+      shadow: ['low', 'balanced', 'high'].includes(source.shadow) ? source.shadow : DEFAULT_GRAPHICS.shadow,
+      lighting: clampNumber(source.lighting, DEFAULT_GRAPHICS.lighting, 0.5, 5),
+      directionalSun: clampNumber(source.directionalSun, DEFAULT_GRAPHICS.directionalSun, 0, 10),
+      directionalSunAngle: Math.round(clampNumber(source.directionalSunAngle, DEFAULT_GRAPHICS.directionalSunAngle, 0, 359)),
+      timeCycle: ['live', 'fixed'].includes(source.timeCycle) ? source.timeCycle : DEFAULT_GRAPHICS.timeCycle,
+      timeOfDay: Math.round(clampNumber(source.timeOfDay, DEFAULT_GRAPHICS.timeOfDay, 0, 1439)),
+      ambientFill: clampNumber(source.ambientFill, DEFAULT_GRAPHICS.ambientFill, 0, 5),
+      clouds: clampNumber(source.clouds, DEFAULT_GRAPHICS.clouds, 0, 1),
+      cloudHeight: clampNumber(source.cloudHeight, DEFAULT_GRAPHICS.cloudHeight, 9, 16),
+      enhancedWater: stableEffects && source.enhancedWater === true,
+      cloudSea: stableEffects && source.cloudSea === true,
+      distantWorlds: stableEffects && source.distantWorlds === true,
+    };
+  }
+
+  function normalizeViewer(value) {
+    const source = Object.assign({}, DEFAULT_VIEWER, value || {});
+    const archetype = String(source.archetype || 'random').trim().toLowerCase();
+    return {
+      archetype: archetype === 'random' || ARCHETYPES.includes(archetype) ? archetype : 'random',
+      gridSize: ISLAND_VIEWER_GRID_SIZE,
+      seed: String(source.seed || '').trim(),
+    };
+  }
+
+  function loadGraphicsDefaults() {
+    return normalizeGraphics(loadJsonStorage(GRAPHICS_LS, DEFAULT_GRAPHICS));
+  }
+
+  function loadViewerDefaults() {
+    return normalizeViewer(loadJsonStorage(VIEWER_LS, DEFAULT_VIEWER));
+  }
+
+  function saveDefaults() {
+    localStorage.setItem(GRAPHICS_LS, JSON.stringify(state.graphics));
+    localStorage.setItem(VIEWER_LS, JSON.stringify(state.viewer));
+  }
+
+  function setStatus(text) {
+    el.status.textContent = text || '';
+  }
+
+  function localDevEnabled() {
+    const host = location.hostname;
+    if (location.search.includes('viewerDev=1')) return true;
+    return location.protocol === 'file:' || host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+  }
+
+  function syncDevForm() {
+    if (!el.devForm) return;
+    el.archetype.value = state.viewer.archetype;
+    el.gridSize.value = String(state.viewer.gridSize);
+    el.seed.value = state.viewer.seed || '';
+    el.resolution.value = String(Math.round(state.graphics.resolution * 100));
+    el.shadow.value = state.graphics.shadow;
+    el.lighting.value = String(Math.round(state.graphics.lighting * 100));
+    el.sun.value = String(Math.round(state.graphics.directionalSun * 100));
+    el.sunAngle.value = String(Math.round(state.graphics.directionalSunAngle));
+    el.timeCycle.value = state.graphics.timeCycle;
+    el.timeOfDay.value = String(Math.round(state.graphics.timeOfDay));
+    el.ambient.value = String(Math.round(state.graphics.ambientFill * 100));
+    el.clouds.value = String(Math.round(state.graphics.clouds * 100));
+    el.cloudHeight.value = String(state.graphics.cloudHeight);
+    el.enhancedWater.checked = !!state.graphics.enhancedWater;
+    el.cloudSea.checked = !!state.graphics.cloudSea;
+    el.distantWorlds.checked = !!state.graphics.distantWorlds;
+    paintDevReadouts();
+  }
+
+  function paintDevReadouts() {
+    if (el.resolutionValue) el.resolutionValue.textContent = el.resolution.value + '%';
+    if (el.lightingValue) el.lightingValue.textContent = el.lighting.value + '%';
+    if (el.sunValue) el.sunValue.textContent = el.sun.value + '%';
+    if (el.sunAngleValue) el.sunAngleValue.textContent = el.sunAngle.value + 'deg';
+    if (el.timeOfDayValue) el.timeOfDayValue.textContent = formatTimeOfDay(el.timeOfDay.value);
+    if (el.ambientValue) el.ambientValue.textContent = el.ambient.value + '%';
+    if (el.cloudsValue) el.cloudsValue.textContent = el.clouds.value + '%';
+    if (el.cloudHeightValue) el.cloudHeightValue.textContent = el.cloudHeight.value;
+  }
+
+  function readDevForm() {
+    state.viewer = normalizeViewer({
+      archetype: el.archetype.value,
+      gridSize: ISLAND_VIEWER_GRID_SIZE,
+      seed: el.seed.value,
+    });
+    state.graphics = normalizeGraphics({
+      resolution: Number(el.resolution.value) / 100,
+      shadow: el.shadow.value,
+      lighting: Number(el.lighting.value) / 100,
+      directionalSun: Number(el.sun.value) / 100,
+      directionalSunAngle: Number(el.sunAngle.value),
+      timeCycle: el.timeCycle.value,
+      timeOfDay: Number(el.timeOfDay.value),
+      ambientFill: Number(el.ambient.value) / 100,
+      clouds: Number(el.clouds.value) / 100,
+      cloudHeight: Number(el.cloudHeight.value),
+      enhancedWater: el.enhancedWater.checked,
+      cloudSea: el.cloudSea.checked,
+      distantWorlds: el.distantWorlds.checked,
+    });
+    paintDevReadouts();
+  }
+
+  function ensureRenderer() {
+    if (state.renderer) return state.renderer;
+    if (!window.TinyWorldIslandRenderer || !window.TinyWorldIslandGenerator) {
+      throw new Error('Island Viewer runtime did not load.');
+    }
+    state.renderer = window.TinyWorldIslandRenderer.mount(el.viewport, { graphics: state.graphics });
+    return state.renderer;
+  }
+
+  function currentProfileFor(world, meta) {
+    if (meta && meta.profile) return meta.profile;
+    const G = window.TinyWorldIslandGenerator;
+    return G && typeof G.profile === 'function'
+      ? G.profile(world, { seed: state.current && state.current.seed, archetype: state.current && state.current.archetype })
+      : null;
+  }
+
+  function applyGraphics() {
+    if (!state.renderer) return;
+    state.renderer.applyGraphics(state.graphics);
+  }
+
+  function commitDevDefaults(opts = {}) {
+    const persist = opts.persist !== false;
+    const apply = opts.apply !== false;
+    readDevForm();
+    if (persist) saveDefaults();
+    if (apply) applyGraphics();
+  }
+
+  function downloadJson(filename, value) {
+    const blob = new Blob([JSON.stringify(value, null, 2) + '\n'], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 200);
+  }
+
+  function saveCurrent() {
+    if (!state.current || !state.current.world) {
+      setStatus('The rendered island is not ready yet.');
+      return;
+    }
+    const exported = state.renderer ? state.renderer.exportWorld() : state.current.world;
+    const profile = state.current.profile || currentProfileFor(exported, {});
+    const name = profile && profile.name || 'island';
+    downloadJson('tinyworld-island-' + slug(name) + '-reveal.json', {
+      type: 'tinyworld.islandViewerReveal',
+      version: 1,
+      savedAt: new Date().toISOString(),
+      seed: state.current.seed || '',
+      archetype: state.current.archetype || '',
+      world: exported,
+      profile,
+      viewerGraphics: state.graphics,
+    });
+    setStatus('Saved island reveal file from the standalone viewer.');
+  }
+
+  function renderWorld(world, meta = {}) {
+    const renderer = ensureRenderer();
+    const profile = currentProfileFor(world, meta);
+    renderer.loadWorld(world, { profile, graphics: state.graphics });
+    state.ready = true;
+    state.current = {
+      seed: meta.seed || '',
+      archetype: meta.archetype || '',
+      world: renderer.exportWorld(),
+      profile,
+    };
+    setStatus(profile && profile.name ? 'Viewing ' + profile.name + '.' : 'Island Viewer is ready.');
+  }
+
+  function generateIsland(opts = {}) {
+    if (el.devForm) readDevForm();
+    const G = window.TinyWorldIslandGenerator;
+    if (!G || typeof G.generate !== 'function') {
+      setStatus('Random island generator is unavailable.');
+      return;
+    }
+    const archetype = opts.archetype || state.viewer.archetype || 'random';
+    const seed = opts.seed || state.viewer.seed || randomIslandSeed();
+    state.viewer.seed = seed;
+    syncDevForm();
+    setStatus(archetype === 'random' ? 'Rendering a random island...' : 'Rendering ' + archetype + ' island...');
+    try { localStorage.setItem(GRAPHICS_LS, JSON.stringify(state.graphics)); } catch (_) {}
+    const world = window.TinyWorldIslandGenerator.generate({ seed, archetype, gridSize: ISLAND_VIEWER_GRID_SIZE });
+    const profile = G.profile(world, { seed, archetype });
+    renderWorld(world, { seed, archetype, profile });
+  }
+
+  function loadPayload(payload) {
+    if (payload && payload.viewerGraphics) {
+      state.graphics = normalizeGraphics(payload.viewerGraphics);
+      syncDevForm();
+      saveDefaults();
+    }
+    const source = payload && payload.type === 'tinyworld.islandViewerReveal' ? payload.world
+      : payload && payload.type === 'tinyworld.randomIslandReveal' ? payload.world
+        : payload;
+    const seed = String(payload && payload.seed || '').trim();
+    const archetype = String(payload && (payload.archetype || payload.archetypeKey) || '').trim().toLowerCase();
+    renderWorld(source, {
+      seed,
+      archetype,
+      profile: payload && payload.profile,
+    });
+  }
+
+  function readSelectedFile(file) {
+    const reader = new FileReader();
+    reader.onload = function () {
+      try {
+        loadPayload(JSON.parse(String(reader.result || '')));
+      } catch (err) {
+        console.error(err);
+        setStatus(err && err.message ? err.message : 'Could not load island file.');
+      }
+    };
+    reader.onerror = function () {
+      setStatus('Could not read island file.');
+    };
+    reader.readAsText(file);
+  }
+
+  el.newButton.addEventListener('click', function () {
+    generateIsland({ seed: randomIslandSeed() });
+  });
+  el.saveReveal.addEventListener('click', saveCurrent);
+  el.loadButton.addEventListener('click', function () {
+    el.loadFile.click();
+  });
+  el.loadFile.addEventListener('change', function () {
+    const file = el.loadFile.files && el.loadFile.files[0];
+    if (file) readSelectedFile(file);
+    el.loadFile.value = '';
+  });
+
+  if (localDevEnabled() && el.devToggle && el.devPanel) {
+    el.devToggle.hidden = false;
+    el.devToggle.addEventListener('click', function () {
+      el.devPanel.hidden = !el.devPanel.hidden;
+      syncDevForm();
+    });
+  }
+  if (el.devClose) {
+    el.devClose.addEventListener('click', function () {
+      el.devPanel.hidden = true;
+    });
+  }
+  if (el.devForm) {
+    const updateDevDefaults = function () {
+      commitDevDefaults();
+    };
+    const liveDefaultsControls = [
+      el.archetype,
+      el.gridSize,
+      el.seed,
+      el.resolution,
+      el.shadow,
+      el.lighting,
+      el.sun,
+      el.sunAngle,
+      el.timeCycle,
+      el.timeOfDay,
+      el.ambient,
+      el.clouds,
+      el.cloudHeight,
+      el.enhancedWater,
+      el.cloudSea,
+      el.distantWorlds,
+    ].filter(Boolean);
+    liveDefaultsControls.forEach(control => {
+      control.addEventListener('input', updateDevDefaults);
+      control.addEventListener('change', updateDevDefaults);
+    });
+  }
+  if (el.applyDefaults) {
+    el.applyDefaults.addEventListener('click', function () {
+      commitDevDefaults();
+      setStatus('Applied island viewer graphics defaults.');
+    });
+  }
+  if (el.saveDefaults) {
+    el.saveDefaults.addEventListener('click', function () {
+      commitDevDefaults();
+      setStatus('Saved island viewer defaults for this browser.');
+    });
+  }
+  if (el.resetDefaults) {
+    el.resetDefaults.addEventListener('click', function () {
+      state.graphics = normalizeGraphics(DEFAULT_GRAPHICS);
+      state.viewer = normalizeViewer(DEFAULT_VIEWER);
+      syncDevForm();
+      saveDefaults();
+      applyGraphics();
+      setStatus('Reset island viewer defaults.');
+    });
+  }
+
+  syncDevForm();
+  if (!state.viewer.seed) state.viewer.seed = randomIslandSeed();
+  generateIsland();
+})();

--- a/styles/island-viewer.css
+++ b/styles/island-viewer.css
@@ -1,0 +1,315 @@
+:root {
+  color-scheme: light;
+  --iv-ink: #172133;
+  --iv-muted: #5a687a;
+  --iv-line: rgba(44, 58, 80, 0.16);
+  --iv-panel: rgba(255, 255, 255, 0.82);
+  --iv-blue: #276ad8;
+  --iv-shadow: 0 18px 60px -34px rgba(20, 32, 52, 0.72);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  color: var(--iv-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(180deg, rgba(237, 244, 246, 0.88), rgba(226, 235, 230, 0.96)),
+    #edf2f0;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+select,
+input {
+  border-radius: 8px;
+}
+
+button {
+  min-height: 38px;
+  border: 1px solid var(--iv-line);
+  color: #223047;
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.82) inset;
+  padding: 0 13px;
+  font-weight: 760;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #fff;
+}
+
+button:disabled {
+  cursor: default;
+  opacity: 0.48;
+}
+
+.iv-primary {
+  border-color: rgba(39, 106, 216, 0.32);
+  color: #fff;
+  background: var(--iv-blue);
+  box-shadow: 0 12px 26px -18px rgba(39, 106, 216, 0.85);
+}
+
+.iv-primary:hover {
+  background: #1f5fc5;
+}
+
+.iv-shell {
+  width: 100%;
+  height: 100%;
+  padding: 12px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 10px;
+}
+
+.iv-topbar,
+.iv-frame-wrap,
+.iv-dev-panel {
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 8px;
+  background: var(--iv-panel);
+  box-shadow: var(--iv-shadow);
+  backdrop-filter: blur(18px) saturate(160%);
+  -webkit-backdrop-filter: blur(18px) saturate(160%);
+}
+
+.iv-topbar {
+  position: relative;
+  z-index: 2;
+  min-height: 62px;
+  padding: 10px 12px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+}
+
+.iv-brand h1,
+.iv-dev-head h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 27px;
+  line-height: 1;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.iv-dev-head h2 {
+  font-size: 24px;
+}
+
+.iv-kicker,
+.iv-dev-grid label span {
+  display: block;
+  color: var(--iv-muted);
+  font-size: 10px;
+  font-weight: 820;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.iv-status {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  color: var(--iv-muted);
+  font-size: 13px;
+  line-height: 1.35;
+  min-width: 0;
+}
+
+.iv-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.iv-frame-wrap {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: #dfe8e7;
+}
+
+#app canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.iv-frame-wrap canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #dfe8e7;
+}
+
+.iv-frame-wrap noscript {
+  display: grid;
+  height: 100%;
+  place-items: center;
+  color: var(--iv-muted);
+  font-weight: 760;
+}
+
+.iv-dev-panel {
+  position: fixed;
+  top: 84px;
+  right: 12px;
+  z-index: 20;
+  width: min(560px, calc(100vw - 24px));
+  max-height: calc(100vh - 104px);
+  overflow: auto;
+  padding: 14px;
+}
+
+.iv-dev-panel[hidden] {
+  display: none;
+}
+
+.iv-dev-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.iv-dev-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.iv-dev-grid label {
+  display: grid;
+  gap: 5px;
+}
+
+.iv-dev-grid .iv-wide {
+  grid-column: 1 / -1;
+}
+
+.iv-dev-grid select,
+.iv-dev-grid input[type="text"],
+.iv-dev-grid input[type="range"] {
+  width: 100%;
+}
+
+.iv-dev-grid select,
+.iv-dev-grid input[type="text"] {
+  height: 38px;
+  border: 1px solid var(--iv-line);
+  background: rgba(255, 255, 255, 0.84);
+  color: #223047;
+  padding: 0 10px;
+}
+
+.iv-dev-grid input[type="range"] {
+  accent-color: var(--iv-blue);
+}
+
+.iv-dev-grid output {
+  min-height: 14px;
+  color: var(--iv-muted);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.iv-dev-checks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  margin: 14px 0;
+  color: #26364f;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.iv-dev-checks label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.iv-dev-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+@media (max-width: 880px) {
+  html,
+  body {
+    overflow: auto;
+  }
+
+  .iv-shell {
+    min-height: 100%;
+    height: auto;
+  }
+
+  .iv-topbar {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .iv-actions {
+    flex-wrap: wrap;
+  }
+
+  .iv-frame-wrap {
+    height: min(760px, calc(100vh - 168px));
+    min-height: 520px;
+  }
+
+  .iv-dev-panel {
+    top: 8px;
+    right: 8px;
+    width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+  }
+}
+
+@media (max-width: 620px) {
+  .iv-shell {
+    padding: 8px;
+  }
+
+  .iv-brand h1 {
+    font-size: 28px;
+  }
+
+  .iv-dev-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .iv-dev-actions {
+    justify-content: stretch;
+    flex-direction: column;
+  }
+
+  .iv-frame-wrap {
+    height: min(760px, calc(100vh - 230px));
+    min-height: 460px;
+  }
+}

--- a/tests/island-viewer-grid-size.test.mjs
+++ b/tests/island-viewer-grid-size.test.mjs
@@ -1,0 +1,396 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const shell = fs.readFileSync(path.join(root, 'island-viewer.html'), 'utf8');
+const controller = fs.readFileSync(path.join(root, 'scripts/island-viewer.js'), 'utf8');
+const generator = fs.readFileSync(path.join(root, 'scripts/island-viewer-sequential-generator.js'), 'utf8');
+const runtime = fs.readFileSync(path.join(root, 'scripts/island-viewer-engine-runtime.js'), 'utf8');
+const prelude = fs.readFileSync(path.join(root, 'scripts/island-viewer-engine-prelude.js'), 'utf8');
+
+function loadIslandGenerator() {
+  const sandboxWindow = {};
+  const factory = new Function('window', generator + '\nreturn window;');
+  return factory(sandboxWindow);
+}
+
+function loadIslandRuntime() {
+  const sandboxWindow = {};
+  const factory = new Function('window', runtime + '\nreturn window;');
+  return factory(sandboxWindow);
+}
+
+function cellAt(world, x, z) {
+  return world.cells.find(cell => cell.x === x && cell.z === z) || null;
+}
+
+function isPath(cell) {
+  return !!(cell && cell.terrain === 'path');
+}
+
+function isWater(cell) {
+  return !!(cell && cell.terrain === 'water');
+}
+
+function manhattan(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.z - b.z);
+}
+
+function perpendicularPathCornerSides(world, cell) {
+  const sides = [
+    ['n', cellAt(world, cell.x, cell.z - 1)],
+    ['e', cellAt(world, cell.x + 1, cell.z)],
+    ['s', cellAt(world, cell.x, cell.z + 1)],
+    ['w', cellAt(world, cell.x - 1, cell.z)],
+  ].filter(([, neighbor]) => isPath(neighbor)).map(([side]) => side);
+  if (sides.length !== 2) return null;
+  if ((sides.includes('n') && sides.includes('s')) || (sides.includes('e') && sides.includes('w'))) return null;
+  return sides;
+}
+
+function doorSideForCell(cell) {
+  const value = Number(cell && cell.transform && cell.transform.rotationY);
+  if (Math.abs(value - Math.PI) < 0.0001) return 'n';
+  if (Math.abs(value - Math.PI / 2) < 0.0001) return 'e';
+  if (Math.abs(value + Math.PI / 2) < 0.0001) return 'w';
+  return 's';
+}
+
+function frontCell(world, cell) {
+  const side = doorSideForCell(cell);
+  if (side === 'n') return cellAt(world, cell.x, cell.z - 1);
+  if (side === 'e') return cellAt(world, cell.x + 1, cell.z);
+  if (side === 'w') return cellAt(world, cell.x - 1, cell.z);
+  return cellAt(world, cell.x, cell.z + 1);
+}
+
+function connectedPathSize(world, start) {
+  if (!isPath(start)) return 0;
+  const queue = [start];
+  const seen = new Set([start.x + ',' + start.z]);
+  while (queue.length) {
+    const current = queue.shift();
+    for (const neighbor of [
+      cellAt(world, current.x + 1, current.z),
+      cellAt(world, current.x - 1, current.z),
+      cellAt(world, current.x, current.z + 1),
+      cellAt(world, current.x, current.z - 1),
+    ]) {
+      if (!isPath(neighbor)) continue;
+      const key = neighbor.x + ',' + neighbor.z;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      queue.push(neighbor);
+    }
+  }
+  return seen.size;
+}
+
+function manorReservedKeys(world) {
+  const keys = new Set();
+  for (const manor of world.cells.filter(cell => cell.kind === 'house' && cell.buildingType === 'manor')) {
+    const side = doorSideForCell(manor);
+    const offsets = side === 'n' ? { back: [0, 1], lateral: [1, 0] }
+      : side === 'e' ? { back: [-1, 0], lateral: [0, 1] }
+        : side === 'w' ? { back: [1, 0], lateral: [0, 1] }
+          : { back: [0, -1], lateral: [1, 0] };
+    for (const lateral of [-1, 0, 1]) {
+      for (const depth of [0, 1]) {
+        const x = manor.x + offsets.lateral[0] * lateral + offsets.back[0] * depth;
+        const z = manor.z + offsets.lateral[1] * lateral + offsets.back[1] * depth;
+        keys.add(x + ',' + z);
+      }
+    }
+  }
+  return keys;
+}
+
+function isOrdinaryEmptyLand(cell) {
+  return !!(cell
+    && cell.terrain === 'grass'
+    && cell.kind === null
+    && (!Array.isArray(cell.extras) || cell.extras.length === 0));
+}
+
+const VIEWER_CROP_KINDS = ['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'];
+
+test('Island Viewer is standalone and does not embed the builder runtime', () => {
+  assert.doesNotMatch(shell, /<iframe\b/);
+  assert.doesNotMatch(shell, /tiny-world-builder/);
+  assert.doesNotMatch(shell, /tiny-world-builder\.html|engine\/world\/(?:18|19|20|21|22|24|25|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60|61|62|63|64|65|67|68|69|70|99)-/);
+  assert.doesNotMatch(controller, /postMessage|contentWindow|iv-frame|tiny-world-builder/);
+  assert.match(shell, /id="app"/);
+  assert.match(shell, /scripts\/island-viewer-sequential-generator\.js/);
+  assert.match(shell, /scripts\/island-viewer-engine-prelude\.js/);
+  assert.match(shell, /scripts\/island-viewer-engine-runtime\.js/);
+  assert.match(shell, /engine\/world\/17-tile-renderers\.js/);
+  assert.doesNotMatch(shell, /scripts\/tinyworld-island-core\.js/);
+  assert.doesNotMatch(shell, /scripts\/island-viewer-renderer\.js/);
+  assert.doesNotMatch(shell, /09-model-stamp-loader\.js/);
+  assert.doesNotMatch(shell, /14-editable-islands-moorings\.js/);
+  assert.doesNotMatch(shell, /26-ai-generation\.js/);
+  assert.match(prelude, /cellDisplayPointForCell/);
+  assert.match(prelude, /cellRenderPositionForCell/);
+  assert.match(prelude, /cellRenderParentForCell/);
+  assert.match(prelude, /stampCellUserData/);
+  assert.match(controller, /TinyWorldIslandRenderer\.mount\(el\.viewport/);
+  assert.match(controller, /TinyWorldIslandGenerator\.generate/);
+});
+
+test('Island Viewer generated islands are locked to 8x8', () => {
+  assert.match(controller, /const ISLAND_VIEWER_GRID_SIZE = 8;/);
+  assert.match(controller, /gridSize: ISLAND_VIEWER_GRID_SIZE,/);
+  assert.match(controller, /gridSize: ISLAND_VIEWER_GRID_SIZE \}/);
+  assert.doesNotMatch(controller, /gridSize:\s*12/);
+
+  assert.match(shell, /<option value="8">8 x 8<\/option>/);
+  assert.doesNotMatch(shell, /<option value="(?:10|12|16|20)">/);
+
+  const api = loadIslandGenerator().TinyWorldIslandGenerator;
+  const world = api.generate({ seed: 'locked-grid', archetype: 'harbor', gridSize: 20 });
+  assert.equal(world.gridSize, 8);
+  assert.equal(world.cells.length, 64);
+});
+
+test('Island Viewer load/export normalization accepts wrapper and raw v4 JSON', () => {
+  const api = loadIslandRuntime().TinyWorldIslandRenderer;
+  const raw = { v: 4, gridSize: 20, cells: [[0, 0, 'water'], [1, 1, 'sand'], { x: 2, z: 2, terrain: 'grass', path: true }, [7, 7, 'stone', 'rock'], [12, 12, 'lava']] };
+  const rawNormalized = api.normalizeWorld(raw);
+  assert.equal(rawNormalized.v, 4);
+  assert.equal(rawNormalized.gridSize, 8);
+  assert.equal(rawNormalized.cells.length, 64);
+  assert.ok(rawNormalized.cells.some(cell => cell.x === 0 && cell.z === 0 && cell.terrain === 'water'));
+  assert.equal(rawNormalized.cells.find(cell => cell.x === 1 && cell.z === 1).terrain, 'grass');
+  assert.equal(rawNormalized.cells.find(cell => cell.x === 2 && cell.z === 2).terrain, 'path');
+  assert.equal(rawNormalized.cells.some(cell => cell.terrain === 'sand'), false);
+  assert.ok(rawNormalized.cells.some(cell => cell.x === 7 && cell.z === 7 && cell.kind === 'rock'));
+  assert.equal(rawNormalized.cells.some(cell => cell.x === 12 || cell.z === 12), false);
+
+  const wrapped = api.normalizeWorld({
+    type: 'tinyworld.islandViewerReveal',
+    world: raw,
+    viewerGraphics: { timeCycle: 'fixed', timeOfDay: 720 },
+  });
+  assert.deepEqual(wrapped, rawNormalized);
+});
+
+test('Island Viewer graphics defaults are viewer scoped and fixed high noon', () => {
+  const api = loadIslandRuntime().TinyWorldIslandRenderer;
+  const graphics = api.normalizeGraphics({ lighting: 9, directionalSun: 20, ambientFill: 7, timeCycle: 'fixed', timeOfDay: 720 });
+  assert.equal(graphics.lighting, 5);
+  assert.equal(graphics.directionalSun, 10);
+  assert.equal(graphics.ambientFill, 5);
+  assert.equal(api.defaults.graphics.timeCycle, 'fixed');
+  assert.equal(api.defaults.graphics.timeOfDay, 720);
+  assert.equal(api.defaults.graphics.viewerEffectsVersion, 2);
+  assert.equal(api.defaults.graphics.enhancedWater, false);
+  assert.equal(api.defaults.graphics.cloudSea, false);
+  assert.equal(api.defaults.graphics.distantWorlds, false);
+  assert.equal(api.normalizeGraphics({ enhancedWater: true, cloudSea: true, distantWorlds: true }).enhancedWater, false);
+  assert.equal(api.normalizeGraphics({ viewerEffectsVersion: 2, enhancedWater: true }).enhancedWater, true);
+
+  assert.match(runtime, /function clearViewerWorld\(\)/);
+  assert.match(runtime, /clearViewerWorld\(\);\s*for \(const cell of normalized\.cells\) applyCell\(cell, false\);/);
+  assert.match(runtime, /if \(cell\.path === true && terrain !== 'water'\) terrain = 'path';/);
+  assert.doesNotMatch(runtime, /path: cell\.path|path: false/);
+
+  assert.match(controller, /const GRAPHICS_LS = 'tinyworld:island-viewer:graphics\.v1'/);
+  assert.match(controller, /const VIEWER_LS = 'tinyworld:island-viewer:defaults\.v1'/);
+  assert.match(controller, /const GRAPHICS_DEFAULTS_VERSION = 2;/);
+  assert.match(controller, /enhancedWater: false/);
+  assert.match(controller, /cloudSea: false/);
+  assert.match(controller, /distantWorlds: false/);
+  assert.match(controller, /generateIsland\(\{ seed: randomIslandSeed\(\) \}\)/);
+  assert.doesNotMatch(controller, /tinyworld:render:|tinyworld:crowd:|tinyworld:view\.camera|localStorage\.setItem\('tinyworld:/);
+});
+
+test('Island Viewer sequential generator emits v4 islands without legacy bridge metadata', () => {
+  assert.doesNotMatch(generator, /water-bridge|bridgeAxis/);
+  const api = loadIslandGenerator().TinyWorldIslandGenerator;
+  for (const archetype of ['pastoral', 'river', 'harbor', 'village']) {
+    const world = api.generate({ seed: 'sequential-' + archetype, archetype, gridSize: 20 });
+    const profile = api.profile(world, { seed: 'sequential-' + archetype, archetype });
+    const serialized = JSON.stringify({ world, profile });
+    assert.equal(world.v, 4);
+    assert.equal(world.gridSize, 8);
+    assert.equal(world.cells.length, 64);
+    assert.equal(world.cells.some(cell => cell.terrain === 'water'), true);
+    assert.equal(world.cells.some(cell => cell.terrain === 'path'), true);
+    assert.equal(world.cells.some(cell => Object.prototype.hasOwnProperty.call(cell, 'path')), false);
+    assert.doesNotMatch(serialized, /water-bridge|bridgeAxis/);
+    assert.ok(profile && profile.name && profile.stats && profile.economy);
+  }
+});
+
+test('Island Viewer bridge detector only marks path-water-path centers', () => {
+  assert.match(generator, /function pathWaterPathBridgeAxis\(cells, index\)/);
+  assert.match(generator, /function placePathWaterPathBridgesLayer\(cells\)/);
+  assert.match(generator, /placePathWaterPathBridgesLayer\(cells\);/);
+  const api = loadIslandGenerator().TinyWorldIslandGenerator;
+  let sawBridge = false;
+  for (let i = 0; i < 180; i++) {
+    const seed = 'viewer-bridge-pattern-' + i;
+    const world = api.generate({ seed, archetype: 'river', gridSize: 8 });
+    for (const bridge of world.cells.filter(cell => cell.kind === 'bridge')) {
+      sawBridge = true;
+      assert.equal(bridge.terrain, 'water', 'bridge center must stay water for seed ' + seed);
+      const west = cellAt(world, bridge.x - 1, bridge.z);
+      const east = cellAt(world, bridge.x + 1, bridge.z);
+      const north = cellAt(world, bridge.x, bridge.z - 1);
+      const south = cellAt(world, bridge.x, bridge.z + 1);
+      const eastWestBridge = isPath(west) && isPath(east) && isWater(north) && isWater(south);
+      const northSouthBridge = isPath(north) && isPath(south) && isWater(west) && isWater(east);
+      assert.equal(eastWestBridge !== northSouthBridge, true, 'bridge must be the center of one unambiguous path-water-path crossing for seed ' + seed + ' at ' + bridge.x + ',' + bridge.z);
+      assert.equal(isPath(west) && isPath(east) && (isPath(north) || isPath(south)), false, 'east-west bridge must not have perpendicular path neighbors for seed ' + seed);
+      assert.equal(isPath(north) && isPath(south) && (isPath(west) || isPath(east)), false, 'north-south bridge must not have perpendicular path neighbors for seed ' + seed);
+    }
+  }
+  assert.equal(sawBridge, true, 'seed sample should include at least one detected path-water-path bridge');
+});
+
+test('Island Viewer lanterns only occupy sparse inside path corners', () => {
+  assert.match(generator, /function placeStrategicLampLayer\(cells, seed\)/);
+  assert.match(generator, /function lampCornerSides\(cells, index\)/);
+  assert.match(generator, /placeStrategicLampLayer\(cells, seed\);/);
+  assert.match(generator, /return placed\.every\(other => distanceBetween\(other, index\) > 3\);/);
+  const api = loadIslandGenerator().TinyWorldIslandGenerator;
+  let sawLamp = false;
+  for (let i = 0; i < 180; i++) {
+    const seed = 'viewer-lantern-corners-' + i;
+    const world = api.generate({ seed, archetype: 'village', gridSize: 8 });
+    const lamps = world.cells.filter(cell => cell.kind === 'lamp-post');
+    if (lamps.length) sawLamp = true;
+    for (const lamp of lamps) {
+      assert.equal(lamp.terrain, 'grass', 'lamp must be placed on grass for seed ' + seed);
+      assert.ok(perpendicularPathCornerSides(world, lamp), 'lamp must sit inside a perpendicular path corner for seed ' + seed + ' at ' + lamp.x + ',' + lamp.z);
+    }
+    for (let a = 0; a < lamps.length; a++) {
+      for (let b = a + 1; b < lamps.length; b++) {
+        assert.ok(manhattan(lamps[a], lamps[b]) > 3, 'lamps must not be within 3 spaces for seed ' + seed);
+      }
+    }
+  }
+  assert.equal(sawLamp, true, 'seed sample should include at least one strategic lantern');
+});
+
+test('Island Viewer manor is a rare connected footprint building', () => {
+  assert.match(generator, /function manorFootprintIndexes\(anchorIndex, doorSide\)/);
+  assert.match(generator, /function routeManorDoorToPath\(cells, startIndex, blocked\)/);
+  assert.match(generator, /function placeManorLayer\(cells, seed\)/);
+  assert.match(generator, /plainHouseIndexes\(cells\)\.length < 3/);
+  assert.match(generator, /seededRandom\(String\(seed\) \+ '\|manor-chance'\)\(\) >= 0\.25/);
+  assert.match(generator, /placeManorLayer\(cells, seed\);\s*placeFencedCropAreaLayer/);
+  const api = loadIslandGenerator().TinyWorldIslandGenerator;
+  let eligible = 0;
+  let sawManor = false;
+  for (let i = 0; i < 320; i++) {
+    const seed = 'viewer-manor-footprint-' + i;
+    const world = api.generate({ seed, archetype: 'village', gridSize: 8 });
+    const plainHouses = world.cells.filter(cell => cell.kind === 'house' && !cell.buildingType);
+    const manors = world.cells.filter(cell => cell.kind === 'house' && cell.buildingType === 'manor');
+    if (plainHouses.length >= 3) eligible++;
+    assert.ok(manors.length <= 1, 'manor should be at most one per island for seed ' + seed);
+    for (const manor of manors) {
+      sawManor = true;
+      assert.ok(plainHouses.length >= 3, 'manor should only appear once three normal houses exist for seed ' + seed);
+      assert.equal(manor.floors, 2);
+      const front = frontCell(world, manor);
+      assert.equal(isPath(front), true, 'manor door front must be path for seed ' + seed + ' at ' + manor.x + ',' + manor.z);
+      assert.ok(connectedPathSize(world, front) > 1, 'manor door path must connect into the existing path network for seed ' + seed);
+    }
+  }
+  assert.ok(eligible > 0, 'seed sample should include manor-eligible islands');
+  assert.equal(sawManor, true, 'seed sample should include a rare manor');
+});
+
+test('Island Viewer fenced crop plot rolls empty and five crop kinds', () => {
+  assert.match(generator, /const cropIds = \['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'\];/);
+  assert.match(generator, /roll < 0\.25 \? null/);
+  assert.match(generator, /crop-area-fill/);
+  const api = loadIslandGenerator().TinyWorldIslandGenerator;
+  const seen = new Map([['empty', 0], ...VIEWER_CROP_KINDS.map(kind => [kind, 0])]);
+  let totalSlots = 0;
+  for (let i = 0; i < 500; i++) {
+    const seed = 'viewer-crop-plot-random-' + i;
+    const world = api.generate({ seed, archetype: 'pastoral', gridSize: 8 });
+    const plot = world.cells.filter(cell => cell.terrain === 'dirt'
+      && Array.isArray(cell.extras)
+      && cell.extras.some(extra => extra && extra.kind === 'fence'));
+    assert.equal(plot.length, 4, 'fenced crop plot should stay four dirt cells for seed ' + seed);
+    for (const cell of plot) {
+      totalSlots++;
+      if (cell.kind === null) {
+        seen.set('empty', seen.get('empty') + 1);
+      } else {
+        assert.ok(VIEWER_CROP_KINDS.includes(cell.kind), 'unexpected crop kind ' + cell.kind + ' for seed ' + seed);
+        seen.set(cell.kind, seen.get(cell.kind) + 1);
+      }
+    }
+  }
+  assert.ok(seen.get('empty') / totalSlots > 0.18 && seen.get('empty') / totalSlots < 0.32, 'empty crop slot rate should stay near 25%');
+  for (const kind of VIEWER_CROP_KINDS) {
+    assert.ok(seen.get(kind) > 0, 'crop plot sample should include ' + kind);
+  }
+});
+
+test('Island Viewer tree, bush, and weighted infill layers fill remaining grass', () => {
+  assert.match(generator, /function placeTreeBushLayer\(cells, seed\)/);
+  assert.match(generator, /function treeCandidates\(cells, seed\)/);
+  assert.match(generator, /function bushCandidates\(cells, seed\)/);
+  assert.match(generator, /function placeProbabilisticInfillLayer\(cells, seed\)/);
+  assert.match(generator, /function weightedInfillOptions\(cells, index\)/);
+  assert.match(generator, /placeTreeBushLayer\(cells, seed\);\s*placeProbabilisticInfillLayer\(cells, seed\);/);
+  const api = loadIslandGenerator().TinyWorldIslandGenerator;
+  let sawTree = false;
+  let sawBush = false;
+  let sawCrop = false;
+  let sawOre = false;
+  let sawAnimal = false;
+  for (let i = 0; i < 180; i++) {
+    const seed = 'viewer-tree-bush-layer-' + i;
+    const world = api.generate({ seed, archetype: 'forest', gridSize: 8 });
+    const trees = world.cells.filter(cell => cell.kind === 'tree');
+    const bushes = world.cells.filter(cell => cell.kind === 'bush');
+    const crops = world.cells.filter(cell => VIEWER_CROP_KINDS.includes(cell.kind));
+    const ores = world.cells.filter(cell => cell.kind === 'rock' && cell.terrain === 'stone');
+    const animals = world.cells.filter(cell => cell.kind === 'cow' || cell.kind === 'sheep');
+    const reserved = manorReservedKeys(world);
+    sawTree ||= trees.length > 0;
+    sawBush ||= bushes.length > 0;
+    sawCrop ||= crops.length > 4;
+    sawOre ||= ores.length > 4;
+    sawAnimal ||= animals.length > 0;
+    for (const tree of trees) {
+      assert.equal(tree.terrain, 'grass', 'tree must be placed on grass for seed ' + seed);
+    }
+    for (const bush of bushes) {
+      assert.equal(bush.terrain, 'grass', 'bush must be placed on grass for seed ' + seed);
+    }
+    for (const cell of world.cells) {
+      if (reserved.has(cell.x + ',' + cell.z)) continue;
+      assert.equal(isOrdinaryEmptyLand(cell), false, 'ordinary empty land should be infilled for seed ' + seed + ' at ' + cell.x + ',' + cell.z);
+    }
+  }
+  assert.equal(sawTree, true, 'seed sample should include trees');
+  assert.equal(sawBush, true, 'seed sample should include bushes');
+  assert.equal(sawCrop, true, 'seed sample should include extra crops');
+  assert.equal(sawOre, true, 'seed sample should include extra ore');
+  assert.equal(sawAnimal, true, 'seed sample should include extra animals');
+});
+
+test('Island Viewer water carving crosses any path area through one cell only', () => {
+  assert.match(generator, /function waterPathComponents\(cells\)/);
+  assert.match(generator, /function waterRouteStateKey\(index, crossedComponents\)/);
+  assert.match(generator, /return Number\.isFinite\(componentId\) && !crossedComponents\.has\(componentId\);/);
+  assert.match(generator, /const crossedComponents = new Set\(current\.crossedComponents\);/);
+  assert.match(generator, /if \(Number\.isFinite\(componentId\)\) crossedComponents\.add\(componentId\);/);
+  const api = loadIslandGenerator().TinyWorldIslandGenerator;
+  for (let i = 0; i < 80; i++) {
+    const seed = 'viewer-water-crossing-' + i;
+    const world = api.generate({ seed, archetype: 'river', gridSize: 8 });
+    assert.equal(world.cells.some(cell => cell.terrain === 'water'), true);
+    assert.equal(world.cells.some(cell => cell.terrain === 'path'), true);
+  }
+});

--- a/tools/check.js
+++ b/tools/check.js
@@ -10,6 +10,7 @@ const islandViewerScriptPath = path.join(root, 'scripts', 'island-viewer.js');
 const islandViewerGeneratorPath = path.join(root, 'scripts', 'island-viewer-sequential-generator.js');
 const islandViewerPreludePath = path.join(root, 'scripts', 'island-viewer-engine-prelude.js');
 const islandViewerRuntimePath = path.join(root, 'scripts', 'island-viewer-engine-runtime.js');
+const islandViewerStatsPath = path.join(root, 'tools', 'island-viewer-sequential-stats.mjs');
 const randomIslandPreviewPath = path.join(root, 'random-island-preview.html');
 const cssPath = path.join(root, 'styles', 'tiny-world.css');
 const schemaPath = path.join(root, 'world.schema.json');
@@ -24,6 +25,7 @@ const islandViewerScriptRaw = fs.existsSync(islandViewerScriptPath) ? readText(i
 const islandViewerGeneratorRaw = fs.existsSync(islandViewerGeneratorPath) ? readText(islandViewerGeneratorPath) : '';
 const islandViewerPreludeRaw = fs.existsSync(islandViewerPreludePath) ? readText(islandViewerPreludePath) : '';
 const islandViewerRuntimeRaw = fs.existsSync(islandViewerRuntimePath) ? readText(islandViewerRuntimePath) : '';
+const islandViewerStatsRaw = fs.existsSync(islandViewerStatsPath) ? readText(islandViewerStatsPath) : '';
 const randomIslandPreviewRaw = fs.existsSync(randomIslandPreviewPath) ? readText(randomIslandPreviewPath) : '';
 const cssRaw = readText(cssPath);
 const publishRaw = fs.existsSync(publishPath) ? readText(publishPath) : '';
@@ -420,6 +422,14 @@ if (!/if \(cell\.path === true && terrain !== 'water'\) terrain = 'path';/.test(
     || !/function clearViewerWorld\(\)/.test(islandViewerRuntimeRaw)
     || /path: cell\.path|path: false/.test(islandViewerRuntimeRaw)) {
   fail('island viewer runtime must normalize legacy path booleans, clear stale cells, and export schema-native paths');
+}
+if (!islandViewerStatsRaw
+    || !/DEFAULT_COUNT = 1000/.test(islandViewerStatsRaw)
+    || !/scripts\/island-viewer-sequential-generator\.js/.test(islandViewerStatsRaw)
+    || !/validateWorld\(world, profile\)/.test(islandViewerStatsRaw)
+    || !/stats-runs\/island-viewer-sequential/.test(islandViewerStatsRaw)
+    || !/"stats:island-viewer": "node tools\/island-viewer-sequential-stats\.mjs"/.test(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))) {
+  fail('island viewer sequential stats CLI must run schema/invariant sweeps from npm');
 }
 if (!/meta http-equiv="refresh" content="0; url=island-viewer\.html"/.test(randomIslandPreviewRaw)
     || !/location\.replace\('island-viewer\.html' \+ location\.search \+ location\.hash\)/.test(randomIslandPreviewRaw)) {

--- a/tools/check.js
+++ b/tools/check.js
@@ -5,6 +5,12 @@ const zlib = require('zlib');
 
 const root = path.resolve(__dirname, '..');
 const htmlPath = path.join(root, 'tiny-world-builder.html');
+const islandViewerHtmlPath = path.join(root, 'island-viewer.html');
+const islandViewerScriptPath = path.join(root, 'scripts', 'island-viewer.js');
+const islandViewerGeneratorPath = path.join(root, 'scripts', 'island-viewer-sequential-generator.js');
+const islandViewerPreludePath = path.join(root, 'scripts', 'island-viewer-engine-prelude.js');
+const islandViewerRuntimePath = path.join(root, 'scripts', 'island-viewer-engine-runtime.js');
+const randomIslandPreviewPath = path.join(root, 'random-island-preview.html');
 const cssPath = path.join(root, 'styles', 'tiny-world.css');
 const schemaPath = path.join(root, 'world.schema.json');
 const vercelPath = path.join(root, 'vercel.json');
@@ -13,6 +19,12 @@ const partykitPath = path.join(root, 'partykit.json');
 const publishPath = path.join(root, 'publish.sh');
 const readText = (file) => fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
 const htmlRaw = readText(htmlPath);
+const islandViewerHtmlRaw = fs.existsSync(islandViewerHtmlPath) ? readText(islandViewerHtmlPath) : '';
+const islandViewerScriptRaw = fs.existsSync(islandViewerScriptPath) ? readText(islandViewerScriptPath) : '';
+const islandViewerGeneratorRaw = fs.existsSync(islandViewerGeneratorPath) ? readText(islandViewerGeneratorPath) : '';
+const islandViewerPreludeRaw = fs.existsSync(islandViewerPreludePath) ? readText(islandViewerPreludePath) : '';
+const islandViewerRuntimeRaw = fs.existsSync(islandViewerRuntimePath) ? readText(islandViewerRuntimePath) : '';
+const randomIslandPreviewRaw = fs.existsSync(randomIslandPreviewPath) ? readText(randomIslandPreviewPath) : '';
 const cssRaw = readText(cssPath);
 const publishRaw = fs.existsSync(publishPath) ? readText(publishPath) : '';
 const defaultsPath = path.join(root, 'tinyworld-defaults.json');
@@ -364,6 +376,58 @@ if (/<link[^>]+rel=["']stylesheet["'][^>]+href=["']styles\//.test(htmlRaw)) {
   if (!/dist\/styles/.test(fs.readFileSync(path.join(root, 'publish.sh'), 'utf8'))) {
     fail('referenced styles/ stylesheet must be copied to dist/styles by publish.sh');
   }
+}
+if (!islandViewerHtmlRaw || !islandViewerScriptRaw || !islandViewerGeneratorRaw || !islandViewerPreludeRaw || !islandViewerRuntimeRaw) {
+  fail('island viewer shell, controller, generator, prelude, and runtime files must be present');
+}
+if (/<iframe\b/.test(islandViewerHtmlRaw) || /scripts\/tinyworld-island-core\.js|scripts\/island-viewer-renderer\.js/.test(islandViewerHtmlRaw)) {
+  fail('island viewer must be standalone and must not load the old core bundle or temporary renderer');
+}
+if (!/scripts\/island-viewer-engine-prelude\.js/.test(islandViewerHtmlRaw)
+    || !/scripts\/island-viewer-sequential-generator\.js/.test(islandViewerHtmlRaw)
+    || !/scripts\/island-viewer-engine-runtime\.js/.test(islandViewerHtmlRaw)
+    || !/scripts\/island-viewer\.js/.test(islandViewerHtmlRaw)
+    || !/engine\/world\/17-tile-renderers\.js/.test(islandViewerHtmlRaw)) {
+  fail('island viewer must load the sequential generator and builder-engine runtime stack');
+}
+if (!/TinyWorldIslandGenerator/.test(islandViewerScriptRaw) || !/TinyWorldIslandRenderer\.mount/.test(islandViewerScriptRaw)) {
+  fail('island viewer controller must call the generator API and mount the renderer runtime');
+}
+if (/water-bridge|bridgeAxis/.test(islandViewerGeneratorRaw)
+    || !/function pathWaterPathBridgeAxis\(cells, index\)/.test(islandViewerGeneratorRaw)
+    || !/function placePathWaterPathBridgesLayer\(cells\)/.test(islandViewerGeneratorRaw)) {
+  fail('island viewer generator must use local bridge detection without legacy bridge metadata');
+}
+if (!/function waterPathComponents\(cells\)/.test(islandViewerGeneratorRaw)
+    || !/return Number\.isFinite\(componentId\) && !crossedComponents\.has\(componentId\);/.test(islandViewerGeneratorRaw)) {
+  fail('island viewer water routing must limit crossings to one cell per connected path area');
+}
+if (!/if \(hasPath\(cell\)\) return 'path';/.test(islandViewerGeneratorRaw) || /entry\.path = true/.test(islandViewerGeneratorRaw)) {
+  fail('island viewer generator must export public paths as terrain:path cells');
+}
+if (!/const cropIds = \['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'\];/.test(islandViewerGeneratorRaw)
+    || !/roll < 0\.25 \? null/.test(islandViewerGeneratorRaw)
+    || !/crop-area-fill/.test(islandViewerGeneratorRaw)) {
+  fail('island viewer crop plot must roll 25% empty, then evenly across the five crop kinds');
+}
+if (!/function placeStrategicLampLayer\(cells, seed\)/.test(islandViewerGeneratorRaw)
+    || !/function placeManorLayer\(cells, seed\)/.test(islandViewerGeneratorRaw)
+    || !/function placeTreeBushLayer\(cells, seed\)/.test(islandViewerGeneratorRaw)
+    || !/function placeProbabilisticInfillLayer\(cells, seed\)/.test(islandViewerGeneratorRaw)) {
+  fail('island viewer generator must keep lantern, manor, tree/bush, and weighted infill layers');
+}
+if (!/if \(cell\.path === true && terrain !== 'water'\) terrain = 'path';/.test(islandViewerRuntimeRaw)
+    || !/function clearViewerWorld\(\)/.test(islandViewerRuntimeRaw)
+    || /path: cell\.path|path: false/.test(islandViewerRuntimeRaw)) {
+  fail('island viewer runtime must normalize legacy path booleans, clear stale cells, and export schema-native paths');
+}
+if (!/meta http-equiv="refresh" content="0; url=island-viewer\.html"/.test(randomIslandPreviewRaw)
+    || !/location\.replace\('island-viewer\.html' \+ location\.search \+ location\.hash\)/.test(randomIslandPreviewRaw)) {
+  fail('random-island-preview.html must stay a compatibility redirect to island-viewer.html');
+}
+if (!/cp island-viewer\.html "\$DIST\/island-viewer\.html"/.test(publishRaw)
+    || !/cp random-island-preview\.html "\$DIST\/random-island-preview\.html"/.test(publishRaw)) {
+  fail('publish.sh must copy the island viewer shell and preview compatibility redirect');
 }
 if (/function makeCustomPartsStamp[\s\S]*?\n\s*addVoxelBuildTrimFrame\(g, trimBounds, voxelTrimMaterial\(trimBase\)\);\n\s*g\.userData/.test(html)) {
   fail('custom voxel part stamps must not render bounding trim frames by default');
@@ -912,6 +976,8 @@ for (const [needle, label] of [
   ['publish = "dist"', 'Netlify publish directory'],
   ['NODE_VERSION = "22"', 'Netlify Node version'],
   ['directory = "netlify/functions"', 'Netlify functions directory'],
+  ['from = "/island-viewer"', 'Island Viewer route'],
+  ['to = "/island-viewer.html"', 'Island Viewer static shell target'],
   ['Content-Security-Policy = "default-src', 'Netlify CSP header'],
   ['script-src \'self\'', 'Netlify self-hosted script policy'],
 ]) {

--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -36,7 +36,7 @@ const WATCH_PATHS = [
 const WATCH_ROOT_FILES = [
   'index.html', 'tiny-world-builder.html', 'roadmap.html',
   'features.html', 'community.html', 'terms.html', 'privacy.html', 'code-of-conduct.html',
-  'worlds.html', 'docs.html', 'harvest.html', 'random-island-preview.html',
+  'worlds.html', 'docs.html', 'harvest.html', 'island-viewer.html', 'random-island-preview.html',
 ];
 
 function watchDir(dir) {
@@ -743,6 +743,9 @@ function routeForRequest(reqUrl) {
   if (pathname === '/') return { file: path.resolve(root, 'index.html') };
   if (pathname === '/tiny-world-builder' || pathname === '/tiny-world-builder/') {
     return { file: path.resolve(root, 'tiny-world-builder.html') };
+  }
+  if (pathname === '/island-viewer' || pathname === '/island-viewer/') {
+    return { file: path.resolve(root, 'island-viewer.html') };
   }
 
   const resolved = path.resolve(root, '.' + pathname);

--- a/tools/island-viewer-sequential-stats.mjs
+++ b/tools/island-viewer-sequential-stats.mjs
@@ -1,0 +1,469 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const DEFAULT_OUT_DIR = 'stats-runs/island-viewer-sequential';
+const DEFAULT_COUNT = 1000;
+const DEFAULT_SEED_PREFIX = 'island-viewer-sequential';
+const VIEWER_GRID_SIZE = 8;
+const ARCHETYPES = ['pastoral', 'forest', 'quarry', 'river', 'village', 'fortress', 'ruins', 'harbor'];
+const TERRAIN_IDS = ['grass', 'path', 'dirt', 'water', 'stone', 'lava', 'snow'];
+const KIND_IDS = [null, 'house', 'tree', 'rock', 'bridge', 'wheat', 'corn', 'carrot', 'pumpkin', 'sunflower', 'cow', 'sheep', 'lamp-post', 'bush'];
+const CROP_KINDS = ['wheat', 'corn', 'carrot', 'pumpkin', 'sunflower'];
+const ANIMAL_KINDS = ['cow', 'sheep'];
+const PROFILE_STATS = ['food', 'materials', 'commerce', 'defense', 'charm'];
+
+function readArg(name, fallback) {
+  const prefix = name + '=';
+  const direct = process.argv.find(arg => arg.startsWith(prefix));
+  if (direct) return direct.slice(prefix.length);
+  const index = process.argv.indexOf(name);
+  if (index !== -1 && process.argv[index + 1]) return process.argv[index + 1];
+  return fallback;
+}
+
+function intArg(name, fallback, min, max) {
+  const n = Math.round(Number(readArg(name, fallback)));
+  const value = Number.isFinite(n) ? n : fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+function boolArg(name, fallback = false) {
+  if (process.argv.includes(name)) return true;
+  if (process.argv.includes('--no-' + name.replace(/^--/, ''))) return false;
+  return fallback;
+}
+
+function safeTimestamp(date) {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+function pct(value, total) {
+  return total ? Number((value / total * 100).toFixed(2)) : 0;
+}
+
+function increment(map, key, amount = 1) {
+  map[String(key)] = (map[String(key)] || 0) + amount;
+}
+
+function sorted(values) {
+  return values.slice().sort((a, b) => a - b);
+}
+
+function percentile(sortedValues, p) {
+  if (!sortedValues.length) return 0;
+  return sortedValues[Math.min(sortedValues.length - 1, Math.floor(sortedValues.length * p))];
+}
+
+function summary(values) {
+  const list = sorted(values);
+  const sum = values.reduce((total, value) => total + value, 0);
+  return {
+    min: Number((list[0] || 0).toFixed(2)),
+    p05: Number(percentile(list, 0.05).toFixed(2)),
+    p25: Number(percentile(list, 0.25).toFixed(2)),
+    median: Number(percentile(list, 0.5).toFixed(2)),
+    mean: Number((sum / Math.max(1, values.length)).toFixed(2)),
+    p75: Number(percentile(list, 0.75).toFixed(2)),
+    p90: Number(percentile(list, 0.9).toFixed(2)),
+    p95: Number(percentile(list, 0.95).toFixed(2)),
+    p99: Number(percentile(list, 0.99).toFixed(2)),
+    max: Number((list[list.length - 1] || 0).toFixed(2)),
+  };
+}
+
+function topEntries(map, total, limit = 12) {
+  return Object.entries(map)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([name, count]) => ({ name, count, percent: pct(count, total) }));
+}
+
+function cellKey(cell) {
+  return cell.x + ',' + cell.z;
+}
+
+function cellAt(world, x, z) {
+  return world.cells.find(cell => cell.x === x && cell.z === z) || null;
+}
+
+function adjacentCells(world, cell) {
+  return [[1, 0], [-1, 0], [0, 1], [0, -1]]
+    .map(([dx, dz]) => cellAt(world, cell.x + dx, cell.z + dz))
+    .filter(Boolean);
+}
+
+function isPath(cell) {
+  return !!(cell && cell.terrain === 'path');
+}
+
+function isWater(cell) {
+  return !!(cell && cell.terrain === 'water');
+}
+
+function isCrop(cell) {
+  return !!(cell && CROP_KINDS.includes(cell.kind));
+}
+
+function isAnimal(cell) {
+  return !!(cell && ANIMAL_KINDS.includes(cell.kind));
+}
+
+function manhattan(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.z - b.z);
+}
+
+function doorSideForCell(cell) {
+  const value = Number(cell && cell.transform && cell.transform.rotationY);
+  if (Math.abs(value - Math.PI) < 0.0001) return 'n';
+  if (Math.abs(value - Math.PI / 2) < 0.0001) return 'e';
+  if (Math.abs(value + Math.PI / 2) < 0.0001) return 'w';
+  return 's';
+}
+
+function frontCell(world, cell) {
+  const side = doorSideForCell(cell);
+  if (side === 'n') return cellAt(world, cell.x, cell.z - 1);
+  if (side === 'e') return cellAt(world, cell.x + 1, cell.z);
+  if (side === 'w') return cellAt(world, cell.x - 1, cell.z);
+  return cellAt(world, cell.x, cell.z + 1);
+}
+
+function connectedPathSize(world, start) {
+  if (!isPath(start)) return 0;
+  const queue = [start];
+  const seen = new Set([cellKey(start)]);
+  while (queue.length) {
+    const current = queue.shift();
+    for (const neighbor of adjacentCells(world, current)) {
+      if (!isPath(neighbor)) continue;
+      const key = cellKey(neighbor);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      queue.push(neighbor);
+    }
+  }
+  return seen.size;
+}
+
+function pathComponents(world) {
+  const seen = new Set();
+  const components = [];
+  for (const cell of world.cells) {
+    if (!isPath(cell) || seen.has(cellKey(cell))) continue;
+    const queue = [cell];
+    const keys = new Set([cellKey(cell)]);
+    seen.add(cellKey(cell));
+    while (queue.length) {
+      const current = queue.shift();
+      for (const neighbor of adjacentCells(world, current)) {
+        const key = cellKey(neighbor);
+        if (!isPath(neighbor) || seen.has(key)) continue;
+        seen.add(key);
+        keys.add(key);
+        queue.push(neighbor);
+      }
+    }
+    components.push(keys);
+  }
+  return components;
+}
+
+function waterCellsTouchingPathComponent(world, component) {
+  const water = new Set();
+  for (const key of component) {
+    const [x, z] = key.split(',').map(Number);
+    for (const neighbor of adjacentCells(world, { x, z })) {
+      if (isWater(neighbor)) water.add(cellKey(neighbor));
+    }
+  }
+  return water;
+}
+
+function bridgeCrossingValid(world, bridge) {
+  const west = cellAt(world, bridge.x - 1, bridge.z);
+  const east = cellAt(world, bridge.x + 1, bridge.z);
+  const north = cellAt(world, bridge.x, bridge.z - 1);
+  const south = cellAt(world, bridge.x, bridge.z + 1);
+  const eastWest = isPath(west) && isPath(east) && isWater(north) && isWater(south);
+  const northSouth = isPath(north) && isPath(south) && isWater(west) && isWater(east);
+  return eastWest !== northSouth;
+}
+
+function lampCornerValid(world, lamp) {
+  const sides = [
+    ['n', cellAt(world, lamp.x, lamp.z - 1)],
+    ['e', cellAt(world, lamp.x + 1, lamp.z)],
+    ['s', cellAt(world, lamp.x, lamp.z + 1)],
+    ['w', cellAt(world, lamp.x - 1, lamp.z)],
+  ].filter(([, cell]) => isPath(cell)).map(([side]) => side);
+  if (sides.length !== 2) return false;
+  return !((sides.includes('n') && sides.includes('s')) || (sides.includes('e') && sides.includes('w')));
+}
+
+function fenceExtraCells(world) {
+  return world.cells.filter(cell => Array.isArray(cell.extras) && cell.extras.some(extra => extra && extra.kind === 'fence'));
+}
+
+function cropPlotCells(world) {
+  return fenceExtraCells(world).filter(cell => cell.terrain === 'dirt');
+}
+
+function animalPenCells(world) {
+  return fenceExtraCells(world).filter(cell => cell.terrain === 'grass' && (cell.kind === null || isAnimal(cell)));
+}
+
+function countMap(items, getKey) {
+  const out = {};
+  for (const item of items) increment(out, getKey(item));
+  return out;
+}
+
+function validateWorld(world, profile) {
+  const errors = [];
+  const allowedTerrain = new Set(TERRAIN_IDS);
+  const allowedKinds = new Set(KIND_IDS);
+  const keys = new Set();
+  const serialized = JSON.stringify(world);
+  if (!world || world.v !== 4) errors.push('world.v must be 4');
+  if (!world || world.gridSize !== VIEWER_GRID_SIZE) errors.push('gridSize must be 8');
+  if (!world || !Array.isArray(world.cells) || world.cells.length !== VIEWER_GRID_SIZE * VIEWER_GRID_SIZE) errors.push('world must contain 64 cells');
+  if (/water-bridge|bridgeAxis/.test(serialized)) errors.push('world must not contain legacy bridge metadata');
+  for (const cell of world.cells || []) {
+    if (!Number.isInteger(cell.x) || !Number.isInteger(cell.z)) errors.push('cell coordinates must be integers');
+    if (cell.x < 0 || cell.x >= VIEWER_GRID_SIZE || cell.z < 0 || cell.z >= VIEWER_GRID_SIZE) errors.push('cell coordinate out of bounds: ' + cellKey(cell));
+    if (keys.has(cellKey(cell))) errors.push('duplicate cell coordinate: ' + cellKey(cell));
+    keys.add(cellKey(cell));
+    if (!allowedTerrain.has(cell.terrain)) errors.push('unexpected terrain: ' + cell.terrain);
+    if (cell.terrain === 'sand') errors.push('viewer output must not emit sand');
+    if (!allowedKinds.has(cell.kind || null)) errors.push('unexpected kind: ' + cell.kind);
+    if (Object.prototype.hasOwnProperty.call(cell, 'path')) errors.push('viewer output must use terrain:path, not path boolean');
+    if (cell.kind === 'bridge' && cell.terrain !== 'water') errors.push('bridge must sit on water at ' + cellKey(cell));
+    if (cell.kind === 'lamp-post' && cell.terrain !== 'grass') errors.push('lamp-post must sit on grass at ' + cellKey(cell));
+    if ((cell.kind === 'tree' || cell.kind === 'bush') && cell.terrain !== 'grass') errors.push(cell.kind + ' must sit on grass at ' + cellKey(cell));
+    if (isCrop(cell) && cell.terrain !== 'dirt') errors.push(cell.kind + ' must sit on dirt at ' + cellKey(cell));
+  }
+  for (const bridge of (world.cells || []).filter(cell => cell.kind === 'bridge')) {
+    if (!bridgeCrossingValid(world, bridge)) errors.push('bridge crossing invalid at ' + cellKey(bridge));
+  }
+  const lamps = (world.cells || []).filter(cell => cell.kind === 'lamp-post');
+  for (const lamp of lamps) {
+    if (!lampCornerValid(world, lamp)) errors.push('lamp-post not at inside path corner: ' + cellKey(lamp));
+  }
+  for (let a = 0; a < lamps.length; a++) {
+    for (let b = a + 1; b < lamps.length; b++) {
+      if (manhattan(lamps[a], lamps[b]) <= 3) errors.push('lamp-post spacing <= 3 at ' + cellKey(lamps[a]) + ' and ' + cellKey(lamps[b]));
+    }
+  }
+  for (const manor of (world.cells || []).filter(cell => cell.kind === 'house' && cell.buildingType === 'manor')) {
+    const front = frontCell(world, manor);
+    if (!isPath(front) || connectedPathSize(world, front) <= 1) errors.push('manor front path not connected at ' + cellKey(manor));
+  }
+  if (!profile || !profile.stats || !profile.economy || !profile.name) errors.push('profile missing required economy summary');
+  return [...new Set(errors)];
+}
+
+function evaluateWorld(world, profile) {
+  const terrain = countMap(world.cells, cell => cell.terrain);
+  const kind = countMap(world.cells.filter(cell => cell.kind), cell => cell.kind);
+  const crops = world.cells.filter(isCrop);
+  const animals = world.cells.filter(isAnimal);
+  const bridges = world.cells.filter(cell => cell.kind === 'bridge');
+  const lamps = world.cells.filter(cell => cell.kind === 'lamp-post');
+  const houses = world.cells.filter(cell => cell.kind === 'house' && !cell.buildingType);
+  const towers = world.cells.filter(cell => cell.kind === 'house' && cell.buildingType === 'tower');
+  const manors = world.cells.filter(cell => cell.kind === 'house' && cell.buildingType === 'manor');
+  const cropPlot = cropPlotCells(world);
+  const animalPen = animalPenCells(world);
+  const pathCrossings = pathComponents(world).map(component => waterCellsTouchingPathComponent(world, component).size);
+  return {
+    terrain,
+    kind,
+    crops: crops.length,
+    cropKinds: countMap(crops, cell => cell.kind),
+    animals: animals.length,
+    animalKinds: countMap(animals, cell => cell.kind),
+    bridges: bridges.length,
+    validBridges: bridges.filter(bridge => bridgeCrossingValid(world, bridge)).length,
+    lamps: lamps.length,
+    validLamps: lamps.filter(lamp => lampCornerValid(world, lamp)).length,
+    houses: houses.length,
+    towers: towers.length,
+    manors: manors.length,
+    trees: kind.tree || 0,
+    bushes: kind.bush || 0,
+    pathCells: terrain.path || 0,
+    waterCells: terrain.water || 0,
+    dirtCells: terrain.dirt || 0,
+    stoneCells: terrain.stone || 0,
+    emptyGrass: world.cells.filter(cell => cell.terrain === 'grass' && !cell.kind && (!cell.extras || !cell.extras.length)).length,
+    cropPlotCells: cropPlot.length,
+    cropPlotEmpty: cropPlot.filter(cell => cell.kind === null).length,
+    cropPlotKinds: countMap(cropPlot, cell => cell.kind || 'empty'),
+    animalPenCells: animalPen.length,
+    animalPenAnimals: animalPen.filter(isAnimal).length,
+    pathComponents: pathCrossings.length,
+    maxWaterTouchesPerPathComponent: Math.max(0, ...pathCrossings),
+    rarityScore: Number(profile && profile.economy && profile.economy.rarityScore) || 0,
+    potential: Number(profile && profile.economy && profile.economy.potential) || 0,
+    rarity: profile && profile.economy && profile.economy.rarity || 'Unknown',
+    stats: Object.fromEntries(PROFILE_STATS.map(stat => [stat, Number(profile && profile.stats && profile.stats[stat]) || 0])),
+    traits: Array.isArray(profile && profile.traits) ? profile.traits : [],
+    synergies: Array.isArray(profile && profile.synergies) ? profile.synergies : [],
+  };
+}
+
+function makeBucket() {
+  return {
+    samples: 0,
+    schemaErrorSamples: 0,
+    schemaErrors: {},
+    terrain: {},
+    kind: {},
+    cropKinds: {},
+    animalKinds: {},
+    cropPlotKinds: {},
+    rarity: {},
+    traits: {},
+    synergies: {},
+    values: {
+      crops: [], animals: [], bridges: [], lamps: [], houses: [], towers: [], manors: [],
+      trees: [], bushes: [], pathCells: [], waterCells: [], dirtCells: [], stoneCells: [],
+      emptyGrass: [], cropPlotCells: [], cropPlotEmpty: [], animalPenCells: [],
+      animalPenAnimals: [], pathComponents: [], maxWaterTouchesPerPathComponent: [],
+      rarityScore: [], potential: [],
+      validBridgesPercent: [], validLampsPercent: [],
+      food: [], materials: [], commerce: [], defense: [], charm: [],
+    },
+  };
+}
+
+function addToBucket(bucket, result, errors) {
+  bucket.samples++;
+  if (errors.length) {
+    bucket.schemaErrorSamples++;
+    for (const error of errors) increment(bucket.schemaErrors, error);
+  }
+  for (const [key, value] of Object.entries(result.terrain)) increment(bucket.terrain, key, value);
+  for (const [key, value] of Object.entries(result.kind)) increment(bucket.kind, key, value);
+  for (const [key, value] of Object.entries(result.cropKinds)) increment(bucket.cropKinds, key, value);
+  for (const [key, value] of Object.entries(result.animalKinds)) increment(bucket.animalKinds, key, value);
+  for (const [key, value] of Object.entries(result.cropPlotKinds)) increment(bucket.cropPlotKinds, key, value);
+  increment(bucket.rarity, result.rarity);
+  for (const trait of result.traits) increment(bucket.traits, trait);
+  for (const synergy of result.synergies) increment(bucket.synergies, synergy);
+  for (const [key, values] of Object.entries(bucket.values)) {
+    if (key === 'validBridgesPercent') values.push(result.bridges ? result.validBridges / result.bridges * 100 : 100);
+    else if (key === 'validLampsPercent') values.push(result.lamps ? result.validLamps / result.lamps * 100 : 100);
+    else if (Object.prototype.hasOwnProperty.call(result.stats, key)) values.push(result.stats[key]);
+    else values.push(Number(result[key]) || 0);
+  }
+}
+
+function finishBucket(bucket) {
+  const cellSamples = Math.max(1, bucket.samples * VIEWER_GRID_SIZE * VIEWER_GRID_SIZE);
+  const out = {
+    samples: bucket.samples,
+    schemaErrorSamples: bucket.schemaErrorSamples,
+    schemaErrorRate: pct(bucket.schemaErrorSamples, bucket.samples),
+    topSchemaErrors: topEntries(bucket.schemaErrors, Math.max(1, bucket.schemaErrorSamples), 20),
+    terrainPercent: Object.fromEntries(TERRAIN_IDS.map(id => [id, pct(bucket.terrain[id] || 0, cellSamples)])),
+    topKinds: topEntries(bucket.kind, cellSamples),
+    cropKindPercent: Object.fromEntries(CROP_KINDS.map(id => [id, pct(bucket.cropKinds[id] || 0, Math.max(1, Object.values(bucket.cropKinds).reduce((a, b) => a + b, 0)))])),
+    cropPlotKindPercent: Object.fromEntries(['empty', ...CROP_KINDS].map(id => [id, pct(bucket.cropPlotKinds[id] || 0, Math.max(1, Object.values(bucket.cropPlotKinds).reduce((a, b) => a + b, 0)))])),
+    animalKindPercent: Object.fromEntries(ANIMAL_KINDS.map(id => [id, pct(bucket.animalKinds[id] || 0, Math.max(1, Object.values(bucket.animalKinds).reduce((a, b) => a + b, 0)))])),
+    rarityPercent: Object.fromEntries(Object.keys(bucket.rarity).sort().map(id => [id, pct(bucket.rarity[id], bucket.samples)])),
+    topTraits: topEntries(bucket.traits, bucket.samples),
+    topSynergies: topEntries(bucket.synergies, bucket.samples),
+    summaries: Object.fromEntries(Object.entries(bucket.values).map(([key, values]) => [key, summary(values)])),
+  };
+  return out;
+}
+
+function loadGenerator() {
+  const generatorPath = path.join(ROOT, 'scripts/island-viewer-sequential-generator.js');
+  const source = fs.readFileSync(generatorPath, 'utf8');
+  const sandboxWindow = {};
+  new Function('window', source + '\nreturn window;')(sandboxWindow);
+  if (!sandboxWindow.TinyWorldIslandGenerator) {
+    throw new Error('TinyWorldIslandGenerator did not register from ' + generatorPath);
+  }
+  return sandboxWindow.TinyWorldIslandGenerator;
+}
+
+const count = intArg('--count', DEFAULT_COUNT, 1, 200000);
+const seedPrefix = String(readArg('--seed-prefix', DEFAULT_SEED_PREFIX));
+const archetypeInput = String(readArg('--archetype', 'all')).trim().toLowerCase();
+const selectedArchetypes = archetypeInput === 'all'
+  ? ARCHETYPES
+  : ARCHETYPES.filter(archetype => archetype === archetypeInput);
+if (!selectedArchetypes.length) throw new Error('unknown --archetype ' + archetypeInput);
+const outDirInput = String(readArg('--out-dir', DEFAULT_OUT_DIR));
+const outDir = path.isAbsolute(outDirInput) ? outDirInput : path.join(ROOT, outDirInput);
+const strict = boolArg('--strict', false);
+const generatedAt = new Date();
+const api = loadGenerator();
+const all = makeBucket();
+const byArchetype = Object.fromEntries(selectedArchetypes.map(archetype => [archetype, makeBucket()]));
+const examples = [];
+
+for (let i = 0; i < count; i++) {
+  const archetype = selectedArchetypes[i % selectedArchetypes.length];
+  const seed = seedPrefix + ':' + count + ':' + i + ':' + archetype;
+  let world;
+  let profile;
+  let errors = [];
+  try {
+    world = api.generate({ seed, archetype, gridSize: VIEWER_GRID_SIZE });
+    profile = api.profile(world, { seed, archetype });
+    errors = validateWorld(world, profile);
+  } catch (err) {
+    errors = ['exception: ' + (err && err.message || String(err))];
+    world = { v: 4, gridSize: VIEWER_GRID_SIZE, cells: [] };
+    profile = {};
+  }
+  const result = evaluateWorld(world, profile);
+  addToBucket(all, result, errors);
+  addToBucket(byArchetype[archetype], result, errors);
+  if (errors.length && examples.length < 25) {
+    examples.push({ seed, archetype, errors, world });
+  }
+}
+
+const report = {
+  generatedAt: generatedAt.toISOString(),
+  generator: 'scripts/island-viewer-sequential-generator.js',
+  samples: count,
+  totalSamples: all.samples,
+  archetypes: selectedArchetypes,
+  seedPrefix,
+  strict,
+  all: finishBucket(all),
+  byArchetype: Object.fromEntries(Object.entries(byArchetype).map(([key, bucket]) => [key, finishBucket(bucket)])),
+  errorExamples: examples,
+};
+
+await mkdir(outDir, { recursive: true });
+const reportPath = path.join(outDir, safeTimestamp(generatedAt) + '.json');
+const latestPath = path.join(outDir, 'latest.json');
+await writeFile(reportPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
+await writeFile(latestPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
+
+console.log('Island Viewer sequential generator stats');
+console.log('samples: ' + report.totalSamples + ' across ' + selectedArchetypes.length + ' archetype(s)');
+console.log('schema error samples: ' + report.all.schemaErrorSamples + ' (' + report.all.schemaErrorRate + '%)');
+console.log('terrain %:', JSON.stringify(report.all.terrainPercent));
+console.log('top kinds:', report.all.topKinds.map(entry => entry.name + '=' + entry.percent + '%').join(', '));
+console.log('crop plot %:', JSON.stringify(report.all.cropPlotKindPercent));
+console.log('rarity %:', JSON.stringify(report.all.rarityPercent));
+console.log('bridge count summary:', JSON.stringify(report.all.summaries.bridges));
+console.log('lamp count summary:', JSON.stringify(report.all.summaries.lamps));
+console.log('manor count summary:', JSON.stringify(report.all.summaries.manors));
+console.log('wrote: ' + path.relative(ROOT, reportPath));
+console.log('latest: ' + path.relative(ROOT, latestPath));
+
+if (strict && report.all.schemaErrorSamples > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- Adds a first-class `/island-viewer` shell for generated island reveal viewing.
- Uses a viewer-only sequential generator instead of loading the large random-island generator bundle.
- Reuses the existing builder-engine renderer stack for current visual parity.
- Keeps saved reveal files to finished `v:4` world/profile data, without generator roll traces or legacy bridge metadata.

## Generation notes
- Sequential layer order: grass base, first house, towers, paths, extra houses, optional manor, fenced crops, fenced animals, rock patch, water route, bridge detection, lanterns, trees/bushes, weighted infill.
- Paths are emitted as normal `terrain: "path"` cells for the public save boundary.
- Water routing limits crossings to one cell per connected path area.
- Bridges are detected after water carving from local path-water-path crossings; no `water-bridge` or `bridgeAxis` metadata is emitted.
- Generated viewer terrain does not emit sand; legacy loaded sand normalizes to grass.

## Validation
- `node --test tests/island-viewer-grid-size.test.mjs` passes.
- `npm run check` passes.
- `npm run build` passes.
- `npm test` currently has one failure that reproduces on pristine `upstream/main`: `tests/random-island-generator.test.mjs` / "resource motif pass composes fenced crop plots and animal pens" reports "pastoral should include a crop plot".

## Local verification
- Verified clean branch route at `http://localhost:3031/island-viewer`.
- Verified the shell loads `scripts/island-viewer-sequential-generator.js` and `scripts/island-viewer-engine-runtime.js`.
- Verified `random-island-preview.html` redirects to `island-viewer.html`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Island Viewer shell with standalone rendering, island create/load/save controls, and reveal payload import/export.
  * Introduced viewer-scoped defaults (including a developer panel) with fixed 8×8 generation and viewer-specific normalization.
* **Bug Fixes**
  * Updated the old island preview to redirect into the new viewer, and added direct `/island-viewer` routing/redirects.
  * Improved auth UI behavior when identity services are unavailable.
* **Tests**
  * Added automated Island Viewer grid/normalization/invariant coverage and a new sequential stats report script.
* **Documentation / Chores**
  * Added Island Viewer specifications and updated publish/Netlify routing/build checks to include the new pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->