### PR TITLE
Skip Netlify Blobs/DB test for Vercel compatibility

### DIFF
--- a/tests/feature-flags-api.test.mjs
+++ b/tests/feature-flags-api.test.mjs
@@ -25,7 +25,12 @@ test('feature-flags POST rejects non-admin callers', async () => {
   assert.equal(res.status, 403);
 });
 
-test('feature-flags POST saves with localhost admin secret', async () => {
+test('feature-flags POST saves with localhost admin secret', async (t) => {
+  if (process.env.VERCEL || process.env.VERCEL_ENV) {
+    t.skip('Netlify Blobs/Database not available on Vercel static builds');
+    return;
+  }
+
   const prev = process.env.TINYWORLD_ADMIN_SECRET;
   process.env.TINYWORLD_ADMIN_SECRET = 'test-feature-flags-secret';
   try {


### PR DESCRIPTION
Minimal change required to restore capability to deploy to Vercel.app the static core runtime by conditionally skipping a localhost admin secret specific test that requires access to a database. A successful redeployment of main and feature branches was assisted by conversations on https://grok.com/ and https://claude.ai/ using the Vercel MCP Server Connector.

A more comprehensive fix would enhance the test suite to run tests of RBAC access to data storage specific to each supported target deployment hosting platform, i.e Netlify, Vercel and (next/soon) also Cloudflare. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated feature flag API testing to skip the localhost persistence check in Vercel environments, preventing unsupported test failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->