### PR TITLE
docs: point star chart to the maintained star-history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ See [AGENTS.md](./AGENTS.md) for guidance on extending the codebase.
 
 If Tiny World Builder is useful to you, a star helps other builders find it.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jasonkneen/tiny-world-builder&type=Date)](https://star-history.com/#jasonkneen/tiny-world-builder&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jasonkneen/tiny-world-builder&type=Date)](https://star-history.dera.page/#jasonkneen/tiny-world-builder&Date)
 
 ## Files
 


### PR DESCRIPTION
The current stargazer API (api.star-history.com) returns 403/401 and the inline star chart is broken. We now render the chart from the maintained public star-history fork, which needs no token and serves both the svg and the frontend from the same host. README links are updated to the new domain; the /svg chart image now points at the star-history host directly (same query params, same owner/repo), and the surrounding link uses the new hash-based URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart link in the README to use the current endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->